### PR TITLE
Avoid defining redundant dependency versions in root pom.xml

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -17,6 +17,7 @@
     <properties>
         <environments>development</environments>
         <app.main.class>io.trino.gateway.ha.HaGatewayLauncher</app.main.class>
+        <dep.activejdbc.version>2.3</dep.activejdbc.version>
     </properties>
 
     <dependencies>
@@ -57,19 +58,19 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>${dep.h2.version}</version>
+            <version>1.4.192</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>${dep.okhttp.version}</version>
+            <version>3.9.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>jakarta.mail</artifactId>
-            <version>${dep.jakarta.mail.version}</version>
+            <version>2.0.0</version>
         </dependency>
 
         <dependency>
@@ -106,7 +107,7 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-jdbc</artifactId>
-            <version>${dep.trino.version}</version>
+            <version>433</version>
         </dependency>
 
         <dependency>
@@ -122,7 +123,7 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>${dep.jakarta.annotations.version}</version>
+            <version>2.1.1</version>
         </dependency>
 
         <dependency>
@@ -146,7 +147,7 @@
         <dependency>
             <groupId>org.ehcache</groupId>
             <artifactId>ehcache</artifactId>
-            <version>${dep.ehcache.version}</version>
+            <version>3.8.1</version>
         </dependency>
 
         <!--db -->
@@ -177,7 +178,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${dep.postgresql.version}</version>
+            <version>42.6.0</version>
         </dependency>
 
         <dependency>
@@ -190,7 +191,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>${dep.wiremock.version}</version>
+            <version>3.0.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -261,7 +262,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>${dep.plugin.maven.shade}</version>
+                <version>2.3</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <shadedArtifactAttached>true</shadedArtifactAttached>

--- a/pom.xml
+++ b/pom.xml
@@ -51,27 +51,10 @@
         <air.check.skip-pmd>true</air.check.skip-pmd>
 
         <!-- dependency versions -->
-        <dep.activejdbc.version>2.3</dep.activejdbc.version>
-        <dep.apache.commons.version>3.13.0</dep.apache.commons.version>
-        <dep.apache.httpcomponents>4.5.13</dep.apache.httpcomponents>
-        <dep.dropwizard.version>4.0.2</dep.dropwizard.version>
-        <dep.ehcache.version>3.8.1</dep.ehcache.version>
-        <dep.h2.version>1.4.192</dep.h2.version>
-        <dep.jakarta.annotations.version>2.1.1</dep.jakarta.annotations.version>
-        <dep.jakarta.mail.version>2.0.0</dep.jakarta.mail.version>
         <dep.jeasy.version>4.1.0</dep.jeasy.version>
-        <dep.jetty.version>11.0.15</dep.jetty.version>
-        <dep.mockwebserver.version>1.2.1</dep.mockwebserver.version>
         <dep.mockito.version>5.8.0</dep.mockito.version>
         <dep.mysqlconnector.version>8.0.17</dep.mysqlconnector.version>
-        <dep.okhttp.version>3.9.0</dep.okhttp.version>
-        <dep.plugin.maven.shade>2.3</dep.plugin.maven.shade>
-        <dep.plugin.maven.source>3.0.0</dep.plugin.maven.source>
-        <dep.postgresql.version>42.6.0</dep.postgresql.version>
         <dep.reflections.version>0.9.10</dep.reflections.version>
-        <dep.trino.version>433</dep.trino.version>
-        <dep.wiremock.version>3.0.1</dep.wiremock.version>
-
     </properties>
 
     <dependencyManagement>
@@ -79,7 +62,7 @@
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-dependencies</artifactId>
-                <version>${dep.dropwizard.version}</version>
+                <version>4.0.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -87,7 +70,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
-                <version>${dep.jetty.version}</version>
+                <version>11.0.15</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -95,7 +78,7 @@
             <dependency>
                 <groupId>com.squareup.okhttp</groupId>
                 <artifactId>mockwebserver</artifactId>
-                <version>${dep.mockwebserver.version}</version>
+                <version>1.2.1</version>
             </dependency>
 
             <dependency>
@@ -113,7 +96,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>${dep.apache.commons.version}</version>
+                <version>3.13.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>${dep.apache.httpcomponents}</version>
+            <version>4.5.13</version>
         </dependency>
 
         <dependency>
@@ -53,7 +53,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>${dep.plugin.maven.source}</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>


### PR DESCRIPTION
No need to define `dep.{name}.version` when it's called from one place. Also, the dependency version which is used in a module should be moved to the module's pom.xml. 