### PR TITLE
allow customization of test containers image name

### DIFF
--- a/gateway-ha/src/test/java/io/trino/gateway/CustomTrinoImageNameSubstitutor.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/CustomTrinoImageNameSubstitutor.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway;
+
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.ImageNameSubstitutor;
+
+/**
+ * We can use this class to override the images used by test containers, if the image has
+ * a different name from dockerhub. This class is used in testcontainers.properties file.
+ * TESTCONTAINERS_TRINO_IMAGE_SUBSTITUTE can be set as an environment variable.
+ */
+public class CustomTrinoImageNameSubstitutor
+        extends ImageNameSubstitutor
+{
+    private static final String TESTCONTAINERS_TRINO_IMAGE_SUBSTITUTE = "TESTCONTAINERS_TRINO_IMAGE_SUBSTITUTE";
+    private static final String TRINO_IMAGE = "trinodb/trino";
+
+    @Override
+    public DockerImageName apply(DockerImageName dockerImageName)
+    {
+        String trinoImageSubstitute = System.getenv(TESTCONTAINERS_TRINO_IMAGE_SUBSTITUTE);
+        if (dockerImageName.getUnversionedPart().equals(TRINO_IMAGE) && trinoImageSubstitute != null) {
+            return DockerImageName.parse(trinoImageSubstitute).asCompatibleSubstituteFor(TRINO_IMAGE);
+        }
+        return dockerImageName;
+    }
+
+    @Override
+    protected String getDescription()
+    {
+        return "custom Trino image name substitutor";
+    }
+}

--- a/gateway-ha/src/test/resources/testcontainers.properties
+++ b/gateway-ha/src/test/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+image.substitutor=io.trino.gateway.CustomTrinoImageNameSubstitutor


### PR DESCRIPTION
Problem: Some tests download trino docker images from public dockerhub. For example: https://github.com/trinodb/trino-gateway/blob/e2aaa0e9c71ae69767f842a3f4834f9d531d6620/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaMultipleBackend.java#L55
However, this will fail when running behind a proxy. Our in-house images have different names from the names on dockerhub.  Therefore, we need a way to override `trinodb/trino` to a completely different name when necessary. This will eventually expand to other public images as they are added to the codebase. 