### PR TITLE
Replace WireMock with okhttp3:mockwebserver

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -24,6 +24,7 @@
         <dep.jdbi.version>3.44.0</dep.jdbi.version>
         <dep.jeasy.version>4.1.0</dep.jeasy.version>
         <dep.mockito.version>5.8.0</dep.mockito.version>
+        <dep.okhttp3.version>3.14.9</dep.okhttp3.version>
         <dep.mysqlconnector.version>8.0.33</dep.mysqlconnector.version>
     </properties>
 
@@ -70,7 +71,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.14.9</version>
+            <version>${dep.okhttp3.version}</version>
         </dependency>
 
         <dependency>
@@ -418,6 +419,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>${dep.okhttp3.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.24.2</version>
@@ -477,13 +485,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>trino</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.wiremock</groupId>
-            <artifactId>wiremock</artifactId>
-            <version>3.3.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Part of #41 

Replace WireMock with okhttp3:mockwebserver.
Trino is also using `okhttp3:mockwebserver` for testing.
WireMock depends on jetty 11 which is incompatible with Airlift (jetty 12 & EE 10).


## TODO
Update okhttp3 to the latest version (`3.14.9` -> `4.12.0`).

Side effect:
New version of okhttp3 won't send Authorization header after a redirect. (See: https://github.com/trinodb/trino/issues/21026)
This will break credentials-based authentication if anyone is using:
`Trino-gateway -> (some proxy with redirect mode) -> Trino`.
Needs to override this behavior and always send Authorization header.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
