### PR TITLE
Remove io.dropwizard.metrics and dropwizard-servlets

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -211,24 +211,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-servlets</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.servlet</groupId>
-                    <artifactId>jakarta.servlet-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-healthchecks</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Related to #41.
Remove `io.dropwizard.metrics` and `io.dropwizard:dropwizard-servlets`.

Subclass of `HealthCheck` or `Task` in classpath with `io.trino.*` prefix were injected automatically.
This PR remove this auto injection function.
**Please let me know if anyone is using this feature.**



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Verified there are no subclass of `HealthCheck` nor `Task` in the current code base.
`http://localhost:9082/healthcheck` and `http://localhost:9082/tasks` work as before.

`op=register type=healthcheck` and `op=register type=task` are not being called when using quickstart-config.yaml.
```
2024-03-25T23:03:56.201+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=create auto_scan_packages=io.trino
2024-03-25T23:03:57.258+0900	INFO	main	io.dropwizard.core.server.DefaultServerFactory	Registering jersey handler with root path prefix: /
2024-03-25T23:03:57.259+0900	INFO	main	io.dropwizard.core.server.DefaultServerFactory	Registering admin handler with root path prefix: /
2024-03-25T23:03:57.260+0900	INFO	main	io.dropwizard.assets.AssetsBundle	Registering AssetBundle with name: assets for path /assets/*
2024-03-25T23:03:57.260+0900	INFO	main	io.dropwizard.assets.AssetsBundle	Registering AssetBundle with name: logo.svg for path /logo.svg/*
2024-03-25T23:03:57.261+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	Trying to load module [io.trino.gateway.ha.module.HaGatewayProviderModule]
2024-03-25T23:03:57.328+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	Trying to load module [io.trino.gateway.ha.module.ClusterStateListenerModule]
2024-03-25T23:03:57.329+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	Trying to load module [io.trino.gateway.ha.module.ClusterStatsMonitorModule]
2024-03-25T23:03:57.406+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register_start configuration=Configuration{server=DefaultServerFactory{applicationConnectors=[io.dropwizard.jetty.HttpConnectorFactory@25765a49], adminConnectors=[io.dropwizard.jetty.HttpConnectorFactory@1a88d194], adminMaxThreads=64, adminMinThreads=1, applicationContextPath='/', adminContextPath='/'}, logging=io.dropwizard.logging.common.ExternalLoggingFactory@771afdd5, metrics=MetricsFactory{frequency=1 minute, reporters=[], reportOnStop=false}, admin=AdminFactory[healthChecks=HealthCheckConfiguration[servletEnabled= true, minThreads=1, maxThreads=4, workQueueSize=1], tasks=TaskConfiguration[printStackTraceOnError=false]], health=null}
2024-03-25T23:03:57.406+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=auth filter item=class io.dropwizard.auth.AuthFilter
2024-03-25T23:03:57.412+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=provider item=class io.trino.gateway.ha.security.AuthorizedExceptionMapper
2024-03-25T23:03:57.437+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=managed item=class io.trino.gateway.ha.GatewayManagedApp
2024-03-25T23:03:57.474+0900	INFO	main	stdout	# WARNING: Unable to get Instrumentation. Dynamic Attach failed. You may add this JAR as -javaagent manually, or supply -Djdk.attach.allowAttachSelf
2024-03-25T23:03:57.854+0900	INFO	main	stdout	# WARNING: Unable to attach Serviceability Agent. You can try again with escalated privileges. Two options: a) use -Djol.tryWithSudo=true to try with sudo; b) echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
2024-03-25T23:03:58.008+0900	INFO	main	io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor	Running cluster monitor with task delay of 1
2024-03-25T23:03:58.008+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=managed item=class io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor
2024-03-25T23:03:58.032+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.EntityEditorResource
2024-03-25T23:03:58.034+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.GatewayViewResource
2024-03-25T23:03:58.035+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.TrinoResource
2024-03-25T23:03:58.037+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.LoginResource
2024-03-25T23:03:58.038+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.PublicResource
2024-03-25T23:03:58.041+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.GatewayWebAppResource
2024-03-25T23:03:58.042+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.GatewayResource
2024-03-25T23:03:58.043+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.HaGatewayResource
2024-03-25T23:03:58.043+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register_end 
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.