### PR TITLE
Upgrade and fix wiremock dependency

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -304,13 +304,6 @@
 
         <!-- Test deps -->
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
-            <version>${dep.wiremock.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>${dep.h2.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dep.postgresql.version>42.6.0</dep.postgresql.version>
         <dep.reflections.version>0.9.10</dep.reflections.version>
         <dep.trino.version>433</dep.trino.version>
-        <dep.wiremock.version>3.0.1</dep.wiremock.version>
+        <dep.wiremock.version>3.3.1</dep.wiremock.version>
 
     </properties>
 


### PR DESCRIPTION
The dependency moved in terms of groupid to `org.wiremock` and we have a duplicate declaration for that already.

Weirdly the package of the java classes did NOT move so there is no code to update.