### PR TITLE
Add release notes for Trino Gateway 8

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -34,7 +34,21 @@
 
 # Release notes
 
-## Trino Gateway 7 (21  Mar 2024)
+## Trino Gateway 8 (6 May 2024)
+
+[JAR file gateway-ha-8-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/8/gateway-ha-8-jar-with-dependencies.jar),
+Docker container `trinodb/trino-gateway:8`
+
+* Add support for configurable router policies. ([#98](https://github.com/trinodb/trino-gateway/pull/98))
+* Add a router policy based on query count per cluster. ([#98](https://github.com/trinodb/trino-gateway/pull/98))
+* Add a router policy for select paths based on cookie content. ([#188](https://github.com/trinodb/trino-gateway/pull/188))
+* Support configuring access permissions for UI pages. ([#296](https://github.com/trinodb/trino-gateway/pull/296))
+* Add Helm chart for Kubernetes deployments.  ([#296](https://github.com/trinodb/trino-gateway/pull/296))
+* Require Java 21 for build and runtime. ([#225](https://github.com/trinodb/trino-gateway/pull/225))
+* Fix the `userInfo` resource to pass role information used by the API, so that
+  the webapp authentication matches the API authentication. ([#310](https://github.com/trinodb/trino-gateway/pull/310))
+
+## Trino Gateway 7 (21 Mar 2024)
 
 [JAR file gateway-ha-7-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/7/gateway-ha-7-jar-with-dependencies.jar),
 Docker container `trinodb/trino-gateway:7`


### PR DESCRIPTION
## Description

Assemble the release notes for Trino Gateway 8 release.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Verification for each pull request

Format: PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

## 22 Mar 2024

- #225 ✅ rn ✅ docs

## 25 Mar 2024

- #290 ✅ rn ✅ docs

## 27 Mar 2024

- #291 ✅ rn ✅ docs

## 30 Mar 2024

- #293 ✅ rn ✅ docs

## 2 Apr 2024

- #295 ✅ rn ✅ docs

## 3 Apr 2024

- #98 ✅ rn ✅ docs
- #247 ✅ rn ✅ docs
- #238 ✅ rn ✅ docs

## 4 Apr 2024

- #284 ✅ rn ✅ docs
- #287 ✅ rn ✅ docs

## 5 Apr 2024

- #299 ✅ rn ✅ docs
- #301 ✅ rn ✅ docs
- #296 ✅ rn ✅ docs

## 6 Apr 2024

- #303 ✅ rn ✅ docs

## 7 Apr 2024

- #306 ✅ rn ✅ docs
- #304 ✅ rn ✅ docs
- #307 ✅ rn ✅ docs

## 8 Apr 2024

- #305 ✅ rn ✅ docs
- #302 ✅ rn ✅ docs

## 9 Apr 2024

- #313 ✅ rn ✅ docs
- #311 ✅ rn ✅ docs
- #310 ✅ rn ✅ docs

## 10 Apr 2024

- #300 ✅ rn ✅ docs
- #315 ✅ rn ✅ docs

## 11 Apr 2024

- #316 ✅ rn ✅ docs
- #312 ✅ rn ✅ docs

## 12 Apr 2024

- #318 ✅ rn ✅ docs
- #297 ✅ rn ✅ docs

## 13 Apr 2024

- #314 ✅ rn ✅ docs

## 15 Apr 2024

- #320 ✅ rn ✅ docs

## 16 Apr 2024

- #321 ✅ rn ✅ docs

## 25 Apr 2024

- #188 ✅ rn ✅ docs

## 2 May 2024

- #328 ✅ rn ✅ docs

## 6 May 2024

- #332 ✅ rn ✅ docs
- #323 ✅ rn ✅ docs