### PR TITLE
Add cookie based routing for selected paths

### DIFF
--- a/docs/assets/gateway-routing-flow.svg
+++ b/docs/assets/gateway-routing-flow.svg
@@ -1,0 +1,1665 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="1642.4956"
+   height="1000"
+   version="1.1"
+   id="svg302"
+   sodipodi:docname="gateway-routing-flow.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:lucid="lucid">
+  <defs
+     id="defs303">
+    <marker
+       style="overflow:visible"
+       id="marker314"
+       refX="0"
+       refY="0"
+       orient="auto-start-reverse"
+       inkscape:stockid="Colored triangle"
+       markerWidth="2"
+       markerHeight="2"
+       viewBox="0 0 1 1"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid">
+      <path
+         transform="scale(0.5)"
+         style="fill:context-fill;fill-rule:evenodd;stroke:context-stroke;stroke-width:2"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path314" />
+    </marker>
+    <rect
+       x="497.09698"
+       y="673.98822"
+       width="218.65717"
+       height="66.334198"
+       id="rect304" />
+    <rect
+       x="463.52042"
+       y="650.23889"
+       width="281.71561"
+       height="106.46229"
+       id="rect303" />
+  </defs>
+  <sodipodi:namedview
+     id="namedview302"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.61054482"
+     inkscape:cx="720.66781"
+     inkscape:cy="374.2559"
+     inkscape:window-width="1624"
+     inkscape:window-height="866"
+     inkscape:window-x="0"
+     inkscape:window-y="38"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g302" />
+  <g
+     transform="translate(45.041741,7.3704663)"
+     lucid:page-tab-id="0_0"
+     id="g302">
+    <path
+       d="M -45.041741,-7.3704663 H 1597.4539 V 992.62953 H -45.041741 Z"
+       fill="#ffffff"
+       id="path1"
+       style="stroke-width:1.04642" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;white-space:pre;shape-inside:url(#path312-4);fill:#000000"
+       x="525.8103"
+       y="306.04346"
+       id="text311-9-8"
+       transform="rotate(-0.1,124301.96,-93467.94)"><tspan
+         x="0"
+         y="0"
+         id="tspan3">Request</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;white-space:pre;shape-inside:url(#path312);fill:#000000"
+       x="525.8103"
+       y="306.04346"
+       id="text311-9"
+       transform="translate(0,8)"><tspan
+         x="84.616341"
+         y="226.57278"
+         id="tspan4">Client</tspan></text>
+    <path
+       d="m 424.52,150.78 a 13.45,13.45 0 0 1 10.96,0 l 159.04,70.94 a 2.68,2.68 0 0 1 0,4.9 l -159.04,70.94 a 13.45,13.45 0 0 1 -10.96,0 L 265.48,226.6 a 2.68,2.68 0 0 1 0,-4.88 z"
+       stroke="#3a414a"
+       fill="#ffffff"
+       id="path2" />
+    <path
+       d="m 864.58,168.75 c 30.6,0 55.42,24.8 55.42,55.42 0,30.6 -24.8,55.4 -55.42,55.4 h -89.16 c -30.6,0 -55.42,-24.8 -55.42,-55.4 0,-30.6 24.8,-55.42 55.42,-55.42 z"
+       stroke="#3a414a"
+       fill="#ffffff"
+       id="path8" />
+    <path
+       d="M 642.75,225.14 H 597.6 v -1.95 h 45.15 z m 58.25,0 h -27.64 v -1.95 H 701 Z"
+       stroke="#008a0e"
+       stroke-width="0.05"
+       fill="#008a0e"
+       id="path14" />
+    <path
+       d="m 597.63,225.14 h -1.2 l 0.1,-0.25 0.08,-0.73 -0.07,-0.73 -0.1,-0.25 h 1.2 z"
+       fill="#008a0e"
+       id="path15" />
+    <path
+       stroke="#008a0e"
+       stroke-width="0.05"
+       fill="#008a0e"
+       id="path16"
+       d="" />
+    <path
+       d="M 716.26,224.17 702,228.8 v -9.27 z"
+       fill="#008a0e"
+       id="path17" />
+    <path
+       d="m 719.42,224.17 -18.4,5.97 V 218.2 Z m -16.45,3.3 10.14,-3.3 -10.13,-3.3 z"
+       stroke="#008a0e"
+       stroke-width="0.05"
+       fill="#008a0e"
+       id="path18" />
+    <use
+       xlink:href="#n"
+       transform="translate(642.74624,227.72222)"
+       id="use18" />
+    <path
+       d="m 424.63,362.67 a 12.1,12.1 0 0 1 10.75,0 l 149.25,74 a 2.98,2.98 0 0 1 0,5.33 l -149.25,74 a 12.1,12.1 0 0 1 -10.75,0 L 275.38,442 a 2.98,2.98 0 0 1 0,-5.33 z"
+       stroke="#3a414a"
+       fill="#ffffff"
+       id="path19" />
+    <path
+       d="m 430.98,343.48 h -1.96 v -2.2 h 1.96 z m 0,-23.54 h -1.96 v -19.72 h 1.96 z"
+       stroke="#e81313"
+       stroke-width="0.05"
+       fill="#e81313"
+       id="path24" />
+    <path
+       d="m 430,299.22 0.98,-0.04 v 1.07 h -1.96 v -1.07 z"
+       fill="#e81313"
+       id="path25" />
+    <path
+       stroke="#e81313"
+       stroke-width="0.05"
+       fill="#e81313"
+       id="path26"
+       d="" />
+    <path
+       d="m 430,358.75 -4.63,-14.27 h 9.26 z"
+       fill="#e81313"
+       id="path27" />
+    <path
+       d="m 430,361.9 -5.98,-18.4 h 11.96 z m -3.3,-16.44 3.3,10.13 3.3,-10.15 z"
+       stroke="#e81313"
+       stroke-width="0.05"
+       fill="#e81313"
+       id="path28" />
+    <use
+       xlink:href="#t"
+       transform="translate(418.19753,334.15799)"
+       id="use28" />
+    <path
+       d="m 683.25,389.92 a 6,6 0 0 1 6,-6 h 308 a 6,6 0 0 1 6,6 v 98.83 a 6,6 0 0 1 -6,6 h -308 a 6,6 0 0 1 -6,-6 z"
+       stroke="#3a414a"
+       fill="#ffffff"
+       id="path29" />
+    <path
+       d="m 619.46,440.3 h -31.68 v -1.94 h 31.68 z m 44.8,0 h -14.18 v -1.94 h 14.17 z"
+       stroke="#008a0e"
+       stroke-width="0.05"
+       fill="#008a0e"
+       id="path36" />
+    <path
+       d="m 587.8,440.3 h -1.18 l 0.08,-0.2 0.08,-0.77 -0.08,-0.76 -0.08,-0.2 h 1.2 z"
+       fill="#008a0e"
+       id="path37" />
+    <path
+       stroke="#008a0e"
+       stroke-width="0.05"
+       fill="#008a0e"
+       id="path38"
+       d="" />
+    <path
+       d="m 679.5,439.33 -14.25,4.64 v -9.27 z"
+       fill="#008a0e"
+       id="path39" />
+    <path
+       d="m 682.67,439.33 -18.4,5.98 v -11.94 z m -16.44,3.3 10.13,-3.3 -10.13,-3.3 z"
+       stroke="#008a0e"
+       stroke-width="0.05"
+       fill="#008a0e"
+       id="path40" />
+    <use
+       xlink:href="#n"
+       transform="translate(619.45758,442.88889)"
+       id="use40" />
+    <path
+       d="m 270,586.92 a 6,6 0 0 1 6,-6 h 308 a 6,6 0 0 1 6,6 v 113.1 a 6,6 0 0 1 -6,6 H 276 a 6,6 0 0 1 -6,-6 z"
+       stroke="#3a414a"
+       fill="#ffffff"
+       id="path41" />
+    <path
+       d="m 430.98,561.9 h -1.96 v -2.14 h 1.96 z m 0,-23.48 h -1.96 v -19.66 h 1.96 z"
+       stroke="#e81313"
+       stroke-width="0.05"
+       fill="#e81313"
+       id="path44" />
+    <path
+       d="m 430,517.76 0.98,-0.04 v 1.07 h -1.96 v -1.08 z"
+       fill="#e81313"
+       id="path45" />
+    <path
+       stroke="#e81313"
+       stroke-width="0.05"
+       fill="#e81313"
+       id="path46"
+       d="" />
+    <path
+       d="m 430,577.18 -4.63,-14.26 h 9.26 z"
+       fill="#e81313"
+       id="path47" />
+    <path
+       d="m 430,580.34 -5.98,-18.4 h 11.96 z m -3.3,-16.45 3.3,10.13 3.3,-10.14 z"
+       stroke="#e81313"
+       stroke-width="0.05"
+       fill="#e81313"
+       id="path48" />
+    <g
+       id="g48">
+      <use
+         xlink:href="#t"
+         transform="translate(418.19753,552.64459)"
+         id="use48" />
+    </g>
+    <path
+       d="m 837.9,577.78 a 12,12 0 0 1 10.72,0 l 126,63 a 3,3 0 0 1 0,5.37 l -126,63 a 12,12 0 0 1 -10.74,0 l -126,-63 a 3,3 0 0 1 0,-5.36 z"
+       stroke="#3a414a"
+       fill="#ffffff"
+       id="path49" />
+    <path
+       d="m 843.25,495.75 v 63.88"
+       stroke="#3a414a"
+       fill="none"
+       id="path53" />
+    <path
+       d="m 843.73,495.76 h -0.95 v -0.5 h 0.95 z"
+       stroke="#3a414a"
+       stroke-width="0.05"
+       fill="#3a414a"
+       id="path54" />
+    <path
+       d="m 843.25,574.4 -4.63,-14.27 h 9.27 z"
+       stroke="#3a414a"
+       fill="#3a414a"
+       id="path55" />
+    <path
+       d="M 591,643.47 H 693.32"
+       stroke="#3a414a"
+       fill="none"
+       id="path56" />
+    <path
+       d="m 591,643.95 h -0.5 V 643 h 0.5 z"
+       stroke="#3a414a"
+       stroke-width="0.05"
+       fill="#3a414a"
+       id="path57" />
+    <path
+       d="m 708.1,643.47 -14.28,4.63 v -9.26 z"
+       stroke="#3a414a"
+       fill="#3a414a"
+       id="path58" />
+    <path
+       d="m 1323.4,590.23788 c 31.25,0 56.6,25.35 56.6,56.62 0,31.27 -25.35,56.6 -56.6,56.6 h -206.8 c -31.25,0 -56.6,-25.33 -56.6,-56.6 0,-31.27 25.35,-56.6 56.6,-56.6 z"
+       stroke="#3a414a"
+       fill="#ffffff"
+       id="path59" />
+    <path
+       d="m 1041,644.25 v 1.95 h -7.54 v -1.96 z m -63.2,0.2 v -1.96 h 25.04 v 1.95 z"
+       stroke="#008a0e"
+       stroke-width="0.05"
+       fill="#008a0e"
+       id="path67" />
+    <path
+       d="m 977.82,644.45 h -1.18 l 0.07,-0.2 0.1,-0.78 -0.1,-0.77 -0.06,-0.2 h 1.18 z"
+       fill="#008a0e"
+       id="path68" />
+    <path
+       stroke="#008a0e"
+       stroke-width="0.05"
+       fill="#008a0e"
+       id="path69"
+       d="" />
+    <path
+       d="m 1056.26,645.22 -14.26,4.63 v -9.26 z"
+       fill="#008a0e"
+       id="path70" />
+    <path
+       d="m 1059.42,645.22 -18.4,5.98 v -11.96 z m -16.45,3.3 10.14,-3.3 -10.13,-3.3 z"
+       stroke="#008a0e"
+       stroke-width="0.05"
+       fill="#008a0e"
+       id="path71" />
+    <g
+       id="g71">
+      <use
+         xlink:href="#n"
+         transform="translate(1002.8386,647.90049)"
+         id="use71" />
+    </g>
+    <path
+       d="m 939.00838,782.55788 c 27.6,0 50,22.38 50,50 0,27.6 -22.4,50 -50,50 H 765.50835 c -27.6,0 -50,-22.4 -50,-50 0,-27.62 22.4,-50 50,-50 z"
+       stroke="#3a414a"
+       fill="#ffffff"
+       id="path72" />
+    <g
+       id="g79" />
+    <path
+       d="m 844.23,761.9 h -1.95 v -5.56 h 1.95 z m 0,-26.9 h -1.95 v -23.07 h 1.95 z"
+       stroke="#e81313"
+       stroke-width="0.05"
+       fill="#e81313"
+       id="path79" />
+    <path
+       d="m 843.25,710.93 0.98,-0.05 v 1.07 h -1.95 v -1.07 z"
+       fill="#e81313"
+       id="path80" />
+    <path
+       stroke="#e81313"
+       stroke-width="0.05"
+       fill="#e81313"
+       id="path81"
+       d="" />
+    <path
+       d="m 843.25,777.18 -4.63,-14.26 h 9.27 z"
+       fill="#e81313"
+       id="path82" />
+    <path
+       d="m 843.25,780.34 -5.98,-18.4 h 11.96 z m -3.3,-16.45 3.3,10.13 3.3,-10.14 z"
+       stroke="#e81313"
+       stroke-width="0.05"
+       fill="#e81313"
+       id="path83" />
+    <g
+       id="g83">
+      <use
+         xlink:href="#t"
+         transform="translate(831.44896,749.22673)"
+         id="use83" />
+    </g>
+    <defs
+       id="defs302">
+      <path
+         fill="#3a414a"
+         d="M 33,0 V -248 H 67 V 0 H 33"
+         id="P" />
+      <path
+         fill="#3a414a"
+         d="m 135,-143 c -3,-34 -86,-38 -87,0 15,53 115,12 119,90 4,78 -150,74 -157,8 l 28,-5 c 4,36 97,45 98,0 -10,-56 -113,-15 -118,-90 -4,-57 82,-63 122,-42 12,7 21,19 24,35"
+         id="Q" />
+      <g
+         id="a">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#P"
+           id="use84" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,6.1728395,0)"
+           xlink:href="#Q"
+           id="use85" />
+      </g>
+      <path
+         fill="#3a414a"
+         d="M 114,-163 C 36,-179 61,-72 57,0 H 25 l -1,-190 h 30 c 1,12 -1,29 2,39 6,-27 23,-49 58,-41 v 29"
+         id="R" />
+      <path
+         fill="#3a414a"
+         d="m 100,-194 c 63,0 86,42 84,106 H 49 c 0,40 14,67 53,68 26,1 43,-12 49,-29 l 28,8 C 168,-13 142,4 102,4 44,4 14,-33 15,-96 c 1,-61 26,-98 85,-98 z m 52,81 c 6,-60 -76,-77 -97,-28 -3,7 -6,17 -6,28 h 103"
+         id="S" />
+      <path
+         fill="#3a414a"
+         d="M 145,-31 C 134,-9 116,4 85,4 32,4 16,-35 15,-94 c 0,-59 17,-99 70,-100 32,-1 48,14 60,33 0,-11 -1,-24 2,-32 h 30 l -1,268 h -32 z m -52,10 c 41,0 51,-33 51,-76 0,-43 -8,-73 -50,-73 -40,0 -46,35 -46,75 0,40 5,74 45,74"
+         id="T" />
+      <path
+         fill="#3a414a"
+         d="M 84,4 C -5,8 30,-112 23,-190 h 32 v 120 c 0,31 7,50 39,49 72,-2 45,-101 50,-169 h 31 l 1,190 h -30 c -1,-10 1,-25 -2,-33 -11,22 -28,36 -60,37"
+         id="U" />
+      <path
+         fill="#3a414a"
+         d="m 59,-47 c -2,24 18,29 38,22 V -1 C 64,9 27,4 27,-40 V -167 H 5 v -23 h 24 l 9,-43 h 21 v 43 h 35 v 23 H 59 v 120"
+         id="V" />
+      <g
+         id="b">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#R"
+           id="use86" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,7.345679,0)"
+           xlink:href="#S"
+           id="use87" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,19.691358,0)"
+           xlink:href="#T"
+           id="use88" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,32.037037,0)"
+           xlink:href="#U"
+           id="use89" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,44.382716,0)"
+           xlink:href="#S"
+           id="use90" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,56.728395,0)"
+           xlink:href="#Q"
+           id="use91" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,67.839506,0)"
+           xlink:href="#V"
+           id="use92" />
+      </g>
+      <path
+         fill="#3a414a"
+         d="m 85,-194 c 31,0 48,13 60,33 l -1,-100 h 32 l 1,261 h -30 c -2,-10 0,-23 -3,-31 C 134,-8 116,4 85,4 32,4 16,-35 15,-94 c 0,-66 23,-100 70,-100 z m 9,24 c -40,0 -46,34 -46,75 0,40 6,74 45,74 42,0 51,-32 51,-76 0,-42 -9,-74 -50,-73"
+         id="W" />
+      <path
+         fill="#3a414a"
+         d="m 96,-169 c -40,0 -48,33 -48,73 0,40 9,75 48,75 24,0 41,-14 43,-38 l 32,2 C 165,-20 140,4 97,4 38,4 21,-37 15,-95 c -10,-93 101,-131 147,-64 4,7 5,14 7,22 l -32,3 c -4,-21 -16,-35 -41,-35"
+         id="X" />
+      <path
+         fill="#3a414a"
+         d="m 117,-194 c 89,-4 53,116 60,194 h -32 v -121 c 0,-31 -8,-49 -39,-48 C 34,-167 62,-67 57,0 H 25 l -1,-190 h 30 c 1,10 -1,24 2,32 11,-22 29,-35 61,-36"
+         id="Y" />
+      <g
+         id="c">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#W"
+           id="use93" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,12.345679,0)"
+           xlink:href="#S"
+           id="use94" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,24.691358,0)"
+           xlink:href="#Q"
+           id="use95" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,35.802469,0)"
+           xlink:href="#X"
+           id="use96" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,46.91358,0)"
+           xlink:href="#S"
+           id="use97" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,59.259259,0)"
+           xlink:href="#Y"
+           id="use98" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,71.604938,0)"
+           xlink:href="#W"
+           id="use99" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,83.950617,0)"
+           xlink:href="#S"
+           id="use100" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,96.296296,0)"
+           xlink:href="#W"
+           id="use101" />
+      </g>
+      <path
+         fill="#3a414a"
+         d="m 101,-234 c -31,-9 -42,10 -38,44 h 38 v 23 H 63 V 0 H 32 V -167 H 5 v -23 h 27 c -7,-52 17,-82 69,-68 v 24"
+         id="Z" />
+      <path
+         fill="#3a414a"
+         d="m 100,-194 c 62,-1 85,37 85,99 1,63 -27,99 -86,99 -59,0 -83,-39 -84,-99 0,-66 28,-99 85,-99 z m -1,174 c 44,1 53,-31 53,-75 0,-43 -8,-75 -51,-75 -43,0 -53,32 -53,75 0,43 10,74 51,75"
+         id="aa" />
+      <path
+         fill="#3a414a"
+         d="m 210,-169 c -67,3 -38,105 -44,169 h -31 v -121 c 0,-29 -5,-50 -35,-48 C 34,-165 62,-65 56,0 H 25 l -1,-190 h 30 c 1,10 -1,24 2,32 10,-44 99,-50 107,0 11,-21 27,-35 58,-36 85,-2 47,119 55,194 h -31 v -121 c 0,-29 -5,-49 -35,-48"
+         id="ab" />
+      <g
+         id="d">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#Z"
+           id="use102" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,6.1728395,0)"
+           xlink:href="#R"
+           id="use103" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,13.518519,0)"
+           xlink:href="#aa"
+           id="use104" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,25.864198,0)"
+           xlink:href="#ab"
+           id="use105" />
+      </g>
+      <path
+         fill="#3a414a"
+         d="M 141,-36 C 126,-15 110,5 73,4 37,3 15,-17 15,-53 c -1,-64 63,-63 125,-63 3,-35 -9,-54 -41,-54 -24,1 -41,7 -42,31 l -33,-3 c 5,-37 33,-52 76,-52 45,0 72,20 72,64 v 82 c -1,20 7,32 28,27 V -1 C 169,8 139,-3 141,-36 Z M 48,-53 c 0,20 12,33 32,33 41,-3 63,-29 60,-74 -43,2 -92,-5 -92,41"
+         id="ac" />
+      <use
+         transform="scale(0.0617284)"
+         xlink:href="#ac"
+         id="e" />
+      <path
+         fill="#3a414a"
+         d="m 115,-194 c 55,1 70,41 70,98 C 185,-39 169,2 115,4 84,4 66,-9 55,-30 L 56,75 H 24 l -1,-265 h 31 l 2,30 c 10,-21 28,-34 59,-34 z m -8,174 c 40,0 45,-34 45,-75 0,-41 -6,-73 -45,-74 -42,0 -51,32 -51,76 0,43 10,73 51,73"
+         id="ad" />
+      <path
+         fill="#3a414a"
+         d="M 108,0 H 70 L 1,-190 h 34 l 54,165 56,-165 h 34"
+         id="ae" />
+      <path
+         fill="#3a414a"
+         d="m 24,-231 v -30 h 32 v 30 z M 24,0 V -190 H 56 V 0 H 24"
+         id="af" />
+      <g
+         id="f">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#ad"
+           id="use106" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,12.345679,0)"
+           xlink:href="#R"
+           id="use107" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,19.691358,0)"
+           xlink:href="#S"
+           id="use108" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,32.037037,0)"
+           xlink:href="#ae"
+           id="use109" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,43.148148,0)"
+           xlink:href="#af"
+           id="use110" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,48.024691,0)"
+           xlink:href="#aa"
+           id="use111" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,60.37037,0)"
+           xlink:href="#U"
+           id="use112" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,72.716049,0)"
+           xlink:href="#Q"
+           id="use113" />
+      </g>
+      <path
+         fill="#3a414a"
+         d="m 103,-251 c 84,0 111,97 45,133 -19,10 -37,24 -39,52 H 78 c 0,-63 77,-55 77,-114 0,-30 -21,-42 -52,-43 -32,0 -53,17 -56,46 l -32,-2 c 7,-45 34,-72 88,-72 z M 77,0 v -35 h 34 V 0 H 77"
+         id="ag" />
+      <g
+         id="g">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#R"
+           id="use114" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,7.345679,0)"
+           xlink:href="#S"
+           id="use115" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,19.691358,0)"
+           xlink:href="#T"
+           id="use116" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,32.037037,0)"
+           xlink:href="#U"
+           id="use117" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,44.382716,0)"
+           xlink:href="#S"
+           id="use118" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,56.728395,0)"
+           xlink:href="#Q"
+           id="use119" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,67.839506,0)"
+           xlink:href="#V"
+           id="use120" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,74.012346,0)"
+           xlink:href="#ag"
+           id="use121" />
+      </g>
+      <path
+         fill="#3a414a"
+         d="m 185,-189 c -5,-48 -123,-54 -124,2 14,75 158,14 163,119 C 227,10 103,19 49,-13 32,-23 21,-39 16,-59 l 33,-7 c 5,56 141,63 141,-1 0,-78 -155,-14 -162,-118 -5,-82 145,-84 179,-34 5,7 8,16 11,25"
+         id="ah" />
+      <g
+         id="h">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#ah"
+           id="use122" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,14.814815,0)"
+           xlink:href="#S"
+           id="use123" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,27.160494,0)"
+           xlink:href="#Y"
+           id="use124" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,39.506173,0)"
+           xlink:href="#W"
+           id="use125" />
+      </g>
+      <g
+         id="i">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#V"
+           id="use126" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,6.1728395,0)"
+           xlink:href="#aa"
+           id="use127" />
+      </g>
+      <g
+         id="j">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#Q"
+           id="use128" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,11.111111,0)"
+           xlink:href="#ac"
+           id="use129" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,23.45679,0)"
+           xlink:href="#ab"
+           id="use130" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,41.91358,0)"
+           xlink:href="#S"
+           id="use131" />
+      </g>
+      <path
+         fill="#3a414a"
+         d="m 115,-194 c 53,0 69,39 70,98 C 185,-30 162,4 115,4 84,3 66,-7 56,-30 L 54,0 H 23 l 1,-261 h 32 v 101 c 10,-23 28,-34 59,-34 z m -8,174 c 40,0 45,-34 45,-75 0,-40 -5,-75 -45,-74 -42,0 -51,32 -51,76 0,43 10,73 51,73"
+         id="ai" />
+      <path
+         fill="#3a414a"
+         d="M 143,0 79,-87 56,-68 V 0 H 24 v -261 h 32 v 163 l 83,-92 h 37 l -77,82 82,108 h -38"
+         id="aj" />
+      <g
+         id="k">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#ai"
+           id="use132" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,12.345679,0)"
+           xlink:href="#ac"
+           id="use133" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,24.691358,0)"
+           xlink:href="#X"
+           id="use134" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,35.802469,0)"
+           xlink:href="#aj"
+           id="use135" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,46.91358,0)"
+           xlink:href="#S"
+           id="use136" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,59.259259,0)"
+           xlink:href="#Y"
+           id="use137" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,71.604938,0)"
+           xlink:href="#W"
+           id="use138" />
+      </g>
+      <g
+         id="l">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#ac"
+           id="use139" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,12.345679,0)"
+           xlink:href="#Q"
+           id="use140" />
+      </g>
+      <g
+         id="m">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#ad"
+           id="use141" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,12.345679,0)"
+           xlink:href="#R"
+           id="use142" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,19.691358,0)"
+           xlink:href="#S"
+           id="use143" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,32.037037,0)"
+           xlink:href="#ae"
+           id="use144" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,43.148148,0)"
+           xlink:href="#af"
+           id="use145" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,48.024691,0)"
+           xlink:href="#aa"
+           id="use146" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,60.37037,0)"
+           xlink:href="#U"
+           id="use147" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,72.716049,0)"
+           xlink:href="#Q"
+           id="use148" />
+      </g>
+      <path
+         fill="#333333"
+         d="M 146,-102 V 0 H 94 V -102 L 6,-248 h 54 l 60,105 60,-105 h 54"
+         id="ak" />
+      <path
+         fill="#333333"
+         d="M 185,-48 C 172,-18 148,5 103,4 43,2 14,-33 14,-96 c 0,-63 30,-98 90,-98 62,0 83,45 84,108 H 66 c 0,31 8,55 39,56 18,0 30,-7 34,-22 z m -45,-69 c 5,-46 -57,-63 -70,-21 -2,6 -4,13 -4,21 h 74"
+         id="al" />
+      <path
+         fill="#333333"
+         d="m 137,-138 c 1,-29 -70,-34 -71,-4 15,46 118,7 119,86 1,83 -164,76 -172,9 l 43,-7 c 4,19 20,25 44,25 33,8 57,-30 24,-41 -43,-14 -102,-11 -104,-66 -2,-80 154,-74 161,-7"
+         id="am" />
+      <g
+         id="n">
+        <use
+           transform="scale(0.04938272)"
+           xlink:href="#ak"
+           id="use149" />
+        <use
+           transform="matrix(0.04938272,0,0,0.04938272,10.864198,0)"
+           xlink:href="#al"
+           id="use150" />
+        <use
+           transform="matrix(0.04938272,0,0,0.04938272,20.740741,0)"
+           xlink:href="#am"
+           id="use151" />
+      </g>
+      <path
+         fill="#3a414a"
+         d="m 30,-248 c 118,-7 216,8 213,122 C 240,-48 200,0 122,0 H 30 Z m 33,221 c 89,8 146,-16 146,-99 0,-83 -60,-101 -146,-95 v 194"
+         id="an" />
+      <g
+         id="o">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#an"
+           id="use152" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,15.987654,0)"
+           xlink:href="#aa"
+           id="use153" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,28.333333,0)"
+           xlink:href="#S"
+           id="use154" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,40.679012,0)"
+           xlink:href="#Q"
+           id="use155" />
+      </g>
+      <g
+         id="p">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#R"
+           id="use156" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,7.345679,0)"
+           xlink:href="#S"
+           id="use157" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,19.691358,0)"
+           xlink:href="#T"
+           id="use158" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,32.037037,0)"
+           xlink:href="#U"
+           id="use159" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,44.382716,0)"
+           xlink:href="#S"
+           id="use160" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,56.728395,0)"
+           xlink:href="#Q"
+           id="use161" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,67.839506,0)"
+           xlink:href="#V"
+           id="use162" />
+      </g>
+      <path
+         fill="#3a414a"
+         d="M 106,-169 C 34,-169 62,-67 57,0 H 25 v -261 h 32 l -1,103 c 12,-21 28,-36 61,-36 89,0 53,116 60,194 h -32 v -121 c 2,-32 -8,-49 -39,-48"
+         id="ao" />
+      <g
+         id="q">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#ab"
+           id="use163" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,18.45679,0)"
+           xlink:href="#ac"
+           id="use164" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,30.802469,0)"
+           xlink:href="#V"
+           id="use165" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,36.975309,0)"
+           xlink:href="#X"
+           id="use166" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,48.08642,0)"
+           xlink:href="#ao"
+           id="use167" />
+      </g>
+      <path
+         fill="#3a414a"
+         d="m 233,-177 c -1,41 -23,64 -60,70 L 243,0 H 205 L 140,-103 H 63 V 0 H 30 v -248 c 88,3 205,-21 203,71 z m -170,48 c 60,-2 137,13 137,-47 0,-61 -80,-42 -137,-45 v 92"
+         id="ap" />
+      <path
+         fill="#3a414a"
+         d="M 177,-190 C 167,-65 218,103 67,71 44,65 29,51 23,28 L 55,23 C 70,70 155,55 144,-5 V -35 C 133,-14 115,1 83,1 29,1 15,-40 15,-95 c 0,-56 16,-97 71,-98 29,-1 48,16 59,35 1,-10 0,-23 2,-32 z M 94,-22 c 36,0 50,-32 50,-73 0,-42 -14,-75 -50,-75 -39,0 -46,34 -46,75 0,41 6,73 46,73"
+         id="aq" />
+      <g
+         id="r">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#ap"
+           id="use168" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,15.987654,0)"
+           xlink:href="#aa"
+           id="use169" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,28.333333,0)"
+           xlink:href="#U"
+           id="use170" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,40.679012,0)"
+           xlink:href="#V"
+           id="use171" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,46.851852,0)"
+           xlink:href="#af"
+           id="use172" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,51.728395,0)"
+           xlink:href="#Y"
+           id="use173" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,64.074074,0)"
+           xlink:href="#aq"
+           id="use174" />
+      </g>
+      <path
+         fill="#3a414a"
+         d="M 24,0 V -261 H 56 V 0 H 24"
+         id="ar" />
+      <g
+         id="s">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#ap"
+           id="use175" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,15.987654,0)"
+           xlink:href="#U"
+           id="use176" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,28.333333,0)"
+           xlink:href="#ar"
+           id="use177" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,33.209877,0)"
+           xlink:href="#S"
+           id="use178" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,45.555556,0)"
+           xlink:href="#ag"
+           id="use179" />
+      </g>
+      <path
+         fill="#333333"
+         d="M 175,0 67,-191 c 6,58 2,128 3,191 H 24 v -248 h 59 l 110,193 c -6,-58 -2,-129 -3,-193 h 46 V 0 h -61"
+         id="as" />
+      <path
+         fill="#333333"
+         d="m 110,-194 c 64,0 96,36 96,99 0,64 -35,99 -97,99 -61,0 -95,-36 -95,-99 0,-62 34,-99 96,-99 z m -1,164 c 35,0 45,-28 45,-65 0,-40 -10,-65 -43,-65 -34,0 -45,26 -45,65 0,36 10,65 43,65"
+         id="at" />
+      <g
+         id="t">
+        <use
+           transform="scale(0.04938272)"
+           xlink:href="#as"
+           id="use180" />
+        <use
+           transform="matrix(0.04938272,0,0,0.04938272,12.790123,0)"
+           xlink:href="#at"
+           id="use181" />
+      </g>
+      <g
+         id="u">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#ah"
+           id="use182" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,14.814815,0)"
+           xlink:href="#S"
+           id="use183" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,27.160494,0)"
+           xlink:href="#ar"
+           id="use184" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,32.037037,0)"
+           xlink:href="#S"
+           id="use185" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,44.382716,0)"
+           xlink:href="#X"
+           id="use186" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,55.493827,0)"
+           xlink:href="#V"
+           id="use187" />
+      </g>
+      <path
+         fill="#3a414a"
+         d="M 143,4 C 61,4 22,-44 18,-125 c -5,-107 100,-154 193,-111 17,8 29,25 37,43 l -32,9 c -13,-25 -37,-40 -76,-40 -61,0 -88,39 -88,99 0,61 29,100 91,101 35,0 62,-11 79,-27 v -45 h -74 v -28 h 105 v 86 C 228,-13 192,4 143,4"
+         id="au" />
+      <g
+         id="v">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#au"
+           id="use188" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,17.283951,0)"
+           xlink:href="#R"
+           id="use189" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,24.62963,0)"
+           xlink:href="#aa"
+           id="use190" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,36.975309,0)"
+           xlink:href="#U"
+           id="use191" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,49.320988,0)"
+           xlink:href="#ad"
+           id="use192" />
+      </g>
+      <g
+         id="w">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#Z"
+           id="use193" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,6.1728395,0)"
+           xlink:href="#R"
+           id="use194" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,13.518519,0)"
+           xlink:href="#aa"
+           id="use195" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,25.864198,0)"
+           xlink:href="#ab"
+           id="use196" />
+      </g>
+      <g
+         id="x">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#ao"
+           id="use197" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,12.345679,0)"
+           xlink:href="#af"
+           id="use198" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,17.222222,0)"
+           xlink:href="#aq"
+           id="use199" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,29.567901,0)"
+           xlink:href="#ao"
+           id="use200" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,41.91358,0)"
+           xlink:href="#S"
+           id="use201" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,54.259259,0)"
+           xlink:href="#Q"
+           id="use202" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,65.37037,0)"
+           xlink:href="#V"
+           id="use203" />
+      </g>
+      <path
+         fill="#3a414a"
+         d="M 179,-190 93,31 C 79,59 56,82 12,73 V 49 C 51,55 65,29 76,-1 L 1,-190 h 34 l 57,156 54,-156 h 33"
+         id="av" />
+      <g
+         id="y">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#ad"
+           id="use204" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,12.345679,0)"
+           xlink:href="#R"
+           id="use205" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,19.691358,0)"
+           xlink:href="#af"
+           id="use206" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,24.567901,0)"
+           xlink:href="#aa"
+           id="use207" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,36.91358,0)"
+           xlink:href="#R"
+           id="use208" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,44.259259,0)"
+           xlink:href="#af"
+           id="use209" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,49.135802,0)"
+           xlink:href="#V"
+           id="use210" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,55.308642,0)"
+           xlink:href="#av"
+           id="use211" />
+      </g>
+      <g
+         id="z">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#ab"
+           id="use212" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,18.45679,0)"
+           xlink:href="#ac"
+           id="use213" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,30.802469,0)"
+           xlink:href="#V"
+           id="use214" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,36.975309,0)"
+           xlink:href="#X"
+           id="use215" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,48.08642,0)"
+           xlink:href="#ao"
+           id="use216" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,60.432099,0)"
+           xlink:href="#S"
+           id="use217" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,72.777778,0)"
+           xlink:href="#W"
+           id="use218" />
+      </g>
+      <g
+         id="A">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#R"
+           id="use219" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,7.345679,0)"
+           xlink:href="#U"
+           id="use220" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,19.691358,0)"
+           xlink:href="#ar"
+           id="use221" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,24.567901,0)"
+           xlink:href="#S"
+           id="use222" />
+      </g>
+      <path
+         fill="#3a414a"
+         d="M 109,-170 H 84 l -4,-78 h 32 z m -65,0 H 19 l -4,-78 h 33"
+         id="aw" />
+      <g
+         id="B">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#aw"
+           id="use223" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,7.8395062,0)"
+           xlink:href="#ac"
+           id="use224" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,20.185185,0)"
+           xlink:href="#W"
+           id="use225" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,32.530864,0)"
+           xlink:href="#ao"
+           id="use226" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,44.876543,0)"
+           xlink:href="#aa"
+           id="use227" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,57.222222,0)"
+           xlink:href="#X"
+           id="use228" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,68.333333,0)"
+           xlink:href="#aw"
+           id="use229" />
+      </g>
+      <g
+         id="C">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#R"
+           id="use230" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,7.345679,0)"
+           xlink:href="#aa"
+           id="use231" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,19.691358,0)"
+           xlink:href="#U"
+           id="use232" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,32.037037,0)"
+           xlink:href="#V"
+           id="use233" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,38.209877,0)"
+           xlink:href="#af"
+           id="use234" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,43.08642,0)"
+           xlink:href="#Y"
+           id="use235" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,55.432099,0)"
+           xlink:href="#aq"
+           id="use236" />
+      </g>
+      <g
+         id="D">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#aq"
+           id="use237" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,12.345679,0)"
+           xlink:href="#R"
+           id="use238" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,19.691358,0)"
+           xlink:href="#aa"
+           id="use239" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,32.037037,0)"
+           xlink:href="#U"
+           id="use240" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,44.382716,0)"
+           xlink:href="#ad"
+           id="use241" />
+      </g>
+      <g
+         id="E">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#P"
+           id="use242" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,6.1728395,0)"
+           xlink:href="#Q"
+           id="use243" />
+      </g>
+      <path
+         fill="#3a414a"
+         d="M 205,0 177,-72 H 64 L 36,0 H 1 l 101,-248 h 38 L 239,0 Z m -38,-99 -47,-123 c -12,45 -31,82 -46,123 h 93"
+         id="ax" />
+      <g
+         id="F">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#ax"
+           id="use244" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,14.814815,0)"
+           xlink:href="#W"
+           id="use245" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,27.160494,0)"
+           xlink:href="#ac"
+           id="use246" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,39.506173,0)"
+           xlink:href="#ad"
+           id="use247" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,51.851852,0)"
+           xlink:href="#V"
+           id="use248" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,58.024691,0)"
+           xlink:href="#af"
+           id="use249" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,62.901235,0)"
+           xlink:href="#ae"
+           id="use250" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,74.012346,0)"
+           xlink:href="#S"
+           id="use251" />
+      </g>
+      <path
+         fill="#3a414a"
+         d="M 30,0 V -248 H 63 V -27 H 188 V 0 H 30"
+         id="ay" />
+      <g
+         id="G">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#ay"
+           id="use252" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,12.345679,0)"
+           xlink:href="#aa"
+           id="use253" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,24.691358,0)"
+           xlink:href="#ac"
+           id="use254" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,37.037037,0)"
+           xlink:href="#W"
+           id="use255" />
+      </g>
+      <path
+         fill="#3a414a"
+         d="m 160,-131 c 35,5 61,23 61,61 0,87 -106,68 -191,70 v -248 c 76,3 177,-17 177,60 0,33 -19,50 -47,57 z m -97,-11 c 50,-1 110,9 110,-42 0,-47 -63,-36 -110,-37 z m 0,115 c 55,-2 124,14 124,-45 0,-56 -70,-42 -124,-44 v 89"
+         id="az" />
+      <g
+         id="H">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#az"
+           id="use256" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,14.814815,0)"
+           xlink:href="#ac"
+           id="use257" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,27.160494,0)"
+           xlink:href="#ar"
+           id="use258" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,32.037037,0)"
+           xlink:href="#ac"
+           id="use259" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,44.382716,0)"
+           xlink:href="#Y"
+           id="use260" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,56.728395,0)"
+           xlink:href="#X"
+           id="use261" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,67.839506,0)"
+           xlink:href="#af"
+           id="use262" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,72.716049,0)"
+           xlink:href="#Y"
+           id="use263" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,85.061728,0)"
+           xlink:href="#aq"
+           id="use264" />
+      </g>
+      <g
+         id="I">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#S"
+           id="use265" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,12.345679,0)"
+           xlink:href="#Y"
+           id="use266" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,24.691358,0)"
+           xlink:href="#ac"
+           id="use267" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,37.037037,0)"
+           xlink:href="#ai"
+           id="use268" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,49.382716,0)"
+           xlink:href="#ar"
+           id="use269" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,54.259259,0)"
+           xlink:href="#S"
+           id="use270" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,66.604938,0)"
+           xlink:href="#W"
+           id="use271" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,78.950617,0)"
+           xlink:href="#ag"
+           id="use272" />
+      </g>
+      <g
+         id="J">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#ar"
+           id="use273" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,4.8765432,0)"
+           xlink:href="#S"
+           id="use274" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,17.222222,0)"
+           xlink:href="#ac"
+           id="use275" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,29.567901,0)"
+           xlink:href="#Q"
+           id="use276" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,40.679012,0)"
+           xlink:href="#V"
+           id="use277" />
+      </g>
+      <g
+         id="K">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#ar"
+           id="use278" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,4.8765432,0)"
+           xlink:href="#aa"
+           id="use279" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,17.222222,0)"
+           xlink:href="#ac"
+           id="use280" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,29.567901,0)"
+           xlink:href="#W"
+           id="use281" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,41.91358,0)"
+           xlink:href="#S"
+           id="use282" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,54.259259,0)"
+           xlink:href="#W"
+           id="use283" />
+      </g>
+      <g
+         id="L">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#ab"
+           id="use284" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,18.45679,0)"
+           xlink:href="#S"
+           id="use285" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,30.802469,0)"
+           xlink:href="#ab"
+           id="use286" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,49.259259,0)"
+           xlink:href="#ai"
+           id="use287" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,61.604938,0)"
+           xlink:href="#S"
+           id="use288" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,73.950617,0)"
+           xlink:href="#R"
+           id="use289" />
+      </g>
+      <g
+         id="M">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#aa"
+           id="use290" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,12.345679,0)"
+           xlink:href="#Z"
+           id="use291" />
+      </g>
+      <g
+         id="N">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#au"
+           id="use292" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,17.283951,0)"
+           xlink:href="#R"
+           id="use293" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,24.62963,0)"
+           xlink:href="#aa"
+           id="use294" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,36.975309,0)"
+           xlink:href="#U"
+           id="use295" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,49.320988,0)"
+           xlink:href="#ad"
+           id="use296" />
+      </g>
+      <g
+         id="O">
+        <use
+           transform="scale(0.0617284)"
+           xlink:href="#R"
+           id="use297" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,7.345679,0)"
+           xlink:href="#ac"
+           id="use298" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,19.691358,0)"
+           xlink:href="#Y"
+           id="use299" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,32.037037,0)"
+           xlink:href="#W"
+           id="use300" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,44.382716,0)"
+           xlink:href="#aa"
+           id="use301" />
+        <use
+           transform="matrix(0.0617284,0,0,0.0617284,56.728395,0)"
+           xlink:href="#ab"
+           id="use302" />
+      </g>
+    </defs>
+    <text
+       xml:space="preserve"
+       transform="translate(235.08636,125.05757)"
+       id="text303"
+       style="white-space:pre;shape-inside:url(#rect303);fill:#000000" />
+    <text
+       xml:space="preserve"
+       id="text304"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20.0001px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;white-space:pre;shape-inside:url(#path72);fill:#000000"
+       x="104.16798"
+       y="0"
+       transform="translate(-0.8189407,13.103051)"><tspan
+         x="771.97421"
+         y="800.80529"
+         id="tspan5">Send request to </tspan><tspan
+         x="755.32377"
+         y="825.80541"
+         id="tspan6">random member of </tspan><tspan
+         x="783.7077"
+         y="850.80553"
+         id="tspan7">routing group</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;fill:#000000"
+       x="1094.1552"
+       y="633.61975"
+       id="text305"><tspan
+         sodipodi:role="line"
+         id="tspan305"
+         x="1094.1552"
+         y="633.61975" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;white-space:pre;shape-inside:url(#path59);fill:#000000"
+       x="1066.3112"
+       y="736.80627"
+       id="text306"
+       transform="matrix(1,0,0,1.118312,0.8189407,-53.814448)"><tspan
+         x="1112.3781"
+         y="608.48489"
+         id="tspan8">Send request to least </tspan><tspan
+         x="1086.4175"
+         y="633.48489"
+         id="tspan9">loaded member of Routing </tspan><tspan
+         x="1189.3506"
+         y="658.48489"
+         id="tspan10">Group</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;white-space:pre;shape-inside:url(#path49);fill:#000000"
+       x="958.211"
+       y="722.88428"
+       id="text307"
+       transform="translate(0,6)"><tspan
+         x="786.55072"
+         y="619.90481"
+         id="tspan11">Is Adaptive </tspan><tspan
+         x="767.41989"
+         y="644.90481"
+         id="tspan12">Load Balancing </tspan><tspan
+         x="798.34277"
+         y="669.90481"
+         id="tspan13">enabled?</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;white-space:pre;shape-inside:url(#path41);fill:#000000"
+       x="444.73517"
+       y="765.46918"
+       id="text308"
+       transform="translate(0.8189407,48.317501)"><tspan
+         x="284.90984"
+         y="599.16653"
+         id="tspan14">Select &quot;adhoc&quot; routing group</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;white-space:pre;shape-inside:url(#path29);fill:#000000"
+       x="651.10822"
+       y="328.15485"
+       id="text309"
+       transform="translate(0,30)"><tspan
+         x="709.63931"
+         y="402.16653"
+         id="tspan15">Select Routing Group from </tspan><tspan
+         x="697.13672"
+         y="427.16653"
+         id="tspan16">highest priority matched rule</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;white-space:pre;shape-inside:url(#path19);fill:#000000"
+       x="488.13904"
+       y="330.61166"
+       id="text310"
+       transform="translate(0,16)"><tspan
+         x="405.06447"
+         y="404.65676"
+         id="tspan17">Does </tspan><tspan
+         x="347.86719"
+         y="429.65676"
+         id="tspan18">request match a </tspan><tspan
+         x="360.80176"
+         y="454.65676"
+         id="tspan19">Routing Rule?</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;white-space:pre;shape-inside:url(#path2);fill:#000000"
+       x="525.8103"
+       y="306.04346"
+       id="text311"
+       transform="translate(0,14)"><tspan
+         x="379.17482"
+         y="192.85989"
+         id="tspan20">Is request </tspan><tspan
+         x="325.61037"
+         y="217.85989"
+         id="tspan21">related to a previous </tspan><tspan
+         x="386.67084"
+         y="242.85989"
+         id="tspan22">request?</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;white-space:pre;shape-inside:url(#path8);fill:#000000"
+       x="701.0636"
+       y="337.98215"
+       id="text312"
+       transform="translate(0,18)"><tspan
+         x="781.1218"
+         y="186.99661"
+         id="tspan23">Send to </tspan><tspan
+         x="733.07199"
+         y="211.99661"
+         id="tspan24">same backend as </tspan><tspan
+         x="777.27637"
+         y="236.99661"
+         id="tspan25">previous</tspan></text>
+    <circle
+       style="fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:1.72716;stroke-dasharray:none;stroke-opacity:1"
+       id="path312"
+       cy="225.74841"
+       cx="113.24237"
+       r="42.421333" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;font-family:'.SF Compact Rounded';-inkscape-font-specification:'.SF Compact Rounded, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:1.4;stroke-dasharray:none;stroke-opacity:1"
+       x="310.01944"
+       y="106.6314"
+       id="text313"><tspan
+         sodipodi:role="line"
+         id="tspan313"
+         x="310.01944"
+         y="106.6314"></tspan></text>
+    <path
+       style="fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:1.4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker314)"
+       d="m 253.24208,223.93293 -97.45394,0.81894"
+       id="path313" />
+  </g>
+</svg>

--- a/docs/design.md
+++ b/docs/design.md
@@ -18,7 +18,8 @@
         <li><a href="gateway-api.md">Gateway API</a></li>
         <li><a href="resource-groups-api.md">Resource groups API</a></li>
         <li><a href="routing-rules.md">Routing rules</a></li>
-      </ul>
+        <li><a href="routing-logic.md">Routing logic</a></li>
+</ul>
     </td>
     <td>
       <ul>

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,6 +18,7 @@
         <li><a href="gateway-api.md">Gateway API</a></li>
         <li><a href="resource-groups-api.md">Resource groups API</a></li>
         <li><a href="routing-rules.md">Routing rules</a></li>
+        <li><a href="routing-logic.md">Routing logic</a></li>
       </ul>
     </td>
     <td>

--- a/docs/gateway-api.md
+++ b/docs/gateway-api.md
@@ -18,6 +18,7 @@
         <li><a href="gateway-api.md">Gateway API</a></li>
         <li><a href="resource-groups-api.md">Resource groups API</a></li>
         <li><a href="routing-rules.md">Routing rules</a></li>
+        <li><a href="routing-logic.md">Routing logic</a></li>
       </ul>
     </td>
     <td>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,6 +18,7 @@
         <li><a href="gateway-api.md">Gateway API</a></li>
         <li><a href="resource-groups-api.md">Resource groups API</a></li>
         <li><a href="routing-rules.md">Routing rules</a></li>
+        <li><a href="routing-logic.md">Routing logic</a></li>
       </ul>
     </td>
     <td>

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -18,6 +18,7 @@
         <li><a href="gateway-api.md">Gateway API</a></li>
         <li><a href="resource-groups-api.md">Resource groups API</a></li>
         <li><a href="routing-rules.md">Routing rules</a></li>
+        <li><a href="routing-logic.md">Routing logic</a></li>
       </ul>
     </td>
     <td>

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,6 +18,7 @@
         <li><a href="gateway-api.md">Gateway API</a></li>
         <li><a href="resource-groups-api.md">Resource groups API</a></li>
         <li><a href="routing-rules.md">Routing rules</a></li>
+        <li><a href="routing-logic.md">Routing logic</a></li>
       </ul>
     </td>
     <td>

--- a/docs/references.md
+++ b/docs/references.md
@@ -18,6 +18,7 @@
         <li><a href="gateway-api.md">Gateway API</a></li>
         <li><a href="resource-groups-api.md">Resource groups API</a></li>
         <li><a href="routing-rules.md">Routing rules</a></li>
+        <li><a href="routing-logic.md">Routing logic</a></li>
       </ul>
     </td>
     <td>

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,6 +18,7 @@
         <li><a href="gateway-api.md">Gateway API</a></li>
         <li><a href="resource-groups-api.md">Resource groups API</a></li>
         <li><a href="routing-rules.md">Routing rules</a></li>
+        <li><a href="routing-logic.md">Routing logic</a></li>
       </ul>
     </td>
     <td>

--- a/docs/resource-groups-api.md
+++ b/docs/resource-groups-api.md
@@ -18,6 +18,7 @@
         <li><a href="gateway-api.md">Gateway API</a></li>
         <li><a href="resource-groups-api.md">Resource groups API</a></li>
         <li><a href="routing-rules.md">Routing rules</a></li>
+        <li><a href="routing-logic.md">Routing logic</a></li>
       </ul>
     </td>
     <td>

--- a/docs/routing-logic.md
+++ b/docs/routing-logic.md
@@ -1,0 +1,111 @@
+**Trino Gateway documentation**
+
+<table>
+  <tr>
+    <td>
+      <img src="./assets/logos/trino-gateway-v.png"/>
+    </td>
+    <td>
+      <ul>
+        <li><a href="quickstart.md">Quickstart</a></li>
+        <li><a href="installation.md">Installation</a></li>
+        <li><a href="security.md">Security</a></li>
+        <li><a href="operation.md">Operation</a></li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+        <li><a href="gateway-api.md">Gateway API</a></li>
+        <li><a href="resource-groups-api.md">Resource groups API</a></li>
+        <li><a href="routing-rules.md">Routing rules</a></li>
+        <li><a href="routing-logic.md">Routing logic</a></li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+        <li><a href="design.md">Design</a></li>
+        <li><a href="development.md">Development</a></li>
+        <li><a href="release-notes.md">Release notes</a></li>
+        <li><a href="references.md">References</a></li>
+      </ul>
+    </td>
+  </tr>
+</table>
+
+# Routing Logic
+
+## Overview
+
+Trino Gateway checks incoming requests to see if they're related to previous 
+ones it handled. If they are, then Trino Gateway sends them to the same backend 
+that dealt with the earlier requests.
+
+If it is a new request, the Trino Gateway refers to [Routing rules](routing-rules.md) 
+to decide which group of backends, called a 'Routing Group,' should handle it. 
+It then picks a backend from that Routing Group to handle the request using 
+either an adaptive or round-robin strategy.
+
+![Request Routing Flow](assets/gateway-routing-flow.svg)
+
+## Sticky routing
+
+A request related to an ongoing process, or to state maintained on a single 
+backend cluster, must be routed to that backend for proper handling. Two 
+mechanisms for identifying related requests are currently implemented. By default,
+only routing based on query identifier is enabled.
+
+### Routing based on query identifier (default)
+
+When a query is initiated through the Trino Gateway, the query id will be 
+extracted from the response and mapped to the backend that provided the 
+response. Any subsequent request containing that query id will be forwarded 
+to that backend. For example, to retrieve query results, the trino client 
+polls a URI of the form 
+`v1/statement/executing/queryid/nonce/counter`. The Trino Gateway will extract
+the queryid from this URI.
+
+### Routing based on cookies
+
+OAuth2 authentication requires that the same backend is used for each step of 
+the handshake. When `gatewayCookieConfiguration.enabled` is set to true, a cookie 
+will be added to requests made to paths beginning with `/oauth2` unless they already have 
+a cookie present, which is used to route further `/oauth2/*` requests to the correct backend. 
+Cookies are not added to requests to `v1/*` and other Trino endpoints.
+
+Trino Gateway signs its cookies to ensure that they are not tampered with. You 
+must set a `cookieSigningSecret` string in your configuration
+```yaml
+gatewayCookieConfiguration:
+    enabled: true
+    cookieSigningSecret: "ahighentropystring"
+```
+when making use of this feature. If you load balance request across multiple Trino Gateway
+instances, ensure each instance has the same `cookieSigningSecret`.
+
+The Trino Gateway handles standard Trino OAuth2 handshakes with no additional 
+configuration. If you are using a customized or commercial Trino distribution, then
+the paths used to define the OAuth handshake may be modified.
+
+`routingPaths`: If the request URI starts with a path in this list, then
+* If no cookie is present, add a routing cookie
+* If a cookie is present, route the request to the backend defined by that cookie
+
+`deletePaths`: If the request URI starts with a path in this list,
+return a response that instructs the client to delete the cookie.
+
+Additionally, the `lifetime` property sets the duration for which a cookie remains in 
+effect after creation. Ensure that it is greater than
+the time required to complete the handshake. Default `lifetime` is 10 minutes.
+
+These properties are defined under the `oauth2GatewayCookieConfiguration` node: 
+
+```yaml
+oauth2GatewayCookieConfiguration:
+  routingPaths:
+    - "/oauth2"
+    - "/custom/oauth2/callback"
+    - "/alternative/oauth2/initiate"
+  deletePaths:
+    - "/custom/logout"
+  lifetime: "5m"
+```

--- a/docs/routing-rules.md
+++ b/docs/routing-rules.md
@@ -18,6 +18,7 @@
         <li><a href="gateway-api.md">Gateway API</a></li>
         <li><a href="resource-groups-api.md">Resource groups API</a></li>
         <li><a href="routing-rules.md">Routing rules</a></li>
+        <li><a href="routing-logic.md">Routing logic</a></li>
       </ul>
     </td>
     <td>

--- a/docs/security.md
+++ b/docs/security.md
@@ -18,6 +18,7 @@
         <li><a href="gateway-api.md">Gateway API</a></li>
         <li><a href="resource-groups-api.md">Resource groups API</a></li>
         <li><a href="routing-rules.md">Routing rules</a></li>
+        <li><a href="routing-logic.md">Routing logic</a></li>
       </ul>
     </td>
     <td>

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -127,6 +127,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <version>1.10</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-assets</artifactId>
             <exclusions>

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/GatewayCookieConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/GatewayCookieConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.config;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class GatewayCookieConfiguration
+{
+    private SecretKey cookieSigningKey;
+    private boolean enabled;
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
+    }
+
+    public SecretKey getCookieSigningKey()
+    {
+        return cookieSigningKey;
+    }
+
+    public void setCookieSigningSecret(String cookieSigningSecret)
+    {
+        cookieSigningKey = new SecretKeySpec(cookieSigningSecret.getBytes(UTF_8), "HmacSHA256");
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/GatewayCookieConfigurationPropertiesProvider.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/GatewayCookieConfigurationPropertiesProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.config;
+
+import javax.crypto.SecretKey;
+
+public class GatewayCookieConfigurationPropertiesProvider
+{
+    private static final GatewayCookieConfigurationPropertiesProvider instance = new GatewayCookieConfigurationPropertiesProvider();
+    private GatewayCookieConfiguration gatewayCookieConfiguration;
+
+    private GatewayCookieConfigurationPropertiesProvider()
+    {}
+
+    public void initialize(GatewayCookieConfiguration gatewayCookieConfiguration)
+    {
+        if (gatewayCookieConfiguration.isEnabled() && gatewayCookieConfiguration.getCookieSigningKey() == null) {
+            throw new IllegalArgumentException("gatewayCookieConfiguration.cookieSigningSecret must be provided when cookies are enabled");
+        }
+        this.gatewayCookieConfiguration = gatewayCookieConfiguration;
+    }
+
+    public static GatewayCookieConfigurationPropertiesProvider getInstance()
+    {
+        return instance;
+    }
+
+    public boolean isEnabled()
+    {
+        ensureInitialized();
+        return gatewayCookieConfiguration.isEnabled();
+    }
+
+    public SecretKey getCookieSigningKey()
+    {
+        ensureInitialized();
+        return gatewayCookieConfiguration.getCookieSigningKey();
+    }
+
+    private void ensureInitialized()
+    {
+        if (gatewayCookieConfiguration == null) {
+            throw new IllegalStateException("getInstance.initialize(GatewayCookieConfiguration) must be called before use");
+        }
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/HaGatewayConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/HaGatewayConfiguration.java
@@ -35,6 +35,8 @@ public class HaGatewayConfiguration
     private BackendStateConfiguration backendState;
     private ClusterStatsConfiguration clusterStatsConfiguration;
     private List<String> extraWhitelistPaths = new ArrayList<>();
+    private OAuth2GatewayCookieConfiguration oauth2GatewayCookieConfiguration = new OAuth2GatewayCookieConfiguration();
+    private GatewayCookieConfiguration gatewayCookieConfiguration = new GatewayCookieConfiguration();
 
     // List of Modules with FQCN (Fully Qualified Class Name)
     private List<String> modules;
@@ -162,6 +164,26 @@ public class HaGatewayConfiguration
     public void setExtraWhitelistPaths(List<String> extraWhitelistPaths)
     {
         this.extraWhitelistPaths = extraWhitelistPaths;
+    }
+
+    public OAuth2GatewayCookieConfiguration getOauth2GatewayCookieConfiguration()
+    {
+        return oauth2GatewayCookieConfiguration;
+    }
+
+    public void setOauth2GatewayCookieConfiguration(OAuth2GatewayCookieConfiguration oauth2GatewayCookieConfiguration)
+    {
+        this.oauth2GatewayCookieConfiguration = oauth2GatewayCookieConfiguration;
+    }
+
+    public GatewayCookieConfiguration getGatewayCookieConfiguration()
+    {
+        return gatewayCookieConfiguration;
+    }
+
+    public void setGatewayCookieConfiguration(GatewayCookieConfiguration gatewayCookieConfiguration)
+    {
+        this.gatewayCookieConfiguration = gatewayCookieConfiguration;
     }
 
     public List<String> getModules()

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/OAuth2GatewayCookieConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/OAuth2GatewayCookieConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.config;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.Duration;
+
+import java.util.List;
+
+public class OAuth2GatewayCookieConfiguration
+{
+    // Configuration initialization using dropwizard requires
+    // instance method setters. Values are global, and can be accessed using static getters
+    private List<String> routingPaths = ImmutableList.of("/oauth2");
+    private List<String> deletePaths = ImmutableList.of("/logout", "/oauth2/logout");
+    private Duration lifetime = Duration.valueOf("10m");
+
+    public List<String> getDeletePaths()
+    {
+        return deletePaths;
+    }
+
+    public void setDeletePaths(List<String> deletePaths)
+    {
+        this.deletePaths = deletePaths;
+    }
+
+    public List<String> getRoutingPaths()
+    {
+        return routingPaths;
+    }
+
+    public void setRoutingPaths(List<String> routingPaths)
+    {
+        this.routingPaths = routingPaths;
+    }
+
+    public Duration getLifetime()
+    {
+        return lifetime;
+    }
+
+    public void setLifetime(String lifetime)
+    {
+        this.lifetime = Duration.valueOf(lifetime);
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/OAuth2GatewayCookieConfigurationPropertiesProvider.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/OAuth2GatewayCookieConfigurationPropertiesProvider.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.config;
+
+import io.airlift.units.Duration;
+
+import java.util.List;
+
+public class OAuth2GatewayCookieConfigurationPropertiesProvider
+{
+    private static final OAuth2GatewayCookieConfigurationPropertiesProvider instance = new OAuth2GatewayCookieConfigurationPropertiesProvider();
+
+    private OAuth2GatewayCookieConfiguration oAuth2GatewayCookieConfiguration;
+
+    private OAuth2GatewayCookieConfigurationPropertiesProvider()
+    {}
+
+    public static OAuth2GatewayCookieConfigurationPropertiesProvider getInstance()
+    {
+        return instance;
+    }
+
+    public void initialize(OAuth2GatewayCookieConfiguration oAuth2GatewayCookieConfiguration)
+    {
+        this.oAuth2GatewayCookieConfiguration = oAuth2GatewayCookieConfiguration;
+    }
+
+    public List<String> getDeletePaths()
+    {
+        ensureInitialized();
+        return oAuth2GatewayCookieConfiguration.getDeletePaths();
+    }
+
+    public List<String> getRoutingPaths()
+    {
+        ensureInitialized();
+        return oAuth2GatewayCookieConfiguration.getRoutingPaths();
+    }
+
+    public Duration getLifetime()
+    {
+        ensureInitialized();
+        return oAuth2GatewayCookieConfiguration.getLifetime();
+    }
+
+    private void ensureInitialized()
+    {
+        if (oAuth2GatewayCookieConfiguration == null) {
+            throw new IllegalStateException("getInstance.initialize(OAuth2GatewayCookieConfiguration) must be called before use");
+        }
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
@@ -27,7 +27,9 @@ import io.dropwizard.jetty.ConnectorFactory;
 import io.dropwizard.jetty.HttpConnectorFactory;
 import io.trino.gateway.ha.config.AuthenticationConfiguration;
 import io.trino.gateway.ha.config.AuthorizationConfiguration;
+import io.trino.gateway.ha.config.GatewayCookieConfigurationPropertiesProvider;
 import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.config.OAuth2GatewayCookieConfigurationPropertiesProvider;
 import io.trino.gateway.ha.config.RequestRouterConfiguration;
 import io.trino.gateway.ha.config.RoutingRulesConfiguration;
 import io.trino.gateway.ha.config.UserConfiguration;
@@ -86,6 +88,12 @@ public class HaGatewayProviderModule
         authenticationFilter = getAuthFilter(configuration);
         backendStateConnectionManager = new BackendStateManager();
         extraWhitelistPaths = configuration.getExtraWhitelistPaths();
+
+        GatewayCookieConfigurationPropertiesProvider gatewayCookieConfigurationPropertiesProvider = GatewayCookieConfigurationPropertiesProvider.getInstance();
+        gatewayCookieConfigurationPropertiesProvider.initialize(configuration.getGatewayCookieConfiguration());
+
+        OAuth2GatewayCookieConfigurationPropertiesProvider oAuth2GatewayCookieConfigurationPropertiesProvider = OAuth2GatewayCookieConfigurationPropertiesProvider.getInstance();
+        oAuth2GatewayCookieConfigurationPropertiesProvider.initialize(configuration.getOauth2GatewayCookieConfiguration());
     }
 
     private LbOAuthManager getOAuthManager(HaGatewayConfiguration configuration)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/GatewayCookie.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/GatewayCookie.java
@@ -1,0 +1,289 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.google.common.hash.Hashing;
+import io.airlift.json.JsonCodec;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+import io.trino.gateway.ha.config.GatewayCookieConfigurationPropertiesProvider;
+import jakarta.servlet.http.Cookie;
+
+import java.util.Base64;
+import java.util.List;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+@JsonPropertyOrder(alphabetic = true)
+public class GatewayCookie
+        implements Comparable<GatewayCookie>
+{
+    private static final Logger log = Logger.get(GatewayCookie.class);
+    private String signature;
+    private final UnsignedGatewayCookie unsignedGatewayCookie;
+    private final GatewayCookieConfigurationPropertiesProvider gatewayCookieConfigurationPropertiesProvider = GatewayCookieConfigurationPropertiesProvider.getInstance();
+
+    public static final String PREFIX = "TG.";
+
+    public static final JsonCodec<GatewayCookie> CODEC = JsonCodec.jsonCodec(GatewayCookie.class);
+
+    @JsonCreator
+    public GatewayCookie(
+            @JsonProperty("ts") Long ts,
+            @JsonProperty("name") String name,
+            @JsonProperty("payload") String payload,
+            @JsonProperty("routingPaths") List<String> routingPaths,
+            @JsonProperty("deletePaths") List<String> deletePaths,
+            @JsonProperty("backend") String backend,
+            @JsonProperty("priority") Integer priority,
+            @JsonProperty("ttl") Duration ttl,
+            @JsonProperty("signature") String signature)
+    {
+        this.unsignedGatewayCookie = new UnsignedGatewayCookie(
+                requireNonNull(ts),
+                requireNonNull(name),
+                payload,
+                backend,
+                requireNonNull(routingPaths),
+                requireNonNull(deletePaths),
+                requireNonNull(ttl),
+                priority);
+        this.signature = signature;
+    }
+
+    public GatewayCookie(String name, String payload, String backend, List<String> routingPaths, List<String> deletePaths, Duration ttl, int priority)
+    {
+        this.unsignedGatewayCookie = new UnsignedGatewayCookie(
+                System.currentTimeMillis(),
+                requireNonNull(name.startsWith(PREFIX) ? name : PREFIX + name),
+                payload,
+                backend,
+                requireNonNull(routingPaths),
+                requireNonNull(deletePaths),
+                requireNonNull(ttl),
+                priority);
+        signature = computeSignature();
+    }
+
+    @JsonProperty
+    public Long getTs()
+    {
+        return unsignedGatewayCookie.getTs();
+    }
+
+    @JsonProperty
+    public String getName()
+    {
+        return unsignedGatewayCookie.getName();
+    }
+
+    @JsonProperty
+    public String getPayload()
+    {
+        return unsignedGatewayCookie.getPayload();
+    }
+
+    @JsonProperty
+    public String getBackend()
+    {
+        return unsignedGatewayCookie.getBackend();
+    }
+
+    @JsonProperty
+    public int getPriority()
+    {
+        return unsignedGatewayCookie.getPriority();
+    }
+
+    @JsonProperty
+    public List<String> getRoutingPaths()
+    {
+        return unsignedGatewayCookie.getRoutingPaths();
+    }
+
+    @JsonProperty
+    public List<String> getDeletePaths()
+    {
+        return unsignedGatewayCookie.getDeletePaths();
+    }
+
+    @JsonProperty
+    public Duration getTtl()
+    {
+        return unsignedGatewayCookie.getTtl();
+    }
+
+    @JsonProperty
+    public String getSignature()
+    {
+        return signature;
+    }
+
+    public void setTs(Long ts)
+    {
+        unsignedGatewayCookie.setTs(ts);
+    }
+
+    private String computeSignature()
+    {
+        return Hashing.hmacSha256(gatewayCookieConfigurationPropertiesProvider.getCookieSigningKey())
+                .hashString(UnsignedGatewayCookie.CODEC.toJson(unsignedGatewayCookie), UTF_8)
+                .toString();
+    }
+
+    @Override
+    public int compareTo(GatewayCookie o)
+    {
+        int priorityDelta = unsignedGatewayCookie.getPriority() - o.getPriority();
+        return priorityDelta != 0 ? priorityDelta : (int) (unsignedGatewayCookie.getTs() - o.getTs());
+    }
+
+    public Cookie toCookie()
+    {
+        Cookie cookie = new Cookie(unsignedGatewayCookie.getName(), Base64.getUrlEncoder().encodeToString(CODEC.toJson(this).getBytes(UTF_8)));
+        cookie.setMaxAge((int) unsignedGatewayCookie.getTtl().toMillis() / 1000);
+        return cookie;
+    }
+
+    public static GatewayCookie fromCookie(Cookie cookie)
+    {
+        return GatewayCookie.CODEC.fromJson(Base64.getUrlDecoder().decode(cookie.getValue()));
+    }
+
+    public boolean matchesRoutingPath(String path)
+    {
+        if (matchesDeletePath(path)) {
+            return false;
+        }
+
+        return unsignedGatewayCookie.getRoutingPaths().stream().anyMatch(path::startsWith);
+    }
+
+    public boolean matchesDeletePath(String path)
+    {
+        return unsignedGatewayCookie.getDeletePaths().contains(path);
+    }
+
+    public boolean isValid()
+    {
+        if (System.currentTimeMillis() > unsignedGatewayCookie.getTs() + unsignedGatewayCookie.getTtl().toMillis()) {
+            return false;
+        }
+
+        if (isNullOrEmpty(signature) || !signature.equals(computeSignature())) {
+            log.error("Invalid cookie: %s", CODEC.toJson(this));
+            throw new IllegalArgumentException("Invalid cookie signature");
+        }
+
+        return true;
+    }
+
+    @JsonPropertyOrder(alphabetic = true)
+    public static class UnsignedGatewayCookie
+    {
+        public static final JsonCodec<UnsignedGatewayCookie> CODEC = JsonCodec.jsonCodec(UnsignedGatewayCookie.class);
+        private Long ts; // timestamp. The shortened name saves 8 bytes of cookie size
+        private final String name;
+        private final String payload;
+        private final List<String> routingPaths;
+
+        private final List<String> deletePaths;
+
+        private final int priority;
+        private final Duration ttl;
+        private final String backend;
+
+        public UnsignedGatewayCookie(GatewayCookie gatewayCookie)
+        {
+            this.ts = gatewayCookie.getTs();
+            this.name = gatewayCookie.getName();
+            this.payload = gatewayCookie.getPayload();
+            this.routingPaths = gatewayCookie.getRoutingPaths();
+            this.deletePaths = gatewayCookie.getDeletePaths();
+            this.priority = gatewayCookie.getPriority();
+            this.ttl = gatewayCookie.getTtl();
+            this.backend = gatewayCookie.getBackend();
+        }
+
+        public UnsignedGatewayCookie(Long ts, String name, String payload, String backend, List<String> routingPaths, List<String> deletePaths, Duration ttl, int priority)
+        {
+            this.name = name.startsWith(PREFIX) ? name : PREFIX + name;
+            this.payload = payload;
+            this.backend = backend;
+            this.routingPaths = routingPaths;
+            this.deletePaths = deletePaths;
+            this.ttl = ttl;
+            this.ts = ts;
+            this.priority = priority;
+        }
+
+        @JsonProperty
+        public Long getTs()
+        {
+            return ts;
+        }
+
+        public void setTs(Long ts)
+        {
+            this.ts = ts;
+        }
+
+        @JsonProperty
+        public String getName()
+        {
+            return name;
+        }
+
+        @JsonProperty
+        public String getPayload()
+        {
+            return payload;
+        }
+
+        @JsonProperty
+        public String getBackend()
+        {
+            return backend;
+        }
+
+        @JsonProperty
+        public int getPriority()
+        {
+            return priority;
+        }
+
+        @JsonProperty
+        public List<String> getRoutingPaths()
+        {
+            return routingPaths;
+        }
+
+        @JsonProperty
+        public List<String> getDeletePaths()
+        {
+            return deletePaths;
+        }
+
+        @JsonProperty
+        public Duration getTtl()
+        {
+            return ttl;
+        }
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/OAuth2GatewayCookie.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/OAuth2GatewayCookie.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.gateway.ha.config.OAuth2GatewayCookieConfigurationPropertiesProvider;
+
+public class OAuth2GatewayCookie
+        extends GatewayCookie
+{
+    public static final String NAME = GatewayCookie.PREFIX + "OAUTH2";
+    public static final String OAUTH2_PATH = "/oauth2";
+
+    public OAuth2GatewayCookie(String backend)
+    {
+        super(
+                NAME,
+                null,
+                backend,
+                ImmutableList.of(OAUTH2_PATH),
+                OAuth2GatewayCookieConfigurationPropertiesProvider.getInstance().getDeletePaths(),
+                OAuth2GatewayCookieConfigurationPropertiesProvider.getInstance().getLifetime(),
+                0);
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyHandler.java
@@ -13,7 +13,9 @@
  */
 package io.trino.gateway.proxyserver;
 
+import com.google.common.collect.ImmutableList;
 import io.airlift.log.Logger;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.client.api.Request;
@@ -27,6 +29,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.zip.GZIPInputStream;
 
 /* Order of control => rewriteTarget, preConnectionHook, postConnectionHook. */
@@ -113,5 +116,10 @@ public class ProxyHandler
     {
         return (compressed[0] == (byte) GZIPInputStream.GZIP_MAGIC)
                 && (compressed[1] == (byte) (GZIPInputStream.GZIP_MAGIC >> 8));
+    }
+
+    public List<Cookie> generateDeleteCookieList(HttpServletRequest clientRequest)
+    {
+        return ImmutableList.of();
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyServletImpl.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyServletImpl.java
@@ -98,6 +98,16 @@ public class ProxyServletImpl
         return target;
     }
 
+    @Override
+    protected void onServerResponseHeaders(
+            HttpServletRequest clientRequest,
+            HttpServletResponse proxyResponse,
+            Response serverResponse)
+    {
+        this.proxyHandler.generateDeleteCookieList(clientRequest).forEach(proxyResponse::addCookie);
+        super.onServerResponseHeaders(clientRequest, proxyResponse, serverResponse);
+    }
+
     /**
      * Customize the response returned from remote server.
      */

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/HaGatewayTestUtils.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/HaGatewayTestUtils.java
@@ -19,8 +19,10 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 
@@ -28,6 +30,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
 import java.util.Random;
 import java.util.Scanner;
 
@@ -64,6 +67,23 @@ public class HaGatewayTestUtils
                 .setBody(expectedResonse)
                 .addHeader(CONTENT_ENCODING, PLAIN_TEXT_UTF_8)
                 .setResponseCode(200));
+    }
+
+    public static void setPathSpecificResponses(
+            MockWebServer backend, Map<String, String> pathResponseMap)
+    {
+        Dispatcher dispatcher = new Dispatcher()
+        {
+            @Override
+            public MockResponse dispatch(RecordedRequest request)
+            {
+                if (pathResponseMap.containsKey(request.getPath())) {
+                    return new MockResponse().setResponseCode(200).setBody(pathResponseMap.get(request.getPath()));
+                }
+                return new MockResponse().setResponseCode(404);
+            }
+        };
+        backend.setDispatcher(dispatcher);
     }
 
     public static TestConfig buildGatewayConfigAndSeedDb(int routerPort, String configFile)

--- a/gateway-ha/src/test/resources/test-config-template.yml
+++ b/gateway-ha/src/test/resources/test-config-template.yml
@@ -26,5 +26,13 @@ managedApps:
 extraWhitelistPaths:
   - "/v1/custom"
 
+gatewayCookieConfiguration:
+  enabled: true
+  cookieSigningSecret: "kjlhbfrewbyuo452cds3dc1234ancdsjh"
+
+oauth2GatewayCookieConfiguration:
+  deletePaths:
+    - "/custom/logout"
+
 logging:
   type: external


### PR DESCRIPTION
This adds an additional routing strategy for the Gateway. Currently the Gateway checks all incoming requests for a query ID. If one is found, the cluster running that query is looked up and the query is routed to that cluster. All other requests are sent to a semi random backend cluster in the routing group chosen by the `RoutingGroupSelector` based on the information present in the request. These routing strategies are not sufficient to solve issues such as https://github.com/trinodb/trino-gateway/issues/165. For https://github.com/trinodb/trino-gateway/issues/165, the Gateway needs the capability to route a request to the same backend that a previous request was sent to.

This adds the ability to add a session cookie, and to map that session cookie to a specific backend. This is lower precedence than the queryID based routing. Cookie based routing is performed only for paths in a configurable list. OAuth with multiple backends in a routing group (#165) can be solved by configuring `cookiePaths: ['/oauth2/callback']`. Finally, a cookie will be deleted if a request is made to a patch in the `logOutCookiePaths` list.