### PR TITLE
Improve security documentation

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -22,11 +22,13 @@ The authentication would happen on https protocol only. Add the
 set using `defaultType: "form"` Following types of the authentications are
 supported.
 
-### odic
+### OAuth/OpenIDConnect
 
 It can be configured as below
 
 ```
+authentication:
+  defaultType: "oauth"
   oauth:
     issuer:
     clientId:
@@ -42,7 +44,7 @@ It can be configured as below
       - s3
 ```
 
-### form
+### Form/Basic Auth
 
 The authentication happens with the pre-defined users from the configuration
 file. To define the preset user use the following section.
@@ -57,16 +59,26 @@ presetUsers:
     privileges: "lb_api"
 ```
 
-Provide a key pair ins RSA format
+Also provide a random key pair in RSA format.
 
 ```
+authentication:
+  defaultType: "form"
   form:
     selfSignKeyPair:
-      privateKeyRSA: |
-      <PEM PRIVATE KEY>
-      publicKeyRSA: |
-      <PEM PUBLIC key>
+      privateKeyRsa: <private_key_path>
+      publicKeyRsa: <public_key_path>
 ```
+
+### Form/LDAP
+
+```
+authentication:
+  defaultType: "form"
+  form:
+    ldapConfigPath: <ldap_config_path>
+```
+
 
 ## Authorization
 


### PR DESCRIPTION
- odic -> OAuth/OpenIDConnect
  - `odic` is typo for `oidc` which means OpenIDConnect
  - Conf is set using OAuth so added example to set defaultType as OAuth to use OIDC/OAuth
- Separated `Form` into `basic auth` and `LDAP auth`
  - I haven't tested LDAP conf yet, but [FormConfiguration code](https://github.com/trinodb/trino-gateway/blob/main/gateway-ha/src/main/java/io/trino/gateway/ha/config/FormAuthConfiguration.java) has LDAP as string type so I just added simple guide
  - `privateKeyRsa` and `publicKeyRsa` had should have R`sa` as lowercase
  - [keypair is read as file, not string](https://github.com/trinodb/trino-gateway/blob/main/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbKeyProvider.java#L35-L53)