### PR TITLE
Fix bug on create backend to support external URL

### DIFF
--- a/docs/gateway-api.md
+++ b/docs/gateway-api.md
@@ -21,10 +21,10 @@
 
 ```$xslt
 curl -X POST http://localhost:8080/entity?entityType=GATEWAY_BACKEND \
- -d '{  "name": "trino-3", \
-        "proxyTo": "http://localhost:8083",\
-        "active": true, \
-        "routingGroup": "adhoc" \
+ -d '{  "name": "trino-3",
+        "proxyTo": "http://localhost:8083",
+        "active": true,
+        "routingGroup": "adhoc"
     }'
 ```
 
@@ -34,18 +34,18 @@ to override the link in the Active Backends page.
 
 ```$xslt
 curl -X POST http://localhost:8080/entity?entityType=GATEWAY_BACKEND \
- -d '{  "name": "trino-3", \
-        "proxyTo": "http://localhost:8083",\
-        "active": true, \
-        "routingGroup": "adhoc" \
-        "externalUrl": "http://localhost:8084",\
+ -d '{  "name": "trino-3",
+        "proxyTo": "http://localhost:8083",
+        "active": true,
+        "routingGroup": "adhoc",
+        "externalUrl": "http://localhost:8084"
     }'
 ```
 
 ## Get all backends
 
+`curl -X GET http://localhost:8080/entity/GATEWAY_BACKEND`
 ```$xslt
-curl -X GET http://localhost:8080/entity/GATEWAY_BACKEND
 [
     {
         "name": "trino-1",
@@ -80,7 +80,7 @@ curl -X POST -d "trino3" http://localhost:8080/gateway/backend/modify/delete
 ## Deactivate a backend
 
 ```$xslt
-curl -X POST http://localhost:8080/gateway/backend/deactivate/trino2
+curl -X POST http://localhost:8080/gateway/backend/deactivate/trino-2
 ```
 
 ## Get all active backends
@@ -101,5 +101,5 @@ curl -X POST http://localhost:8080/gateway/backend/deactivate/trino2
 
 ## Activate a backend
 
-`curl -X POST http://localhost:8080/gateway/backend/activate/trino2`
+`curl -X POST http://localhost:8080/gateway/backend/activate/trino-2`
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/GatewayBackend.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/GatewayBackend.java
@@ -55,6 +55,8 @@ public class GatewayBackend extends Model {
             backend.getRoutingGroup(),
             backendUrl,
             backend.getProxyTo(),
+            externalUrl,
+            backend.getExternalUrl(),
             active,
             backend.isActive())
         .insert();

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
I was looking at some [PRs](https://github.com/lyft/presto-gateway/pull/122/files) from lyft/gateway to see any improvements that can be made and noticed that `externalUrl` was not added on create.
If the user wanted to set external url as [Gateway API guide](https://github.com/trinodb/trino-gateway/blob/main/docs/gateway-api.md#add-or-update-a-backend) saids, I need to create add backend, then edit external url.

There was no issue code-wise until now because proxyTo conf (a.k.a backend_url) was used instead of external_url
- https://github.com/trinodb/trino-gateway/blob/main/gateway-ha/src/main/java/io/trino/gateway/ha/config/ProxyBackendConfiguration.java#L16-L21

Also updated docs/gateway-api docs as it has typos/curl syntax issue

FYI. ~Test fails until https://github.com/trinodb/trino-gateway/pull/74 is merged.~ PR is merged and test is success