### PR TITLE
Add org.mvel:mvel2 dependency

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -176,6 +176,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mvel</groupId>
+            <artifactId>mvel2</artifactId>
+            <version>2.5.1.Final</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>${dep.postgresql.version}</version>


### PR DESCRIPTION
This is a prerequisite for Java 21 and enables building with Java 21 without requiring Java 21 for runtime.

I am happy for this to be merged now .. and then the original PR requiring Java 21 after at least one Trino Gateway release. That can then also update the Trino JDBC dependency maybe.