### PR TITLE
Remove dropwizard configuration and jackson

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -55,6 +55,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
             <optional>true</optional>
@@ -144,11 +149,6 @@
 
         <dependency>
             <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-configuration</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
             <exclusions>
                 <exclusion>
@@ -161,11 +161,6 @@
                     <artifactId>jakarta.servlet-api</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-jackson</artifactId>
         </dependency>
 
         <dependency>
@@ -232,17 +227,13 @@
         </dependency>
 
         <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <!-- Prevent a ClassNotFoundException caused by io.dropwizard.jackson.Jackson:newObjectMapper
              calling findModules() indiscriminately-->
+        <!-- io.dropwizard.core.setup.Bootstrap also uses io.dropwizard.jackson.Jackson -->
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/LdapConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/LdapConfiguration.java
@@ -13,14 +13,17 @@
  */
 package io.trino.gateway.ha.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.airlift.log.Logger;
-import io.dropwizard.configuration.ConfigurationException;
-import io.dropwizard.configuration.YamlConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
+
+import java.io.File;
+import java.io.IOException;
 
 public class LdapConfiguration
 {
     private static final Logger log = Logger.get(LdapConfiguration.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
     private String ldapHost;
     private Integer ldapPort;
     private boolean useTls;
@@ -77,17 +80,9 @@ public class LdapConfiguration
     {
         LdapConfiguration configuration = null;
         try {
-            configuration =
-                    new YamlConfigurationFactory<LdapConfiguration>(LdapConfiguration.class,
-                            null,
-                            Jackson.newObjectMapper(), "lb")
-                            .build(new java.io.File(path));
+            configuration = OBJECT_MAPPER.readValue(new File(path), LdapConfiguration.class);
         }
-        catch (java.io.IOException e) {
-            log.error(e, "Error loading configuration file");
-            throw new RuntimeException(e);
-        }
-        catch (ConfigurationException e) {
+        catch (IOException e) {
             log.error(e, "Error loading configuration file");
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Part of #41.
Remove dropwizard configuration and jackson.

Dropwizard configuration support override values using system properties.
For example, `-Dlb.ldapHost=test.com` can override the ldapHost value in `SomeLdapConfig.yml`.
Not sure is anyone relying on this feature.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
