### PR TITLE
Ignore the unhandled ODIC properties gracefully

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbOAuthManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbOAuthManager.java
@@ -7,6 +7,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.gateway.ha.config.OAuthConfiguration;
 
@@ -132,7 +133,8 @@ public class LbOAuthManager {
   }
 
   @Data
-  private static final class OidcTokens {
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static final class OidcTokens {
 
     @JsonProperty
     private final String accessToken;

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestOidcToken.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestOidcToken.java
@@ -11,7 +11,11 @@ import org.junit.jupiter.api.Test;
 @Slf4j
 public class TestOidcToken {
   @Test
-  public void testOidcTokenParams() {
+  public void testParseTokenParamsGracefully() {
+    // This test is to make sure that we simulate the condition where
+    // the OIDC providers send additional parameters in the token
+    // 'to_be_ignored' parameter should not cause any parsing exception
+    // All the other parameters should have the correct values
     OidcTokens oidcTokens = null;
     try {
       ObjectMapper objectMapper = new ObjectMapper();

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestOidcToken.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestOidcToken.java
@@ -1,0 +1,40 @@
+package io.trino.gateway.ha.security;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.trino.gateway.ha.security.LbOAuthManager.OidcTokens;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class TestOidcToken {
+  @Test
+  public void testOidcTokenParams() {
+    OidcTokens oidcTokens = null;
+    try {
+      ObjectMapper objectMapper = new ObjectMapper();
+
+      String jsonStr = "{\"id_token\" : \"ABC235234\", "
+          + "\"access_token\" : \"AcessABCD123\", "
+          + "\"refresh_token\" : \"RefreshTKN\", "
+          + "\"token_type\" : \"TOKENType\", "
+          + "\"expires_in\" : \"123456\", "
+          + "\"to_be_ignored\" : \"XYX123456\", "
+          + "\"scope\" : \"global\" "
+          + "}";
+
+      oidcTokens = objectMapper.readValue(jsonStr, OidcTokens.class);
+    } catch (JsonProcessingException ex) {
+      log.error(ex.getMessage());
+      assertTrue(false);
+    }
+
+    assertTrue(oidcTokens.getIdToken().equals("ABC235234"));
+    assertTrue(oidcTokens.getAccessToken().equals("AcessABCD123"));
+    assertTrue(oidcTokens.getRefreshToken().equals("RefreshTKN"));
+    assertTrue(oidcTokens.getExpiresIn().equals("123456"));
+    assertTrue(oidcTokens.getScope().equals("global"));
+  }
+}


### PR DESCRIPTION
We currently have the bare minimum oauth properties supported. Any additional properties in the token result in parsing exception. The scope of the fix is to avoid the exception by ignoring unsupported properties.