### PR TITLE
Fix internal project dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
             <dependency>
                 <groupId>io.trino.gateway</groupId>
                 <artifactId>baseapp</artifactId>
-                <version>1.9.5</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.trino.gateway</groupId>
                 <artifactId>proxyserver</artifactId>
-                <version>1.9.5</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Our CI run found a first problem .. version was hardcoded in the dependencyMgt section. This fixes the problem and should get us back to a passing CI.