### PR TITLE
Update release notes for version 3

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,19 +18,21 @@
 
 ## Trino Gateway 3 (26 Sep 2023)
 
+* [gateway-ha-3-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/3/gateway-ha-3-jar-with-dependencies.jar)
+
 The first release of Trino Gateway is based on the [Presto
 Gateway](https://github.com/lyft/presto-gateway/) 1.9.5 codebase
 [#4](#4), with these additions:
 
 * Add authentication and authorization with LDAP, OIDC and user list from config
-  file. ([#9](#9))
-* Add support for user, admin and API roles. ([#9](#9))
-* Add healthcheck for Trino backends using JDBC. ([#9](#9))
-* Add TCP check for routing. ([#9](#9))
-* Add logic to route requests only to healthy backends. ([#13](#13))
-* Add PostgreSQL support for backend database. ([#13](#13))
-* Allow routing of `/v1/node` endpoint URL ([#27](#27))
-* Filter logs for sensitive information. ([#9](#9))
-* Require Java 17 for build and runtime. ([#16](#16))
-* Deactivate clusters with zero workers. ([#13](#13))
-* Remove concurrency issue from repeated rules file loading. ([#9](#9))
+  file. (https://github.com/trinodb/trino-gateway/pull/9)
+* Add support for user, admin and API roles. (https://github.com/trinodb/trino-gateway/pull/9)
+* Add healthcheck for Trino backends using JDBC. (https://github.com/trinodb/trino-gateway/pull/9)
+* Add TCP check for routing. (https://github.com/trinodb/trino-gateway/pull/9)
+* Add logic to route requests only to healthy backends. (https://github.com/trinodb/trino-gateway/pull/13)
+* Add PostgreSQL support for backend database. (https://github.com/trinodb/trino-gateway/pull/13)
+* Allow routing of `/v1/node` endpoint URL. (https://github.com/trinodb/trino-gateway/pull/27)
+* Filter logs for sensitive information. (https://github.com/trinodb/trino-gateway/pull/9)
+* Require Java 17 for build and runtime. (https://github.com/trinodb/trino-gateway/pull/16)
+* Deactivate clusters with zero workers. (https://github.com/trinodb/trino-gateway/pull/13)
+* Remove concurrency issue from repeated rules file loading. (https://github.com/trinodb/trino-gateway/pull/9)


### PR DESCRIPTION
@martint seems like whatever we did for testing .. when merged it did not work. When testing this PR I observed that there is quite a delay in github sometimes between a commit arriving and the update of the rendered markdown.

Anyway, I looked up autolinking at https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls and I think the current approach is shortest and seems to work. 

Also note that this branch is in the main repo for testing purposes - https://github.com/trinodb/trino-gateway/blob/release-3/docs/release-notes.md