### PR TITLE
Add JVM config for test runs

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -239,6 +239,14 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- necessary for integration tests, also see /.mvn/jvm.config -->
+                    <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.javalite</groupId>
                 <artifactId>db-migrator-maven-plugin</artifactId>
                 <version>${activejdbc.version}</version>


### PR DESCRIPTION
- Open package access for integration tests
- Add note about same content in jvm.config

This reinstates a setting we moved into jvm.config since surefire can not pick it up. Brings the build back to passing. 

Please review and chime in @willmostly 

Once we adopt airbase this will move again to use the property

air.test.jvm.additional-arguments

