### PR TITLE
Allow pnpmRegistryURL to be configurable

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -18,6 +18,7 @@
         <environments>development</environments>
         <app.main.class>io.trino.gateway.ha.HaGatewayLauncher</app.main.class>
         <frontend.project.name>webapp</frontend.project.name>
+        <frontend.pnpmRegistryURL>https://registry.npmmirror.com</frontend.pnpmRegistryURL>
 
         <!-- dependency versions -->
         <dep.jeasy.version>4.1.0</dep.jeasy.version>
@@ -601,6 +602,7 @@
                         <phase>generate-resources</phase>
                         <configuration>
                             <arguments>install --ignore-scripts</arguments>
+                            <pnpmRegistryURL>${frontend.pnpmRegistryURL}</pnpmRegistryURL>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Currently the `pnpm-lock.yaml` has the version locked in at `registry.npmmirror.com`. Building it behind a company proxy will likely fail if your company doesn't allow to download from external sources. Therefore, we can specify the `pnpmRegistryURL` for it.  Specifying this parameter will get rid of the hard-coded path and only use the version part of the dependency.

This can help align the versions but use different download URLs simultaneously

For example: 

Was:
```
  '@douyinfe/semi-icons':
    specifier: ^2.47.1
    version: registry.npmmirror.com/@douyinfe/semi-icons@2.47.1(react@18.2.0)
```

Now:
```
  '@douyinfe/semi-icons':
    specifier: ^2.47.1
    version: 2.47.1(react@18.2.0)
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Allow pnpmRegistryURL to be configurable
```
