### PR TITLE
Add option for extra whitelisted paths

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,45 @@
+**Trino Gateway documentation**
+
+<table>
+  <tr>
+    <td><a href="configuration.md">Configuration</a></td>
+    <td><a href="design.md">Design</a></td>
+    <td><b><a href="development.md">Development</a></b></td>
+    <td><a href="security.md">Security</a></td>
+    <td><a href="operation.md">Operation</a></td>
+    <td><a href="gateway-api.md">Gateway API</a></td>
+    <td><a href="resource-groups-api.md">Resource groups API</a></td>
+    <td><a href="routing-rules.md">Routing rules</a></td>
+    <td><a href="references.md">References</a></td>
+    <td><a href="release-notes.md">Release notes</a></td>
+  </tr>
+</table>
+
+# Configuration
+
+The Trino Gateway is configured by passing a yaml when running the start command.
+```shell
+java -XX:MinRAMPercentage=50 -XX:MaxRAMPercentage=80 --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED -jar gateway-ha.jar server gateway-config.yml
+```
+Each component of the Trino Gateway will have a corresponding node in the configuration yaml. 
+
+## Proxying additional paths
+
+By default, Trino Gateway only proxies requests to paths starting with 
+`/v1/statement`, `/v1/query`, `/ui`, `/v1/info`, `/v1/node`, 
+`/ui/api/stats` and `/oauth`. 
+
+If you want to proxy additional paths, 
+you can add them by adding the `extraWhitelistPaths` node to your gateway 
+configuration yaml:
+
+```yaml
+extraWhitelistPaths:
+  - "/ui/insights"
+  - "/api/v1/biac"
+  - "/api/v1/dataProduct"
+  - "/api/v1/dataproduct"
+  - "/ext/faster"
+```
+
+This example enables additional proxying of any requests to path starting with the specified paths. 

--- a/docs/design.md
+++ b/docs/design.md
@@ -2,6 +2,7 @@
 
 <table>
   <tr>
+    <td><a href="configuration.md">Configuration</a></td>
     <td><b><a href="design.md">Design</a></b></td>
     <td><a href="development.md">Development</a></td>
     <td><a href="security.md">Security</a></td>

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,6 +2,7 @@
 
 <table>
   <tr>
+    <td><a href="configuration.md">Configuration</a></td>
     <td><a href="design.md">Design</a></td>
     <td><b><a href="development.md">Development</a></b></td>
     <td><a href="security.md">Security</a></td>

--- a/docs/gateway-api.md
+++ b/docs/gateway-api.md
@@ -2,6 +2,7 @@
 
 <table>
   <tr>
+    <td><a href="configuration.md">Configuration</a></td>
     <td><b><a href="design.md">Design</a></b></td>
     <td><a href="development.md">Development</a></td>
     <td><a href="security.md">Security</a></td>

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -2,6 +2,7 @@
 
 <table>
   <tr>
+    <td><a href="configuration.md">Configuration</a></td>
     <td><b><a href="design.md">Design</a></b></td>
     <td><a href="development.md">Development</a></td>
     <td><a href="security.md">Security</a></td>

--- a/docs/references.md
+++ b/docs/references.md
@@ -2,6 +2,7 @@
 
 <table>
   <tr>
+    <td><a href="configuration.md">Configuration</a></td>
     <td><b><a href="design.md">Design</a></b></td>
     <td><a href="development.md">Development</a></td>
     <td><a href="security.md">Security</a></td>

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,7 @@
 
 <table>
   <tr>
+    <td><a href="configuration.md">Configuration</a></td>
     <td><a href="design.md">Design</a></td>
     <td><a href="development.md">Development</a></b></td>
     <td><a href="security.md">Security</a></td>

--- a/docs/resource-groups-api.md
+++ b/docs/resource-groups-api.md
@@ -2,6 +2,7 @@
 
 <table>
   <tr>
+    <td><a href="configuration.md">Configuration</a></td>
     <td><b><a href="design.md">Design</a></b></td>
     <td><a href="development.md">Development</a></td>
     <td><a href="security.md">Security</a></td>

