### PR TITLE
Avoid test run in release build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <air.java.version>17</air.java.version>
         <air.check.skip-spotbugs>true</air.check.skip-spotbugs>
         <air.check.skip-pmd>true</air.check.skip-pmd>
+        <air.release.preparation-goals>clean verify -DskipTests</air.release.preparation-goals>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
This is fine since we rely on CI runs before release build as evidence.

As requested by @martint 

Can you maybe confirm @wendigo - the idea is that the mvn release prepare run should not run tests again so its faster. I just lifted this approach from the trino root pom