### PR TITLE
Fixes a wrong logging format in QueryIdCachingProxyHandler

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -156,7 +156,7 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
     String trinoUser = request.getHeader(USER_HEADER);
 
     if (!Strings.isNullOrEmpty(trinoUser)) {
-      log.info("user from %s", USER_HEADER);
+      log.info("user from {}", USER_HEADER);
       return trinoUser;
     }
 


### PR DESCRIPTION
### Context
A small fix for a logging format in `QueryIdCachingProxyHandler`.