### PR TITLE
Add release notes for Trino Gateway 6

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,6 +18,15 @@
 
 # Release notes
 
+## Trino Gateway 6 (16 Feb 2024)
+
+[gateway-ha-6-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/6/gateway-ha-6-jar-with-dependencies.jar)
+
+* Add Docker container build, publishing, and usage setup and instructions. ([#86](https://github.com/trinodb/trino-gateway/issues/86))
+
+[Details about all pull requests and issues](https://github.com/trinodb/trino-gateway/issues?q=milestone%3A6+is%3Aclosed)
+
+
 ## Trino Gateway 5 (24 Jan 2024)
 
 [gateway-ha-5-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/5/gateway-ha-5-jar-with-dependencies.jar)


### PR DESCRIPTION
## Description

Assemble the release notes for Trino Gateway 6 release.

## Additional context and related issues
 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Verification for each pull request

Format: PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

## 25 Jan 2024

- #181 ✅ rn ✅ docs
- #182 ✅ rn ✅ docs
- #180 ✅ rn ✅ docs
- #185 ✅ rn ✅ docs
- #189 ✅ rn ✅ docs
- #193 ✅ rn ✅ docs
- #183 ✅ rn ✅ docs
- #190 ✅ rn ✅ docs
- #191 ✅ rn ✅ docs
- #192 ✅ rn ✅ docs

## 26 Jan 2024

- #113 ✅ rn ✅ docs
- #198 ✅ rn ✅ docs
- #178 ✅ rn ✅ docs

## 28 Jan 2024

- #199 ✅ rn ✅ docs
- #201 ✅ rn ✅ docs
- #200 ✅ rn ✅ docs

## 29 Jan 2024

- #203 ✅ rn ✅ docs
- #204 ✅ rn ✅ docs
- #205 ✅ rn ✅ docs
- #206 ✅ rn ✅ docs
- #207 ✅ rn ✅ docs
- #208 ✅ rn ✅ docs 
- #212 ✅ rn ✅ docs 
- #211 ✅ rn ✅ docs
- #215 ✅ rn ✅ docs

## 30 Jan 2024

- #218 ✅ rn ✅ docs
- #214 ✅ rn ✅ docs
- #221 ✅ rn ✅ docs
- #220 ✅ rn ✅ docs

## 31 Jan 2024

- #224 ✅ rn ✅ docs
- #194 ✅ rn ✅ docs
- #228 ✅ rn ✅ docs

## 1 Feb 2024

- #226 ✅ rn ✅ docs
- #219 ✅ rn ✅ docs
- #145 ✅ rn ✅ docs

## 5 Feb 2024

- #236 ✅ rn ✅ docs
- #234 ✅ rn ✅ docs
- #237 ✅ rn ✅ docs
- #235 ✅ rn ✅ docs

## 7 Feb 2024

- #227 ✅ rn ✅ docs
- #232 ✅ rn ✅ docs

## 9 Feb 2024

- #240 ✅ rn ✅ docs

## 10 Feb 2024

- #243 ✅ rn ✅ docs

## 14 Feb 2024

- #252 ✅ rn ✅ docs
- #250 ✅ rn ✅ docs

## 15 Feb 2024

- #251 ✅ rn ✅ docs
- #230 ✅ rn ✅ docs
- #231 ✅ rn ✅ docs
- #209 ✅ rn ✅ docs
