### PR TITLE
Update Jdbi to 3.45.1

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -20,7 +20,6 @@
         <frontend.project.name>webapp</frontend.project.name>
 
         <!-- dependency versions -->
-        <dep.jdbi.version>3.44.0</dep.jdbi.version>
         <dep.jeasy.version>4.1.0</dep.jeasy.version>
         <dep.mockito.version>5.8.0</dep.mockito.version>
         <dep.okhttp3.version>4.12.0</dep.okhttp3.version>
@@ -313,17 +312,14 @@
             <artifactId>jersey-server</artifactId>
         </dependency>
 
-        <!--db -->
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
-            <version>${dep.jdbi.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-sqlobject</artifactId>
-            <version>${dep.jdbi.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,14 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jdbi</groupId>
+                <artifactId>jdbi3-bom</artifactId>
+                <version>3.45.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
                 <version>1.19.6</version>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Update Jdbi to 3.45.1 to sync with Trino.

https://github.com/trinodb/trino/blob/5f5210f039bb4c8055a6267805b11063dbb2c6d3/pom.xml#L279-L285

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

