### PR TITLE
Allow /v1/node to be routed by gateway

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -33,6 +33,7 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
   public static final String V1_STATEMENT_PATH = "/v1/statement";
   public static final String V1_QUERY_PATH = "/v1/query";
   public static final String V1_INFO_PATH = "/v1/info";
+  public static final String V1_NODE_PATH = "/v1/node";
   public static final String UI_API_STATS_PATH = "/ui/api/stats";
   public static final String UI_LOGIN_PATH = "/ui/login";
   public static final String UI_API_QUEUED_LIST_PATH = "/ui/api/query?state=QUEUED";
@@ -215,6 +216,7 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
         || path.startsWith(V1_QUERY_PATH)
         || path.startsWith(TRINO_UI_PATH)
         || path.startsWith(V1_INFO_PATH)
+        || path.startsWith(V1_NODE_PATH)
         || path.startsWith(UI_API_STATS_PATH)
         || path.startsWith(OAUTH_PATH);
   }


### PR DESCRIPTION
Allow gateway to route `v1/node` that returns node info. 
- We use this to API to find all workers address, then request `{worker_addr}/v1/status` to find cpu/memory stats.