### PR TITLE
Fix SSL not enabled, resulting in RequestHeaderSize not being effective.

### DIFF
--- a/proxyserver/src/main/java/io/trino/gateway/proxyserver/ProxyServer.java
+++ b/proxyserver/src/main/java/io/trino/gateway/proxyserver/ProxyServer.java
@@ -78,7 +78,12 @@ public class ProxyServer implements Closeable {
                   new SslConnectionFactory(sslContextFactory, connectionFactory.getProtocol()),
                   connectionFactory);
     } else {
-      connector = new ServerConnector(server);
+      HttpConfiguration httpConfig = new HttpConfiguration();
+      httpConfig.setOutputBufferSize(config.getOutputBufferSize());
+      httpConfig.setRequestHeaderSize(config.getRequestHeaderSize());
+      httpConfig.setResponseHeaderSize(config.getResponseHeaderSize());
+      HttpConnectionFactory connectionFactory = new HttpConnectionFactory(httpConfig);
+      connector = new ServerConnector(server, connectionFactory);
     }
     connector.setHost("0.0.0.0");
     connector.setPort(config.getLocalPort());


### PR DESCRIPTION
Fix [issue](https://github.com/trinodb/trino-gateway/issues/100)