### PR TITLE
Suggest changing health check conf in docker compose

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -6,6 +6,11 @@ The Docker image of Trino Gateway is designed for the following use cases:
 * Automated usage with an orchestration system like Kubernetes to simplify
   deployment
 
+## Production setup
+
+The healthcheck configurations in the `docker-compose` file is for suitable for development and testing purposes only.
+Change the configuration for your production deployment based on the workload and your specific requirements.
+
 ## Build requirements
 
 This docker build process requires the following software:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
+      test: ["CMD-SHELL", "/usr/lib/trino/bin/health-check || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 60


### PR DESCRIPTION
~It seems unncessary as of now to have healthcheck confs in both minimal compose and each extended compose files.~
~IDE shows `Missing required key(s): 'test'` error too so unless a different health check is needed for running minimal compose, it seems better to get rid of one conf (makes it more confusing)~
- ~[gateway-compose yaml](https://github.com/trinodb/trino-gateway/blob/main/docker/gateway-compose.yml) and [postgres compose yaml](https://github.com/trinodb/trino-gateway/blob/main/docker/postgres-backend-compose.yml)~

Since docker compose files is merged into one + docker compose conf is updated,
This PR 
- adds a test as IDE shows `Missing required key(s): 'test' warning
- suggests users to change in health check depending on the workload in production usage