### PR TITLE
Add check before borrowing from pool

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -151,4 +151,8 @@ The LDAP config file should have the following contents:
   ldapAdminPassword: <>
   ldapTrustStorePath: <for a secure ldap connectivity>
   ldapTrustStorePassword: '<for a secure ldap connectivity>'
+  poolMaxIdle: 8
+  poolMaxTotal: 8
+  poolMinIdle: 0
+  poolTestOnBorrow: true
 ```

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/LdapConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/LdapConfiguration.java
@@ -33,8 +33,15 @@ public class LdapConfiguration
     private String ldapAdminPassword;
     private String ldapTrustStorePath;
     private String ldapTrustStorePassword;
+    private Integer poolMaxIdle;
+    private Integer poolMaxTotal;
+    private Integer poolMinIdle;
+    private boolean poolTestOnBorrow;
 
-    public LdapConfiguration(String ldapHost, Integer ldapPort, boolean useTls, boolean useSsl, String ldapAdminBindDn, String ldapUserBaseDn, String ldapUserSearch, String ldapGroupMemberAttribute, String ldapAdminPassword, String ldapTrustStorePath, String ldapTrustStorePassword)
+    public LdapConfiguration(String ldapHost, Integer ldapPort, boolean useTls, boolean useSsl, String ldapAdminBindDn,
+                             String ldapUserBaseDn, String ldapUserSearch, String ldapGroupMemberAttribute,
+                             String ldapAdminPassword, String ldapTrustStorePath, String ldapTrustStorePassword,
+                             Integer poolMaxIdle, Integer poolMaxTotal, Integer poolMinIdle, boolean poolTestOnBorrow)
     {
         this.ldapHost = ldapHost;
         this.ldapPort = ldapPort;
@@ -47,6 +54,10 @@ public class LdapConfiguration
         this.ldapAdminPassword = ldapAdminPassword;
         this.ldapTrustStorePath = ldapTrustStorePath;
         this.ldapTrustStorePassword = ldapTrustStorePassword;
+        this.poolMaxIdle = poolMaxIdle;
+        this.poolMaxTotal = poolMaxTotal;
+        this.poolMinIdle = poolMinIdle;
+        this.poolTestOnBorrow = poolTestOnBorrow;
     }
 
     public LdapConfiguration() {}
@@ -180,5 +191,45 @@ public class LdapConfiguration
     public void setLdapTrustStorePassword(String ldapTrustStorePassword)
     {
         this.ldapTrustStorePassword = ldapTrustStorePassword;
+    }
+
+    public Integer getPoolMaxIdle()
+    {
+        return this.poolMaxIdle;
+    }
+
+    public void setPoolMaxIdle(Integer poolMaxIdle)
+    {
+        this.poolMaxIdle = poolMaxIdle;
+    }
+
+    public Integer getPoolMaxTotal()
+    {
+        return this.poolMaxTotal;
+    }
+
+    public void setPoolMaxTotal(Integer poolMaxTotal)
+    {
+        this.poolMaxTotal = poolMaxTotal;
+    }
+
+    public Integer getPoolMinIdle()
+    {
+        return this.poolMinIdle;
+    }
+
+    public void setPoolMinIdle(Integer poolMinIdle)
+    {
+        this.poolMinIdle = poolMinIdle;
+    }
+
+    public boolean isPoolTestOnBorrow()
+    {
+        return this.poolTestOnBorrow;
+    }
+
+    public void setPoolTestOnBorrow(boolean poolTestOnBorrow)
+    {
+        this.poolTestOnBorrow = poolTestOnBorrow;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbLdapClient.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbLdapClient.java
@@ -62,9 +62,10 @@ public class LbLdapClient
 
         //A single connection and keep it alive
         GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
-        poolConfig.setMaxIdle(1);
-        poolConfig.setMaxTotal(1);
-        poolConfig.setMinIdle(0);
+        poolConfig.setMaxIdle(ldapConfig.getPoolMaxIdle());
+        poolConfig.setMaxTotal(ldapConfig.getPoolMaxTotal());
+        poolConfig.setMinIdle(ldapConfig.getPoolMinIdle());
+        poolConfig.setTestOnBorrow(ldapConfig.isPoolTestOnBorrow());
 
         ValidatingPoolableLdapConnectionFactory validatingFactory =
                 new ValidatingPoolableLdapConnectionFactory(defaultFactory);

--- a/gateway-ha/src/test/resources/auth/ldapTestConfig.yml
+++ b/gateway-ha/src/test/resources/auth/ldapTestConfig.yml
@@ -10,3 +10,7 @@ ldapGroupMemberAttribute: 'memberOf'
 ldapAdminPassword: 'passit'
 ldapTrustStorePath: '/etc/ssl/certs/java/cacerts'
 ldapTrustStorePassword: 'secret'
+poolMaxIdle: 8
+poolMaxTotal: 8
+poolMinIdle: 0
+poolTestOnBorrow: true


### PR DESCRIPTION
Add checking connection before borrowing from the pool for stability.
- In our k8s, unless KA is set for sockets, it cleans up process that has been idle for 10 min.
- So, if the LDAP connection socket is not used and goes idle for more than 10 min, it gets deleted without gateway server knowing that is is invalid.
- Then next time ldapClient borrows the connection and makes request, it fails as log below.
![image](https://github.com/trinodb/trino-gateway/assets/25147023/26ae9df2-7998-41bf-9620-3956d1f3e7ee)


- https://trinodb.slack.com/archives/C059KUNPTSP/p1700796849182119

