### PR TITLE
Set version to 3-SNAPSHOT

### DIFF
--- a/baseapp/pom.xml
+++ b/baseapp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.trino.gateway</groupId>
         <artifactId>trinogateway-parent</artifactId>
-        <version>1.9.5</version>
+        <version>3-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -91,4 +91,3 @@
     </build>
 
 </project>
-

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.trino.gateway</groupId>
         <artifactId>trinogateway-parent</artifactId>
-        <version>1.9.5</version>
+        <version>3-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>trinogateway-parent</artifactId>
     <name>trinogateway-parent</name>
     <packaging>pom</packaging>
-    <version>1.9.5</version>
+    <version>3-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>1.9</maven.compiler.source>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.trino.gateway</groupId>
         <artifactId>trinogateway-parent</artifactId>
-        <version>1.9.5</version>
+        <version>3-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -21,7 +21,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
-
 
     <dependencies>
         <dependency>
@@ -84,4 +83,3 @@
     </build>
 
 </project>
-


### PR DESCRIPTION
So that we can later release version 3 (which is higher than 1.9.5 from original project and 2.x used at some current users) and avoid the whole semantic version idea and follow the same pattern as Trino itself.

As discussed with @martint 
