### PR TITLE
Specify platform when running docker compose files

### DIFF
--- a/docker/gateway-compose.yml
+++ b/docker/gateway-compose.yml
@@ -5,6 +5,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    platform: linux
     healthcheck:
       interval: 10s
       timeout: 5s

--- a/docker/postgres-backend-compose.yml
+++ b/docker/postgres-backend-compose.yml
@@ -7,6 +7,7 @@ services:
       - POSTGRES_PASSWORD=P0stG&es
       - POSTGRES_DB=trino_gateway_db
       - POSTGRES_USER=trino_gateway_db_admin
+    platform: linux
     ports:
       - "5432:5432"
     healthcheck:


### PR DESCRIPTION
When running docker compose after using [build.sh](https://github.com/trinodb/trino-gateway/blob/main/docker/build.sh#L129), it failes to run in darwin os (Mac M1).
Error like below happens, and to bypass this I had to specify platform as linux in docker compose file.

## error

```bash
TRINO_GATEWAY_IMAGE=${TEST_GATEWAY_IMAGE} DOCKER_DEFAULT_PLATFORM=${TEST_PLATFORM} \
    docker compose -f minimal-compose.yml \
    up --wait
[+] Running 1/2
 ✔ Network docker_default       Created                                                                                                                                                          0.0s 
 ⠋ Container docker-postgres-1  Creating                                                                                                                                                         0.1s 
Error response from daemon: image with reference postgres was found but does not match the specified platform: wanted darwin/arm64, actual: linux/arm64
