### PR TITLE
Handle NPE for reading user records

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbFilter.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbFilter.java
@@ -13,6 +13,9 @@ import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.SecurityContext;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Priority(Priorities.AUTHENTICATION)
 public class LbFilter<P extends Principal> extends AuthFilter<String, P> {
 
@@ -41,6 +44,7 @@ public class LbFilter<P extends Principal> extends AuthFilter<String, P> {
       }
 
     } catch (Exception e) {
+      log.debug("Error while filtering request for authentication", e);
       throw new WebApplicationException(unauthorizedHandler.buildResponse(prefix, realm));
     }
 


### PR DESCRIPTION
1. Handle NPE error caused while getting entry from UserRecord object.
    - If the attribute key for `memberOf` conf, which is set by user using `ldapGroupMemberAttribute` in LDAP config, does not exist, then NPE happens because `engtry.get(memberOf)` returns null in `entry.get(memberOf).toString()` code.
    - Although error is caught by throwing LdapException, I suggest returning empty record instead.

2. Error above is caught by LbFilter, but the error message is not logged, so added logging code.
