### PR TITLE
Improve routing rules document

### DIFF
--- a/docs/routing-rules.md
+++ b/docs/routing-rules.md
@@ -248,7 +248,7 @@ actions:
   - "if (request.getHeader(\"X-Trino-Client-Tags\") contains \"label=foo\") {
       result.put(\"routingGroup\", \"etl-foo\")
     }
-    else "if (request.getHeader(\"X-Trino-Client-Tags\") contains \"label=bar\") {
+    else if (request.getHeader(\"X-Trino-Client-Tags\") contains \"label=bar\") {
       result.put(\"routingGroup\", \"etl-bar\")
     }
     else {
@@ -268,3 +268,5 @@ routingRules:
   rulesConfigPath: "src/test/resources/rules/routing_rules.yml" # replace with path to your rules config file
 ```
 
+If there is error opening routing rules configuration file, then request is routed
+using routing group header `X-Trino-Routing-Group` as default.


### PR DESCRIPTION
- Simple typo to fix the example where `"` should not exist in the rules
- Add explanation to the logic where if routing-rules config is not set properly, it uses default routing logic (using header)