### PR TITLE
Ensure file change is observable

### DIFF
--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelector.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelector.java
@@ -111,6 +111,11 @@ public class TestRoutingGroupSelector {
     assertEquals("etl",
         routingGroupSelector.findRoutingGroup(mockRequest));
 
+    Thread.sleep(1);
+    // java.nio.file.attribute.FileTime offers a maximum precision of 1 ms. If the first
+    // half of this test runs in <1ms, the gateway may not recognize that the file
+    // has changed.
+
     fw = new FileWriter(file);
     fw.write(
         "---\n"


### PR DESCRIPTION
The routing rules engine will reload the rules file if it is newer than the last set of rules, based on the timestamp from the file attributes. However, `java.nio.file.attribute.FileTime` offers a maximum precision of 1 ms. 

We see an intermittent test failure due to a rules file being changed but not reloaded. The theory is that the test writes a new rules file <1ms after the first one, so a 1ms sleep is added to prevent this.