### PR TITLE
Add java opts guide

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -67,8 +67,12 @@ db information.
 
 ```
 cd gateway-ha/target/
-java -jar gateway-ha-{{VERSION}}-jar-with-dependencies.jar server ../gateway-ha-config.yml
+java --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED -jar gateway-ha-{{VERSION}}-jar-with-dependencies.jar server ../gateway-ha-config.yml
 ```
+
+If you encounter `module java.base does not "opens java.lang" to unnamed module` error, 
+this may be due to newer version of java.
+Do check opts at [jvm.config](../.mvn/jvm.config) when running java command.
 
 If you encounter a `Failed to connect to JDBC URL` error, this may be due to
 newer versions of java disabling certain algorithms when using SSL/TLS, in

--- a/docs/development.md
+++ b/docs/development.md
@@ -57,8 +57,7 @@ testing
 
 ### Build and run
 
-Please note these steps have been verified with JDK 8 and 11. Higher versions of
-Java might run into unexpected issues.
+Please note these steps have been verified with JDK 17.
 
 run `mvn clean install` to build `trino-gateway`
 


### PR DESCRIPTION
Added guide to use java opts when running with java cmd because of java version issue causing the following error

> Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @49c9930c

- https://github.com/trinodb/trino-gateway/pull/20#discussion_r1312440769

I linked `[jvm.config](../.mvn/jvm.config)` as this will be added soon in the following PR
- https://github.com/trinodb/trino-gateway/pull/18/files
