### PR TITLE
Update logging in quickstart-config.yaml

### DIFF
--- a/docs/quickstart-config.yaml
+++ b/docs/quickstart-config.yaml
@@ -32,3 +32,6 @@ modules:
 managedApps:
   - io.trino.gateway.ha.GatewayManagedApp
   - io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor
+
+logging:
+    type: external


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Update logging in quickstart-config.yaml.

`logging: type: external` is required after #260. Otherwise the following error will occur.


```
$ java -Xmx1g --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED \
    -Dlog.levels-file=gateway-ha/etc/log.properties \
    -jar gateway-ha/target/gateway-ha-7-SNAPSHOT-jar-with-dependencies.jar \
    server docs/quickstart-config.yaml

2024-03-21T17:50:24.270+0900    INFO    main    io.airlift.log.Logging  Logging to stderr
2024-03-21T17:50:24.306+0900    INFO    main    stderr  SLF4J(W): Class path contains multiple SLF4J providers.
2024-03-21T17:50:24.306+0900    INFO    main    stderr  SLF4J(W): Found provider [org.slf4j.jul.JULServiceProvider@4de5031f]
2024-03-21T17:50:24.307+0900    INFO    main    stderr  SLF4J(W): Found provider [ch.qos.logback.classic.spi.LogbackServiceProvider@67e2d983]
2024-03-21T17:50:24.307+0900    INFO    main    stderr  SLF4J(W): See https://www.slf4j.org/codes.html#multiple_bindings for an explanation.
2024-03-21T17:50:24.307+0900    INFO    main    stderr  SLF4J(I): Actual provider is of type [org.slf4j.jul.JULServiceProvider@4de5031f]
2024-03-21T17:50:24.310+0900    INFO    main    org.hibernate.validator.internal.util.Version   HV000001: Hibernate Validator 6-26-g739ec5e-dirty
2024-03-21T17:50:24.413+0900    INFO    main    io.trino.gateway.baseapp.BaseApp        op=create auto_scan_packages=io.trino
2024-03-21T17:50:45.169+0900    INFO    main    stderr  java.lang.IllegalStateException: Unable to acquire the logger context
2024-03-21T17:50:45.170+0900    INFO    main    stderr          at io.dropwizard.logging.common.LoggingUtil.getLoggerContext(LoggingUtil.java:46)
2024-03-21T17:50:45.171+0900    INFO    main    stderr          at io.dropwizard.logging.common.DefaultLoggingFactory.<init>(DefaultLoggingFactory.java:66)
2024-03-21T17:50:45.171+0900    INFO    main    stderr          at io.dropwizard.core.Configuration.getLoggingFactory(Configuration.java:113)
2024-03-21T17:50:45.171+0900    INFO    main    stderr          at io.dropwizard.core.cli.ConfiguredCommand.cleanup(ConfiguredCommand.java:114)
2024-03-21T17:50:45.171+0900    INFO    main    stderr          at io.dropwizard.core.cli.ConfiguredCommand.run(ConfiguredCommand.java:101)
2024-03-21T17:50:45.172+0900    INFO    main    stderr          at io.dropwizard.core.cli.Cli.run(Cli.java:78)
2024-03-21T17:50:45.172+0900    INFO    main    stderr          at io.dropwizard.core.Application.run(Application.java:94)
2024-03-21T17:50:45.172+0900    INFO    main    stderr          at io.trino.gateway.ha.HaGatewayLauncher.main(HaGatewayLauncher.java:56)
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