--- a/docs/routing-rules.md
+++ b/docs/routing-rules.md
@@ -2,6 +2,7 @@
 
 <table>
   <tr>
+    <td><a href="configuration.md">Configuration</a></td>
     <td><b><a href="design.md">Design</a></b></td>
     <td><a href="development.md">Development</a></td>
     <td><a href="security.md">Security</a></td>

--- a/docs/security.md
+++ b/docs/security.md
@@ -2,6 +2,7 @@
 
 <table>
   <tr>
+    <td><a href="configuration.md">Configuration</a></td>
     <td><b><a href="design.md">Design</a></b></td>
     <td><a href="development.md">Development</a></td>
     <td><b><a href="security.md">Security</a></b></td>

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/HaGatewayConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/HaGatewayConfiguration.java
@@ -1,7 +1,10 @@
 package io.trino.gateway.ha.config;
 
 import io.trino.gateway.baseapp.AppConfiguration;
+
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -19,4 +22,5 @@ public class HaGatewayConfiguration extends AppConfiguration {
   private Map<String, UserConfiguration> presetUsers = new HashMap();
   private BackendStateConfiguration backendState;
   private ClusterStatsConfiguration clusterStatsConfiguration;
+  private List<String> extraWhitelistPaths = new ArrayList<>();
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -55,18 +55,20 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
 
   private final Meter requestMeter;
   private final int serverApplicationPort;
+  private final List<String> extraWhitelistPaths;
 
   public QueryIdCachingProxyHandler(
       QueryHistoryManager queryHistoryManager,
       RoutingManager routingManager,
       RoutingGroupSelector routingGroupSelector,
       int serverApplicationPort,
-      Meter requestMeter) {
+      Meter requestMeter, List<String> extraWhitelistPaths) {
     this.requestMeter = requestMeter;
     this.routingManager = routingManager;
     this.routingGroupSelector = routingGroupSelector;
     this.queryHistoryManager = queryHistoryManager;
     this.serverApplicationPort = serverApplicationPort;
+    this.extraWhitelistPaths = extraWhitelistPaths;
   }
 
   protected static String extractQueryIdIfPresent(String path, String queryParams) {
@@ -217,7 +219,8 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
         || path.startsWith(V1_INFO_PATH)
         || path.startsWith(V1_NODE_PATH)
         || path.startsWith(UI_API_STATS_PATH)
-        || path.startsWith(OAUTH_PATH);
+        || path.startsWith(OAUTH_PATH)
+        || extraWhitelistPaths.stream().anyMatch(s -> path.startsWith(s));
   }
 
   public boolean isAuthEnabled() {

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
@@ -59,6 +59,7 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
   private final AuthorizationManager authorizationManager;
   private final BackendStateManager backendStateConnectionManager;
   private final AuthFilter authenticationFilter;
+  private final List<String> extraWhitelistPaths;
 
   public HaGatewayProviderModule(HaGatewayConfiguration configuration, Environment environment) {
     super(configuration, environment);
@@ -79,6 +80,7 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
         presetUsers);
     authenticationFilter = getAuthFilter(configuration);
     backendStateConnectionManager = new BackendStateManager(configuration.getBackendState());
+    extraWhitelistPaths = configuration.getExtraWhitelistPaths();
   }
 
   private LbOAuthManager getOAuthManager(HaGatewayConfiguration configuration) {
@@ -156,7 +158,8 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
         getRoutingManager(),
         routingGroupSelector,
         getApplicationPort(),
-        requestMeter);
+        requestMeter,
+        extraWhitelistPaths);
   }
 
   protected AuthFilter getAuthFilter(HaGatewayConfiguration configuration) {

--- a/gateway-ha/src/test/resources/test-config-template.yml
+++ b/gateway-ha/src/test/resources/test-config-template.yml
@@ -22,3 +22,6 @@ modules:
 
 managedApps:
   - io.trino.gateway.ha.GatewayManagedApp
+
+extraWhitelistPaths:
+  - "/v1/custom"


### PR DESCRIPTION
This submission allows configuring extra paths to proxy without a code change. This is useful for cases in which Trino has been extended to add extra APIs, and cases in which access to one of the paths not whitelisted by default is desired.