### PR TITLE
Use static resource binding instead of runtime reflection based binding

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -348,18 +348,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <version>0.9.10</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.code.findbugs</groupId>
-                    <artifactId>annotations</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/HaGatewayLauncher.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/HaGatewayLauncher.java
@@ -28,11 +28,6 @@ import static io.airlift.configuration.ConfigurationLoader.getSystemProperties;
 public class HaGatewayLauncher
         extends BaseApp<HaGatewayConfiguration>
 {
-    public HaGatewayLauncher(String... basePackages)
-    {
-        super(basePackages);
-    }
-
     @Override
     public void initialize(Bootstrap<HaGatewayConfiguration> bootstrap)
     {
@@ -51,8 +46,6 @@ public class HaGatewayLauncher
         Logging logging = Logging.initialize();
         logging.configure(configuration);
 
-        /* base package is scanned for any Resource class to be loaded by default. */
-        String basePackage = "io.trino";
-        new HaGatewayLauncher(basePackage).run(args);
+        new HaGatewayLauncher().run(args);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->

## Description
Part of #41.

Remove org.reflections.
Use static resource binding instead of runtime reflection based binding.
This is a common practice in Trino (eg. [CoordinatorModule.java](https://github.com/trinodb/trino/blob/fbaff0224df8b1448ba095e9da9139761b2c0f0a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java#L194))
Also makes [conditioinal binding based on a config using Airlift](https://github.com/airlift/airlift/blob/master/docs/recipes.md#how-do-i-do-conditional-binding-based-on-a-config-value) easier in the future.

Before PR:
```
2024-04-08T13:40:40.043+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register_start configuration=Configuration{server=DefaultServerFactory{applicationConnectors=[io.dropwizard.jetty.HttpConnectorFactory@37a1beb3], adminConnectors=[io.dropwizard.jetty.HttpConnectorFactory@7adbec34], adminMaxThreads=64, adminMinThreads=1, applicationContextPath='/', adminContextPath='/'}, logging=io.dropwizard.logging.common.ExternalLoggingFactory@1f3aa970, metrics=MetricsFactory{frequency=1 minute, reporters=[], reportOnStop=false}, admin=AdminFactory[healthChecks=HealthCheckConfiguration[servletEnabled= true, minThreads=1, maxThreads=4, workQueueSize=1], tasks=TaskConfiguration[printStackTraceOnError=false]], health=null}
2024-04-08T13:40:40.044+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=auth filter item=class io.dropwizard.auth.AuthFilter
2024-04-08T13:40:40.049+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=provider item=class io.trino.gateway.ha.security.AuthorizedExceptionMapper
2024-04-08T13:40:40.068+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=managed item=class io.trino.gateway.ha.GatewayManagedApp
2024-04-08T13:40:40.113+0900	INFO	main	stdout	# WARNING: Unable to get Instrumentation. Dynamic Attach failed. You may add this JAR as -javaagent manually, or supply -Djdk.attach.allowAttachSelf
2024-04-08T13:40:40.618+0900	INFO	main	stdout	# WARNING: Unable to attach Serviceability Agent. You can try again with escalated privileges. Two options: a) use -Djol.tryWithSudo=true to try with sudo; b) echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
2024-04-08T13:40:40.720+0900	INFO	main	io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor	Running cluster monitor with connection task delay of 60 seconds
2024-04-08T13:40:40.721+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=managed item=class io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor
2024-04-08T13:40:40.735+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.GatewayWebAppResource
2024-04-08T13:40:40.736+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.PublicResource
2024-04-08T13:40:40.737+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.GatewayResource
2024-04-08T13:40:40.738+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.LoginResource
2024-04-08T13:40:40.739+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.HaGatewayResource
2024-04-08T13:40:40.740+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.TrinoResource
2024-04-08T13:40:40.741+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.GatewayViewResource
2024-04-08T13:40:40.742+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.EntityEditorResource
2024-04-08T13:40:40.742+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register_end configuration=Configuration{server=DefaultServerFactory{applicationConnectors=[io.dropwizard.jetty
```
After PR (same):
```
2024-04-08T13:44:28.657+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register_start configuration=Configuration{server=DefaultServerFactory{applicationConnectors=[io.dropwizard.jetty.HttpConnectorFactory@1000d54d], adminConnectors=[io.dropwizard.jetty.HttpConnectorFactory@5c448433], adminMaxThreads=64, adminMinThreads=1, applicationContextPath='/', adminContextPath='/'}, logging=io.dropwizard.logging.common.ExternalLoggingFactory@3f4f5330, metrics=MetricsFactory{frequency=1 minute, reporters=[], reportOnStop=false}, admin=AdminFactory[healthChecks=HealthCheckConfiguration[servletEnabled= true, minThreads=1, maxThreads=4, workQueueSize=1], tasks=TaskConfiguration[printStackTraceOnError=false]], health=null}
2024-04-08T13:44:28.658+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=auth filter item=class io.dropwizard.auth.AuthFilter
2024-04-08T13:44:28.660+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=provider item=class io.trino.gateway.ha.security.AuthorizedExceptionMapper
2024-04-08T13:44:28.682+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=managed item=class io.trino.gateway.ha.GatewayManagedApp
2024-04-08T13:44:28.741+0900	INFO	main	stdout	# WARNING: Unable to get Instrumentation. Dynamic Attach failed. You may add this JAR as -javaagent manually, or supply -Djdk.attach.allowAttachSelf
2024-04-08T13:44:29.296+0900	INFO	main	stdout	# WARNING: Unable to attach Serviceability Agent. You can try again with escalated privileges. Two options: a) use -Djol.tryWithSudo=true to try with sudo; b) echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
2024-04-08T13:44:29.418+0900	INFO	main	io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor	Running cluster monitor with connection task delay of 60 seconds
2024-04-08T13:44:29.418+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=managed item=class io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor
2024-04-08T13:44:29.439+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.EntityEditorResource
2024-04-08T13:44:29.440+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.GatewayResource
2024-04-08T13:44:29.441+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.GatewayViewResource
2024-04-08T13:44:29.444+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.GatewayWebAppResource
2024-04-08T13:44:29.445+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.HaGatewayResource
2024-04-08T13:44:29.446+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.LoginResource
2024-04-08T13:44:29.447+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.PublicResource
2024-04-08T13:44:29.449+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register type=resource item=class io.trino.gateway.ha.resource.TrinoResource
2024-04-08T13:44:29.449+0900	INFO	main	io.trino.gateway.baseapp.BaseApp	op=register_end configuration=Configuration{server=DefaultServerFactory{applicationConnectors=[io.dropwizard.jetty
```
<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

