### PR TITLE
Get cluster health from v1/info

### DIFF
--- a/docs/quickstart-config.yaml
+++ b/docs/quickstart-config.yaml
@@ -22,11 +22,7 @@ dataStore:
   driver: org.postgresql.Driver
 
 clusterStatsConfiguration:
-  useApi: true
-
-backendState:
-  username: gateway
-  ssl: false
+  monitorType: INFO_API
 
 modules:
   - io.trino.gateway.ha.module.HaGatewayProviderModule

--- a/gateway-ha/gateway-ha-config-docker.yml
+++ b/gateway-ha/gateway-ha-config-docker.yml
@@ -15,12 +15,8 @@ dataStore:
   driver: org.postgresql.Driver
   queryHistoryHoursRetention: 24
 
-backendState:
-  username: lb_query
-  ssl: false
-
 clusterStatsConfiguration:
-  useApi: true
+  monitorType: INFO_API
 
 server:
   applicationConnectors:

--- a/gateway-ha/gateway-ha-config.yml
+++ b/gateway-ha/gateway-ha-config.yml
@@ -15,12 +15,8 @@ dataStore:
   driver: org.postgresql.Driver
   queryHistoryHoursRetention: 24
 
-backendState:
-  username: lb_query
-  ssl: false
-
 clusterStatsConfiguration:
-  useApi: true
+  monitorType: INFO_API
 
 server:
   applicationConnectors:

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -98,6 +98,16 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>http-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-assets</artifactId>
             <exclusions>
@@ -237,6 +247,13 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+
+        <!-- Prevent a ClassNotFoundException caused by io.dropwizard.jackson.Jackson:newObjectMapper
+             calling findModules() indiscriminately-->
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
         </dependency>
 
         <dependency>
@@ -506,9 +523,22 @@
                 </executions>
             </plugin>
 
-            <!-- maven shade plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <configuration>
+                            <ignoredDependencies>
+                                <ignoredDependency>joda-time:joda-time</ignoredDependency>
+                            </ignoredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- maven shade plugin -->
+            <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterStatsInfoApiMonitor.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterStatsInfoApiMonitor.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.clustermonitor;
+
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.HttpClientConfig;
+import io.airlift.http.client.JsonResponseHandler;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.jetty.JettyHttpClient;
+import io.trino.gateway.ha.config.ProxyBackendConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+
+import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.json.JsonCodec.jsonCodec;
+
+public class ClusterStatsInfoApiMonitor
+        implements ClusterStatsMonitor
+{
+    //TODO: make client options configurable
+    private static final HttpClient client = new JettyHttpClient(new HttpClientConfig());
+    private static final Logger log = LoggerFactory.getLogger(ClusterStatsInfoApiMonitor.class);
+    private static final JsonResponseHandler<ServerInfo> SERVER_INFO_JSON_RESPONSE_HANDLER = createJsonResponseHandler(jsonCodec(ServerInfo.class));
+
+    @Override
+    public ClusterStats monitor(ProxyBackendConfiguration backend)
+    {
+        return ClusterStats.builder(backend.getName()).healthy(isReadyStatus(backend.getProxyTo()))
+                .proxyTo(backend.getProxyTo())
+                .externalUrl(backend.getExternalUrl())
+                .routingGroup(backend.getRoutingGroup()).build();
+    }
+
+    private boolean isReadyStatus(String baseUrl)
+    {
+        Request request = prepareGet()
+                .setUri(uriBuilderFrom(URI.create(baseUrl)).appendPath("/v1/info").build())
+                .build();
+
+        try {
+            ServerInfo serverInfo = client.execute(request, SERVER_INFO_JSON_RESPONSE_HANDLER);
+            return !serverInfo.isStarting();
+        }
+        catch (Exception e) {
+            log.error("Exception checking {} for health: {} ", request.getUri(), e.getMessage());
+        }
+        return false;
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ServerInfo.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ServerInfo.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.clustermonitor;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Objects.requireNonNull;
+
+// based on https://github.com/trinodb/trino/blob/439/client/trino-client/src/main/java/io/trino/client/ServerInfo.java
+// without unused fields
+public class ServerInfo
+{
+    private final Boolean starting;
+
+    @JsonCreator
+    public ServerInfo(
+            @JsonProperty("starting") Boolean starting)
+    {
+        this.starting = requireNonNull(starting, "starting is null");
+    }
+
+    public boolean isStarting()
+    {
+        return starting;
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/ClusterStatsMonitorType.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/ClusterStatsMonitorType.java
@@ -13,19 +13,10 @@
  */
 package io.trino.gateway.ha.config;
 
-public class ClusterStatsConfiguration
+public enum ClusterStatsMonitorType
 {
-    private ClusterStatsMonitorType monitorType;
-
-    public ClusterStatsConfiguration() {}
-
-    public ClusterStatsMonitorType getMonitorType()
-    {
-        return monitorType;
-    }
-
-    public void setMonitorType(ClusterStatsMonitorType monitorType)
-    {
-        this.monitorType = monitorType;
-    }
+    NOOP,
+    INFO_API,
+    UI_API,
+    JDBC
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/clustermonitor/TestClusterStatsMonitor.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/clustermonitor/TestClusterStatsMonitor.java
@@ -56,6 +56,12 @@ public class TestClusterStatsMonitor
         testClusterStatsMonitor(ClusterStatsJdbcMonitor::new);
     }
 
+    @Test
+    public void testInfoApiMonitor()
+    {
+        testClusterStatsMonitor(ignored -> new ClusterStatsInfoApiMonitor());
+    }
+
     private void testClusterStatsMonitor(Function<BackendStateConfiguration, ClusterStatsMonitor> monitorFactory)
     {
         BackendStateConfiguration backendStateConfiguration = new BackendStateConfiguration();


### PR DESCRIPTION
This adds a lightweight health check against the coordinator's `v1/info`. A cluster is set to healthy as long as the coordinator returns a 200 response and is not in the process of starting. `v1/info` does not require authentication, which  addresses the concerns raised in
* https://github.com/trinodb/trino-gateway/issues/233
* https://github.com/trinodb/trino-gateway/issues/166
* https://github.com/trinodb/trino-gateway/issues/66
