### PR TITLE
Move VM options to jvm.config

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -254,15 +254,6 @@
                     </dependency>
                 </dependencies>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.2</version>
-                <configuration>
-                    <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED</argLine>
-                </configuration>
-            </plugin>
-
         </plugins>
     </build>
 </project>

--- a/mvnw
+++ b/mvnw
@@ -280,9 +280,7 @@ if [ -n "$wrapperSha256Sum" ]; then
   fi
 fi
 
-#This option is required by the javalite db-migrator-maven-plugin, which does not support adding VM options in its config
-REQUIRED_BUILD_OPTIONS='--add-opens=java.base/java.net=ALL-UNNAMED'
-MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $REQUIRED_BUILD_OPTIONS $MAVEN_OPTS"
+MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then


### PR DESCRIPTION
This allows the build to succeed using `mvn install` instead of requiring `./mvnw install`