### PR TITLE
Skip spotbugs instead of false fail-spotbugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <air.check.skip-enforcer>true</air.check.skip-enforcer>
         <air.check.skip-dependency>true</air.check.skip-dependency>
         <air.check.skip-duplicate-finder>true</air.check.skip-duplicate-finder>
-        <air.check.fail-spotbugs>false</air.check.fail-spotbugs>
+        <air.check.skip-spotbugs>true</air.check.skip-spotbugs>
         <air.check.skip-pmd>true</air.check.skip-pmd>
 
         <!-- dependency versions -->


### PR DESCRIPTION
`air.check.skip-spotbugs` with true is same as Trino repository. 
`air.check.fail-spotbugs` with false leaves noisy error messages. 