### PR TITLE
Disable javadoc linting

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -184,10 +184,9 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.0</version>
+                <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <skipSource>true</skipSource>
+                    <doclint>none</doclint>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This disables javadoc linting and enables source jar creation. Therefore enables release process.

With this I can run

```
./mvnw clean install -P oss-release -Dgpg.skip=true
```

successfully and get source and javadoc jar files.