### PR TITLE
Fix rest user info to match API auth with Webapp Auth

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
@@ -33,7 +33,6 @@ import io.trino.gateway.ha.router.GatewayBackendManager;
 import io.trino.gateway.ha.router.HaGatewayManager;
 import io.trino.gateway.ha.router.QueryHistoryManager;
 import io.trino.gateway.ha.router.ResourceGroupsManager;
-import io.trino.gateway.ha.security.LbPrincipal;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
@@ -46,7 +45,6 @@ import jakarta.ws.rs.core.SecurityContext;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -110,10 +108,8 @@ public class GatewayWebAppResource
     @Path("/findQueryHistory")
     public Response findQueryHistory(QueryHistoryRequest query, @Context SecurityContext securityContext)
     {
-        LbPrincipal principal = (LbPrincipal) securityContext.getUserPrincipal();
-        String[] roles = principal.getMemberOf().orElse("").split("_");
-        if (!Arrays.asList(roles).contains("ADMIN")) {
-            query.setUser(principal.getName());
+        if (!securityContext.isUserInRole("ADMIN")) {
+            query.setUser(securityContext.getUserPrincipal().getName());
         }
         TableData<?> queryHistory = queryHistoryManager.findQueryHistory(query);
         return Response.ok(Result.ok(queryHistory)).build();

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/LoginResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/LoginResource.java
@@ -13,6 +13,7 @@
  */
 package io.trino.gateway.ha.resource;
 
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.trino.gateway.ha.domain.Result;
 import io.trino.gateway.ha.domain.request.RestLoginRequest;
@@ -107,7 +108,17 @@ public class LoginResource
     public Response restUserinfo(@Context SecurityContext securityContext)
     {
         LbPrincipal principal = (LbPrincipal) securityContext.getUserPrincipal();
-        List<String> roles = List.of(principal.getMemberOf().map(String::toLowerCase).orElse("").split("_"));
+        ImmutableList.Builder<String> rolesBuilder = ImmutableList.builder();
+        if (securityContext.isUserInRole("ADMIN")) {
+            rolesBuilder.add("ADMIN");
+        }
+        if (securityContext.isUserInRole("USER")) {
+            rolesBuilder.add("USER");
+        }
+        if (securityContext.isUserInRole("API")) {
+            rolesBuilder.add("API");
+        }
+        List<String> roles = rolesBuilder.build();
         List<String> pagePermissions;
         if (formAuthManager != null) {
             pagePermissions = formAuthManager.processPagePermissions(roles);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
Fixes the restUserInfo function to return Trino Gateway Roles (ADMIN, USER, API) to the Webapp, which is what the webapp expects.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
I opened [this PR to map LDAP groups to Trino gateway roles](https://github.com/trinodb/trino-gateway/pull/292) and then came up with this simpler solution.

The following configs will break in the current (prior to this commit) version of Trino gateway because the admin user will not have admin privileges within the webapp like it should. This is because the webapp checks role membership by comparing the roles passed to those in an enum.

breaking auth example:
```
authorization:
    admin: .*FOO.*
    user: .*BAR.*
    api: .*BAZ.*

presetUsers:
    admin1:
        password: password
        privileges: FOO_BAR
    user1:
        password: password
        privileges: BAR_BAZ
```

This broken example works as expected after this fix.

This is how the webapp checks role membership:
https://github.com/trinodb/trino-gateway/blob/739ec5e67799dd5df0ab8aaec7934e21a63507fa/webapp/src/store/access.ts#L73C9-L76C9

And where those role membership checks are made:

https://github.com/trinodb/trino-gateway/blob/ac407dcbd02c3e00655a2ce0a63dd21be429585b/webapp/src/components/selector.tsx#L80
https://github.com/trinodb/trino-gateway/blob/ac407dcbd02c3e00655a2ce0a63dd21be429585b/webapp/src/components/cluster.tsx#L89
https://github.com/trinodb/trino-gateway/blob/ac407dcbd02c3e00655a2ce0a63dd21be429585b/webapp/src/components/history.tsx#L93
https://github.com/trinodb/trino-gateway/blob/ac407dcbd02c3e00655a2ce0a63dd21be429585b/webapp/src/components/resource-group.tsx#L88

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
* fixed userInfo resource to pass role information used by the api, so that webapp auth matches api auth
```
