### PR TITLE
Remove restart policy from docker compose file

### DIFF
--- a/docker/gateway-compose.yml
+++ b/docker/gateway-compose.yml
@@ -2,7 +2,6 @@ version: "3.4"
 services:
   gateway:
     image: ${TRINO_GATEWAY_IMAGE:-trinodb/trino-gateway:latest}
-    restart: always
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/postgres-backend-compose.yml
+++ b/docker/postgres-backend-compose.yml
@@ -2,7 +2,6 @@ version: "3.4"
 services:
   postgres:
     image: ${TRINO_GATEWAY_POSTGRES_IMAGE:-postgres}
-    restart: always
     environment:
       - PGPORT=5432
       - POSTGRES_PASSWORD=P0stG&es


### PR DESCRIPTION
The expected restart policy should be decided by users, not us. 
Restarting these containers automatically looks annoying for me. 