### PR TITLE
Fix the error caused by the missing 'audiences' configuration

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbOAuthManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbOAuthManager.java
@@ -139,7 +139,7 @@ public class LbOAuthManager
             Jwk jwk = provider.get(jwt.getKeyId());
             RSAPublicKey publicKey = (RSAPublicKey) jwk.getPublicKey();
 
-            if (LbTokenUtil.validateToken(idToken, publicKey, jwt.getIssuer(), Optional.of(oauthConfig.getAudiences()))) {
+            if (LbTokenUtil.validateToken(idToken, publicKey, jwt.getIssuer(), Optional.ofNullable(oauthConfig.getAudiences()))) {
                 return Optional.of(jwt.getClaims());
             }
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fix the error caused by the missing 'audiences' configuration


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

```
ERROR	pool-6-thread-8 - POST /webapp/getDistribution	io.trino.gateway.ha.security.LbOAuthManager	Could not validate token or get claims from it.
```

See details at: https://trinodb.slack.com/archives/CG9K9MX1V/p1711980180964969