### PR TITLE
Fix development environment configs

### DIFF
--- a/localdev/docker-compose.yml
+++ b/localdev/docker-compose.yml
@@ -1,14 +1,15 @@
-version: "3.3"
+version: "3.4"
 services:
   mysqldb:
     environment:
       - MYSQL_ROOT_PASSWORD=root123
       - MYSQL_DATABASE=trinogateway
-    image: mysql:5.5
+    image: mysql:5.7
+    platform: linux/amd64
     ports:
       - "3306:3306"
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-proot123"]
       start_period: 20s
       timeout: 5s
       retries: 5
@@ -26,7 +27,9 @@ services:
       - PGPORT=5432
       - POSTGRES_PASSWORD=P0stG&es
       - POSTGRES_DB=trino_gateway_db
+      - PGDATABASE=trino_gateway_db
       - POSTGRES_USER=trino_gateway_db_admin
+      - PGUSER=trino_gateway_db_admin
     ports:
       - "5432:5432"
     healthcheck:

--- a/localdev/docker-compose.yml
+++ b/localdev/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     ports:
       - "3306:3306"
     healthcheck:
+      # Need root password to check MySQL server status
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-proot123"]
       start_period: 20s
       timeout: 5s
@@ -27,13 +28,12 @@ services:
       - PGPORT=5432
       - POSTGRES_PASSWORD=P0stG&es
       - POSTGRES_DB=trino_gateway_db
-      - PGDATABASE=trino_gateway_db
       - POSTGRES_USER=trino_gateway_db_admin
-      - PGUSER=trino_gateway_db_admin
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready || exit 1"]
+      # Need user and database name to check PostgreSQL server status
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB || exit 1"]
       interval: 10s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
Upgrade docker-compose file version
- The `start_period` option was added in file format 3.4
- https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck

Specify `PGUSER=trino_gateway_db_admin` in postgresql so that it doesn't use current OS user as database user name. 
- Postgre keeps logging `FATAL:  role "root" does not exist` 
- https://stackoverflow.com/questions/60193781/postgres-with-docker-compose-gives-fatal-role-root-does-not-exist-error/60194261#60194261

Specify `PGDATABASE=trino_gateway_db` so that it doesn't use user name as DB name to access in default.
- `FATAL:  database "trino_gateway_db_admin" does not exist`

Update mysql healthcheck cmd (needs pwd)
- Mysql keeps logging `[Note] Access denied for user 'root'@'localhost' (using password: NO)`

Add support for development using m1
- Add `platform: linux/amd64` so that it can download image
- upgrade mysql version to 5.7 as there is bug with 5.5 (maybe use 8.x version as 5.x is too old?)
- https://github.com/docker/for-mac/issues/6137
