### PR TITLE
Update OkHttp to 4.12.0

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -24,7 +24,7 @@
         <dep.jdbi.version>3.44.0</dep.jdbi.version>
         <dep.jeasy.version>4.1.0</dep.jeasy.version>
         <dep.mockito.version>5.8.0</dep.mockito.version>
-        <dep.okhttp3.version>3.14.9</dep.okhttp3.version>
+        <dep.okhttp3.version>4.12.0</dep.okhttp3.version>
         <dep.mysqlconnector.version>8.0.33</dep.mysqlconnector.version>
     </properties>
 

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaMultipleBackend.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaMultipleBackend.java
@@ -94,7 +94,7 @@ public class TestGatewayHaMultipleBackend
         Response response1 = httpClient.newCall(request1).execute();
         assertThat(response1.body().string()).isEqualTo(CUSTOM_RESPONSE);
         RecordedRequest recordedRequest = customBackend.takeRequest();
-        assertThat(recordedRequest.getRequestLine()).contains("POST");
+        assertThat(recordedRequest.getMethod()).isEqualTo("POST");
         assertThat(recordedRequest.getPath()).isEqualTo(CUSTOM_PATH);
 
         Request request2 =


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Part of #41. Follow up of #291.

We are using okhttp for form authentication and some tests only.
The issue of new version okhttp3 won't send Authorization header after a redirect doesn't matter.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.