### PR TITLE
add dynamic header size config for http server and client

### DIFF
--- a/gateway-ha/gateway-ha-config.yml
+++ b/gateway-ha/gateway-ha-config.yml
@@ -6,6 +6,7 @@ requestRouter:
   port: 8080
   name: trinoRouter
   historySize: 1000
+  requestBufferSize: 8 * 1024
 
 dataStore:
   jdbcUrl: jdbc:postgresql://localhost:5432/trino_gateway_db

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/RequestRouterConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/RequestRouterConfiguration.java
@@ -19,4 +19,13 @@ public class RequestRouterConfiguration {
 
   // Use the certificate between gateway and trino?
   private boolean forwardKeystore;
+
+  // Set size for HttpConfiguration
+  private int outputBufferSize = 32 * 1024;
+  private int requestHeaderSize = 8 * 1024;
+  private int responseHeaderSize = 8 * 1024;
+
+  // Set size for HttpClient
+  private int requestBufferSize = 4 * 1024;
+  private int responseBufferSize = 16 * 1024;
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
@@ -195,6 +195,11 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
       routerProxyConfig.setKeystorePass(routerConfiguration.getKeystorePass());
       routerProxyConfig.setForwardKeystore(routerConfiguration.isForwardKeystore());
       routerProxyConfig.setPreserveHost("false");
+      routerProxyConfig.setOutputBufferSize(routerConfiguration.getOutputBufferSize());
+      routerProxyConfig.setRequestHeaderSize(routerConfiguration.getRequestHeaderSize());
+      routerProxyConfig.setResponseHeaderSize(routerConfiguration.getResponseHeaderSize());
+      routerProxyConfig.setRequestBufferSize(routerConfiguration.getRequestBufferSize());
+      routerProxyConfig.setResponseHeaderSize(routerConfiguration.getResponseBufferSize());
       ProxyHandler proxyHandler = getProxyHandler();
       gateway = new ProxyServer(routerProxyConfig, proxyHandler);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <dep.testng.version>6.10</dep.testng.version>
         <dep.trino.version>387</dep.trino.version>
         <dep.wiremock.version>3.0.1</dep.wiremock.version>
+        <dep.apache.commons.version>3.13.0</dep.apache.commons.version>
 
     </properties>
 
@@ -114,6 +115,12 @@
                 <artifactId>testng</artifactId>
                 <version>${dep.testng.version}</version>
                 <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${dep.apache.commons.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -49,6 +49,11 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/proxyserver/src/main/java/io/trino/gateway/proxyserver/ProxyServer.java
+++ b/proxyserver/src/main/java/io/trino/gateway/proxyserver/ProxyServer.java
@@ -63,7 +63,9 @@ public class ProxyServer implements Closeable {
       HttpConfiguration httpsConfig = new HttpConfiguration();
       httpsConfig.setSecureScheme(HttpScheme.HTTPS.asString());
       httpsConfig.setSecurePort(config.getLocalPort());
-      httpsConfig.setOutputBufferSize(32768);
+      httpsConfig.setOutputBufferSize(config.getOutputBufferSize());
+      httpsConfig.setRequestHeaderSize(config.getRequestHeaderSize());
+      httpsConfig.setResponseHeaderSize(config.getResponseHeaderSize());
 
       SecureRequestCustomizer src = new SecureRequestCustomizer();
       src.setStsMaxAge(TimeUnit.SECONDS.toSeconds(2000));
@@ -111,7 +113,6 @@ public class ProxyServer implements Closeable {
   }
 
   public void start() {
-
     try {
       this.server.start();
     } catch (Exception e) {

--- a/proxyserver/src/main/java/io/trino/gateway/proxyserver/ProxyServerConfiguration.java
+++ b/proxyserver/src/main/java/io/trino/gateway/proxyserver/ProxyServerConfiguration.java
@@ -14,6 +14,11 @@ public class ProxyServerConfiguration {
   private String keystorePath;
   private String keystorePass;
   private boolean forwardKeystore;
+  private int outputBufferSize = 2 * 1024 * 1024;
+  private int requestHeaderSize = 2 * 1024 * 1024;
+  private int responseHeaderSize = 8 * 1024;
+  private int requestBufferSize = 4 * 1024;
+  private int responseBufferSize = 16 * 1024;
 
   protected String getPrefix() {
     return prefix;
@@ -45,5 +50,25 @@ public class ProxyServerConfiguration {
 
   protected int getLocalPort() {
     return localPort;
+  }
+
+  protected int getOutputBufferSize() {
+    return outputBufferSize;
+  }
+
+  protected int getRequestHeaderSize() {
+    return requestHeaderSize;
+  }
+
+  protected int getResponseHeaderSize() {
+    return responseHeaderSize;
+  }
+
+  protected int getRequestBufferSize() {
+    return requestBufferSize;
+  }
+
+  protected int getResponseBufferSize() {
+    return responseBufferSize;
   }
 }

--- a/proxyserver/src/main/java/io/trino/gateway/proxyserver/ProxyServletImpl.java
+++ b/proxyserver/src/main/java/io/trino/gateway/proxyserver/ProxyServletImpl.java
@@ -48,6 +48,8 @@ public class ProxyServletImpl extends ProxyServlet.Transparent {
     HttpClient httpClient = new HttpClient(new HttpClientTransportDynamic(clientConnector));
     httpClient.setMaxConnectionsPerDestination(10000);
     httpClient.setConnectTimeout(TimeUnit.SECONDS.toMillis(60));
+    httpClient.setRequestBufferSize(serverConfig.getRequestBufferSize());
+    httpClient.setResponseBufferSize(serverConfig.getResponseBufferSize());
     return httpClient;
   }
 


### PR DESCRIPTION
Add dynamic header size config for http server and client
- Idk where to document it. Any ideas?
- https://trinodb.slack.com/archives/C059KUNPTSP/p1695708028907499

Values set in the conf are the default sizes set by Jetty
[HttpConfiguration](https://github.com/eclipse/jetty.project/blob/jetty-9.4.48.v20220622/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java#L61-L64) & [HttpClient](https://github.com/eclipse/jetty.project/blob/jetty-9.4.x/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java#L142-L143)
```java
  // Set size for HttpConfiguration
  private int outputBufferSize = 32 * 1024;
  private int requestHeaderSize = 8 * 1024;
  private int responseHeaderSize = 8 * 1024;

  // Set size for HttpClient
  private int requestBufferSize = 4 * 1024;
  private int responseBufferSize = 16 * 1024;
```