### PR TITLE
Add airlift stats

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -122,6 +122,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>stats</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-assets</artifactId>
             <exclusions>
@@ -344,6 +349,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-views-freemarker</artifactId>
             <scope>runtime</scope>
@@ -529,6 +539,8 @@
                 <configuration>
                     <!-- necessary for integration tests, also see /.mvn/jvm.config -->
                     <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED</argLine>
+                    <!-- This is needed because we call main() in test setups. Otherwise Guice singleton won't work. -->
+                    <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/ProxyHandlerStats.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/ProxyHandlerStats.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.handler;
+
+import com.codahale.metrics.Meter;
+import io.airlift.stats.CounterStat;
+import io.dropwizard.core.setup.Environment;
+import org.weakref.jmx.MBeanExporter;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import java.lang.management.ManagementFactory;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ProxyHandlerStats
+{
+    // Airlift
+    private final CounterStat requestCount = new CounterStat();
+
+    // Dropwizard
+    private final Meter requestMeter;
+
+    private ProxyHandlerStats(Environment environment, String metricsName)
+    {
+        this.requestMeter = requireNonNull(environment, "environment is null")
+                .metrics()
+                .meter(requireNonNull(metricsName, "metricsName is null"));
+    }
+
+    public void recordRequest()
+    {
+        requestCount.update(1);
+        requestMeter.mark();
+    }
+
+    // Replace this with Guice bind after migrated to Airlift
+    public static ProxyHandlerStats create(Environment environment, String metricsName)
+    {
+        ProxyHandlerStats proxyHandlerStats = new ProxyHandlerStats(environment, metricsName);
+        MBeanExporter exporter = new MBeanExporter(ManagementFactory.getPlatformMBeanServer());
+        exporter.exportWithGeneratedName(proxyHandlerStats);
+        return proxyHandlerStats;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getRequestCount()
+    {
+        return requestCount;
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -13,7 +13,6 @@
  */
 package io.trino.gateway.ha.handler;
 
-import com.codahale.metrics.Meter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Splitter;
 import com.google.common.io.CharStreams;
@@ -82,7 +81,7 @@ public class QueryIdCachingProxyHandler
     private final RoutingGroupSelector routingGroupSelector;
     private final QueryHistoryManager queryHistoryManager;
 
-    private final Meter requestMeter;
+    private final ProxyHandlerStats proxyHandlerStats;
     private final List<String> extraWhitelistPaths;
     private final String applicationEndpoint;
 
@@ -91,9 +90,10 @@ public class QueryIdCachingProxyHandler
             RoutingManager routingManager,
             RoutingGroupSelector routingGroupSelector,
             int serverApplicationPort,
-            Meter requestMeter, List<String> extraWhitelistPaths)
+            ProxyHandlerStats proxyHandlerStats,
+            List<String> extraWhitelistPaths)
     {
-        this.requestMeter = requestMeter;
+        this.proxyHandlerStats = proxyHandlerStats;
         this.routingManager = routingManager;
         this.routingGroupSelector = routingGroupSelector;
         this.queryHistoryManager = queryHistoryManager;
@@ -238,7 +238,7 @@ public class QueryIdCachingProxyHandler
     {
         if (request.getMethod().equals(HttpMethod.POST)
                 && request.getRequestURI().startsWith(V1_STATEMENT_PATH)) {
-            requestMeter.mark();
+            proxyHandlerStats.recordRequest();
             try {
                 String requestBody = CharStreams.toString(request.getReader());
                 log.info(

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
@@ -13,7 +13,6 @@
  */
 package io.trino.gateway.ha.module;
 
-import com.codahale.metrics.Meter;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import io.dropwizard.auth.AuthFilter;
@@ -28,6 +27,7 @@ import io.trino.gateway.ha.config.HaGatewayConfiguration;
 import io.trino.gateway.ha.config.RequestRouterConfiguration;
 import io.trino.gateway.ha.config.RoutingRulesConfiguration;
 import io.trino.gateway.ha.config.UserConfiguration;
+import io.trino.gateway.ha.handler.ProxyHandlerStats;
 import io.trino.gateway.ha.handler.QueryIdCachingProxyHandler;
 import io.trino.gateway.ha.router.BackendStateManager;
 import io.trino.gateway.ha.router.QueryHistoryManager;
@@ -133,10 +133,9 @@ public class HaGatewayProviderModule
     protected ProxyHandler getProxyHandler(QueryHistoryManager queryHistoryManager,
                                          RoutingManager routingManager)
     {
-        Meter requestMeter =
-                getEnvironment()
-                        .metrics()
-                        .meter(getConfiguration().getRequestRouter().getName() + ".requests");
+        ProxyHandlerStats proxyHandlerStats = ProxyHandlerStats.create(
+                getEnvironment(),
+                getConfiguration().getRequestRouter().getName() + ".requests");
 
         // By default, use routing group header to route
         RoutingGroupSelector routingGroupSelector = RoutingGroupSelector.byRoutingGroupHeader();
@@ -152,7 +151,7 @@ public class HaGatewayProviderModule
                 routingManager,
                 routingGroupSelector,
                 getApplicationPort(),
-                requestMeter,
+                proxyHandlerStats,
                 extraWhitelistPaths);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Part of #41.

Abstract the stats counting using ProxyHandlerStats.
This is similar to the implementation inTrino, see: [CallStats.java](https://github.com/trinodb/trino/blob/master/lib/trino-hdfs/src/main/java/io/trino/hdfs/CallStats.java)

Add airlift stats in parallel with io.dropwizard.metrics.
Can't remove io.dropwizard.metrics right now because we can't export airlift stats in REST API under Dropwizard.

After switch to Airlift, `ProxyHandlerStats` and `CounterStat` will stay.
`com.codahale.metrics.Meter` and `Environment` will be gone.

|                            | JMX                               | JMX using RESTful API                      | JMX Provider                     |
|----------------------------|-----------------------------------|--------------------------------------------|----------------------------------|
| Before this PR             | Dropwizard metric                 | Dropwizard metric (localhost:9082/metrics) | Dropwizard and MetricRegistry    |
| After this PR              | Dropwizard metric + Airlift stats | Dropwizard metric (localhost:9082/metrics) | Dropwizard and MetricRegistry    |
| After migration to Airlift | Airlift stats                     | Airlift stats (/v1/jmx)                    | Airlift:jmx and Airlift:jmx-http |

JMX can be accessed using RMI (by jconsole or jvisualvm).
Airlift stats (new):
![image](https://github.com/trinodb/trino-gateway/assets/2330687/dafb0222-69a6-43e5-a336-aebc48820064)

Dropwizard metrics (existing):
![image](https://github.com/trinodb/trino-gateway/assets/2330687/0f0448a2-548a-46ee-b4e1-b1df34490ced)


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

