### PR TITLE
Set the defaults to forward the headers

### DIFF
--- a/docs/quickstart-config.yaml
+++ b/docs/quickstart-config.yaml
@@ -8,9 +8,11 @@ server:
   applicationConnectors:
     - type: http
       port: 9081
+      useForwardedHeaders: true
   adminConnectors:
     - type: http
       port: 9082
+      useForwardedHeaders: true
 
 dataStore:
   #This stores the URLs of backend Trino servers and query history

--- a/gateway-ha/gateway-ha-config-docker.yml
+++ b/gateway-ha/gateway-ha-config-docker.yml
@@ -26,9 +26,11 @@ server:
   applicationConnectors:
     - type: http
       port: 8090
+      useForwardedHeaders: true
   adminConnectors:
     - type: http
       port: 8091
+      useForwardedHeaders: true
 
 # This can be adjusted based on the coordinator state
 monitor:

--- a/gateway-ha/gateway-ha-config.yml
+++ b/gateway-ha/gateway-ha-config.yml
@@ -26,9 +26,11 @@ server:
   applicationConnectors:
     - type: http
       port: 8090
+      useForwardedHeaders: true
   adminConnectors:
     - type: http
       port: 8091
+      useForwardedHeaders: true
 
 # This can be adjusted based on the coordinator state
 monitor:


### PR DESCRIPTION
This is should be default value, dropwizard changed the defaults from 1.0 to some higher version. It takes care of the issues like https://github.com/trinodb/trino-gateway/issues/114