### PR TITLE
Annotate JsonProperty on getter

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ServerInfo.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ServerInfo.java
@@ -31,6 +31,7 @@ public class ServerInfo
         this.starting = requireNonNull(starting, "starting is null");
     }
 
+    @JsonProperty
     public boolean isStarting()
     {
         return starting;

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/ProxyBackendConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/ProxyBackendConfiguration.java
@@ -13,6 +13,7 @@
  */
 package io.trino.gateway.ha.config;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.gateway.proxyserver.ProxyServerConfiguration;
 
 public class ProxyBackendConfiguration
@@ -24,6 +25,7 @@ public class ProxyBackendConfiguration
 
     public ProxyBackendConfiguration() {}
 
+    @JsonProperty
     public String getExternalUrl()
     {
         if (externalUrl == null) {
@@ -37,6 +39,7 @@ public class ProxyBackendConfiguration
         this.externalUrl = externalUrl;
     }
 
+    @JsonProperty
     public boolean isActive()
     {
         return this.active;
@@ -47,6 +50,7 @@ public class ProxyBackendConfiguration
         this.active = active;
     }
 
+    @JsonProperty
     public String getRoutingGroup()
     {
         return this.routingGroup;

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/Result.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/Result.java
@@ -29,13 +29,10 @@ public class Result<T>
 
     public static final int FAIL = 500;
 
-    @JsonProperty
     private int code;
 
-    @JsonProperty
     private String msg;
 
-    @JsonProperty
     private T data;
 
     public static <T> Result<T> ok()
@@ -84,6 +81,7 @@ public class Result<T>
 
     public Result() {}
 
+    @JsonProperty
     public int getCode()
     {
         return code;
@@ -94,6 +92,7 @@ public class Result<T>
         this.code = code;
     }
 
+    @JsonProperty
     public String getMsg()
     {
         return msg;
@@ -104,6 +103,7 @@ public class Result<T>
         this.msg = msg;
     }
 
+    @JsonProperty
     public T getData()
     {
         return data;

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/TableData.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/TableData.java
@@ -28,13 +28,11 @@ public class TableData<T>
     /**
      * Total number of table data
      */
-    @JsonProperty
     private long total;
 
     /**
      * page data
      */
-    @JsonProperty
     private List<T> rows;
 
     public TableData(List<T> list, long total)
@@ -50,6 +48,7 @@ public class TableData<T>
 
     public TableData() {}
 
+    @JsonProperty
     public long getTotal()
     {
         return total;
@@ -60,6 +59,7 @@ public class TableData<T>
         this.total = total;
     }
 
+    @JsonProperty
     public List<T> getRows()
     {
         return rows;

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/GlobalPropertyRequest.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/GlobalPropertyRequest.java
@@ -14,40 +14,16 @@
 package io.trino.gateway.ha.domain.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.gateway.ha.router.ResourceGroupsManager;
 
 /**
  * Parameters for adding, modifying, and deleting GlobalProperty.
+ *
+ * @param useSchema Optional, defaults to the Schema of the configuration file.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class GlobalPropertyRequest
+public record GlobalPropertyRequest(
+        String useSchema,
+        ResourceGroupsManager.GlobalPropertiesDetail data)
 {
-    /**
-     * Optional, defaults to the Schema of the configuration file.
-     */
-    @JsonProperty
-    private String useSchema;
-    @JsonProperty
-    private ResourceGroupsManager.GlobalPropertiesDetail data;
-
-    public String getUseSchema()
-    {
-        return useSchema;
-    }
-
-    public void setUseSchema(String useSchema)
-    {
-        this.useSchema = useSchema;
-    }
-
-    public ResourceGroupsManager.GlobalPropertiesDetail getData()
-    {
-        return data;
-    }
-
-    public void setData(ResourceGroupsManager.GlobalPropertiesDetail data)
-    {
-        this.data = data;
-    }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/QueryDistributionRequest.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/QueryDistributionRequest.java
@@ -14,27 +14,18 @@
 package io.trino.gateway.ha.domain.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Query parameters for Distribution
+ *
+ * @param latestHour Latest statistics for multiple hours.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class QueryDistributionRequest
+public record QueryDistributionRequest(
+        Integer latestHour)
 {
-    /**
-     * Latest statistics for multiple hours.
-     */
-    @JsonProperty
-    private Integer latestHour = 1;
-
-    public Integer getLatestHour()
+    public QueryDistributionRequest
     {
-        return latestHour;
-    }
-
-    public void setLatestHour(Integer latestHour)
-    {
-        this.latestHour = latestHour;
+        latestHour = latestHour == null ? 1 : latestHour;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/QueryGlobalPropertyRequest.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/QueryGlobalPropertyRequest.java
@@ -14,43 +14,16 @@
 package io.trino.gateway.ha.domain.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Query parameters for GlobalProperty
+ *
+ * @param useSchema Optional, defaults to the Schema of the configuration file.
+ * @param name Optional, you can query the configuration for a specific name.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class QueryGlobalPropertyRequest
+public record QueryGlobalPropertyRequest(
+        String useSchema,
+        String name)
 {
-    /**
-     * Optional, defaults to the Schema of the configuration file.
-     */
-    @JsonProperty
-    private String useSchema;
-
-    /**
-     * Optional, you can query the configuration for a specific name.
-     */
-    @JsonProperty
-    private String name;
-
-    public String getUseSchema()
-    {
-        return useSchema;
-    }
-
-    public void setUseSchema(String useSchema)
-    {
-        this.useSchema = useSchema;
-    }
-
-    public String getName()
-    {
-        return name;
-    }
-
-    public void setName(String name)
-    {
-        this.name = name;
-    }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/QueryHistoryRequest.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/QueryHistoryRequest.java
@@ -14,92 +14,27 @@
 package io.trino.gateway.ha.domain.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Query parameters for History
+ *
+ * @param page page index
+ * @param size page size
+ * @param user Query histories of specified user. ADMIN role is optional, other roles are mandatory.
+ * @param backendUrl Optional, you can query the history based on the backendUrl.
+ * @param queryId Optional, you can query the query history based on the queryId of Trino.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class QueryHistoryRequest
+public record QueryHistoryRequest(
+        Integer page,
+        Integer size,
+        String user,
+        String backendUrl,
+        String queryId)
 {
-    /**
-     * page index
-     */
-    @JsonProperty
-    private Integer page = 1;
-
-    /**
-     * page size
-     */
-    @JsonProperty
-    private Integer size = 10;
-
-    /**
-     * Query histories of specified user.
-     * ADMIN role is optional, other roles are mandatory.
-     */
-    @JsonProperty
-    private String user;
-
-    /**
-     * Optional, you can query the history based on the backendUrl.
-     */
-    @JsonProperty
-    private String backendUrl;
-
-    /**
-     * Optional, you can query the query history based on the queryId of Trino.
-     */
-    @JsonProperty
-    private String queryId;
-
-    public Integer getPage()
+    public QueryHistoryRequest
     {
-        return page;
-    }
-
-    public void setPage(Integer page)
-    {
-        this.page = page;
-    }
-
-    public Integer getSize()
-    {
-        return size;
-    }
-
-    public void setSize(Integer size)
-    {
-        this.size = size;
-    }
-
-    public String getUser()
-    {
-        return user;
-    }
-
-    public void setUser(String user)
-    {
-        this.user = user;
-    }
-
-    public String getBackendUrl()
-    {
-        return backendUrl;
-    }
-
-    public void setBackendUrl(String backendUrl)
-    {
-        this.backendUrl = backendUrl;
-    }
-
-    public String getQueryId()
-    {
-        return queryId;
-    }
-
-    public void setQueryId(String queryId)
-    {
-        this.queryId = queryId;
+        page = page == null ? 1 : page;
+        size = size == null ? 10 : size;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/QueryResourceGroupsRequest.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/QueryResourceGroupsRequest.java
@@ -14,43 +14,16 @@
 package io.trino.gateway.ha.domain.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Query parameters for ResourceGroups
+ *
+ * @param useSchema Optional, defaults to the Schema of the configuration file.
+ * @param resourceGroupId Query a single item by id.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class QueryResourceGroupsRequest
+public record QueryResourceGroupsRequest(
+        String useSchema,
+        Long resourceGroupId)
 {
-    /**
-     * Optional, defaults to the Schema of the configuration file.
-     */
-    @JsonProperty
-    private String useSchema;
-
-    /**
-     * Query a single item by id.
-     */
-    @JsonProperty
-    private Long resourceGroupId;
-
-    public String getUseSchema()
-    {
-        return useSchema;
-    }
-
-    public void setUseSchema(String useSchema)
-    {
-        this.useSchema = useSchema;
-    }
-
-    public Long getResourceGroupId()
-    {
-        return resourceGroupId;
-    }
-
-    public void setResourceGroupId(Long resourceGroupId)
-    {
-        this.resourceGroupId = resourceGroupId;
-    }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/QuerySelectorsRequest.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/QuerySelectorsRequest.java
@@ -14,43 +14,16 @@
 package io.trino.gateway.ha.domain.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Query parameters for Selectors
+ *
+ * @param useSchema Optional, defaults to the Schema of the configuration file.
+ * @param resourceGroupId Query the selectors under the resource Group.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class QuerySelectorsRequest
+public record QuerySelectorsRequest(
+        String useSchema,
+        Long resourceGroupId)
 {
-    /**
-     * Optional, defaults to the Schema of the configuration file.
-     */
-    @JsonProperty
-    private String useSchema;
-
-    /**
-     * Query the selectors under the resource Group.
-     */
-    @JsonProperty
-    private Long resourceGroupId;
-
-    public String getUseSchema()
-    {
-        return useSchema;
-    }
-
-    public void setUseSchema(String useSchema)
-    {
-        this.useSchema = useSchema;
-    }
-
-    public Long getResourceGroupId()
-    {
-        return resourceGroupId;
-    }
-
-    public void setResourceGroupId(Long resourceGroupId)
-    {
-        this.resourceGroupId = resourceGroupId;
-    }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/ResourceGroupsRequest.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/ResourceGroupsRequest.java
@@ -14,40 +14,16 @@
 package io.trino.gateway.ha.domain.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.gateway.ha.router.ResourceGroupsManager;
 
 /**
  * Parameters for adding, modifying, and deleting ResourceGroups.
+ *
+ * @param useSchema Optional, defaults to the Schema of the configuration file.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ResourceGroupsRequest
+public record ResourceGroupsRequest(
+        String useSchema,
+        ResourceGroupsManager.ResourceGroupsDetail data)
 {
-    /**
-     * Optional, defaults to the Schema of the configuration file.
-     */
-    @JsonProperty
-    private String useSchema;
-    @JsonProperty
-    private ResourceGroupsManager.ResourceGroupsDetail data;
-
-    public String getUseSchema()
-    {
-        return useSchema;
-    }
-
-    public void setUseSchema(String useSchema)
-    {
-        this.useSchema = useSchema;
-    }
-
-    public ResourceGroupsManager.ResourceGroupsDetail getData()
-    {
-        return data;
-    }
-
-    public void setData(ResourceGroupsManager.ResourceGroupsDetail data)
-    {
-        this.data = data;
-    }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/RestLoginRequest.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/RestLoginRequest.java
@@ -14,36 +14,13 @@
 package io.trino.gateway.ha.domain.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Receiving form login parameters.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class RestLoginRequest
+public record RestLoginRequest(
+        String username,
+        String password)
 {
-    @JsonProperty
-    private String username;
-    @JsonProperty
-    private String password;
-
-    public String getUsername()
-    {
-        return username;
-    }
-
-    public void setUsername(String username)
-    {
-        this.username = username;
-    }
-
-    public String getPassword()
-    {
-        return password;
-    }
-
-    public void setPassword(String password)
-    {
-        this.password = password;
-    }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/SelectorsRequest.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/SelectorsRequest.java
@@ -14,60 +14,19 @@
 package io.trino.gateway.ha.domain.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.gateway.ha.router.ResourceGroupsManager;
 
 /**
  * Parameters for adding, modifying, and deleting Selectors.
+ *
+ * @param useSchema Optional, defaults to the Schema of the configuration file.
+ * @param data This field is used for adding, modifying, and deleting.
+ * @param oldData This field is only used for modification.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SelectorsRequest
+public record SelectorsRequest(
+        String useSchema,
+        ResourceGroupsManager.SelectorsDetail data,
+        ResourceGroupsManager.SelectorsDetail oldData)
 {
-    /**
-     * Optional, defaults to the Schema of the configuration file.
-     */
-    @JsonProperty
-    private String useSchema;
-
-    /**
-     * This field is used for adding, modifying, and deleting.
-     */
-    @JsonProperty
-    private ResourceGroupsManager.SelectorsDetail data;
-
-    /**
-     * This field is only used for modification
-     */
-    @JsonProperty
-    private ResourceGroupsManager.SelectorsDetail oldData;
-
-    public String getUseSchema()
-    {
-        return useSchema;
-    }
-
-    public void setUseSchema(String useSchema)
-    {
-        this.useSchema = useSchema;
-    }
-
-    public ResourceGroupsManager.SelectorsDetail getData()
-    {
-        return data;
-    }
-
-    public void setData(ResourceGroupsManager.SelectorsDetail data)
-    {
-        this.data = data;
-    }
-
-    public ResourceGroupsManager.SelectorsDetail getOldData()
-    {
-        return oldData;
-    }
-
-    public void setOldData(ResourceGroupsManager.SelectorsDetail oldData)
-    {
-        this.oldData = oldData;
-    }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/response/BackendResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/response/BackendResponse.java
@@ -19,11 +19,10 @@ import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 public class BackendResponse
         extends ProxyBackendConfiguration
 {
-    @JsonProperty
     private Integer queued;
-    @JsonProperty
     private Integer running;
 
+    @JsonProperty
     public Integer getQueued()
     {
         return queued;
@@ -34,6 +33,7 @@ public class BackendResponse
         this.queued = queued;
     }
 
+    @JsonProperty
     public Integer getRunning()
     {
         return running;

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/response/DistributionResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/response/DistributionResponse.java
@@ -20,50 +20,42 @@ import java.util.Map;
 
 public class DistributionResponse
 {
-    @JsonProperty
     private Integer totalBackendCount;
-    @JsonProperty
     private Integer offlineBackendCount;
-    @JsonProperty
     private Integer onlineBackendCount;
 
     /**
      * Total number of queries.
      * The QueryDistributionRequest's latestHour parameter will affect the statistical range.
      */
-    @JsonProperty
     private Long totalQueryCount;
 
     /**
      * Average number of queries per minute.
      * The QueryDistributionRequest's latestHour parameter will affect the statistical range.
      */
-    @JsonProperty
     private Double averageQueryCountMinute;
 
     /**
      * Average number of queries per second.
      * The QueryDistributionRequest's latestHour parameter will affect the statistical range.
      */
-    @JsonProperty
     private Double averageQueryCountSecond;
 
     /**
      * Pie chart of the number of backend queries.
      * The QueryDistributionRequest's latestHour parameter will affect the statistical range.
      */
-    @JsonProperty
     private List<DistributionChart> distributionChart;
 
     /**
      * Line graph of the number of queries per minute for each backend.
      * The QueryDistributionRequest's latestHour parameter will affect the statistical range.
      */
-    @JsonProperty
     private Map<String, List<LineChart>> lineChart;
-    @JsonProperty
     private String startTime;
 
+    @JsonProperty
     public String getStartTime()
     {
         return startTime;
@@ -74,6 +66,7 @@ public class DistributionResponse
         this.startTime = startTime;
     }
 
+    @JsonProperty
     public Integer getTotalBackendCount()
     {
         return totalBackendCount;
@@ -84,6 +77,7 @@ public class DistributionResponse
         this.totalBackendCount = totalBackendCount;
     }
 
+    @JsonProperty
     public Integer getOfflineBackendCount()
     {
         return offlineBackendCount;
@@ -94,6 +88,7 @@ public class DistributionResponse
         this.offlineBackendCount = offlineBackendCount;
     }
 
+    @JsonProperty
     public Integer getOnlineBackendCount()
     {
         return onlineBackendCount;
@@ -104,6 +99,7 @@ public class DistributionResponse
         this.onlineBackendCount = onlineBackendCount;
     }
 
+    @JsonProperty
     public Long getTotalQueryCount()
     {
         return totalQueryCount;
@@ -114,6 +110,7 @@ public class DistributionResponse
         this.totalQueryCount = totalQueryCount;
     }
 
+    @JsonProperty
     public Double getAverageQueryCountMinute()
     {
         return averageQueryCountMinute;
@@ -124,6 +121,7 @@ public class DistributionResponse
         this.averageQueryCountMinute = averageQueryCountMinute;
     }
 
+    @JsonProperty
     public Double getAverageQueryCountSecond()
     {
         return averageQueryCountSecond;
@@ -134,6 +132,7 @@ public class DistributionResponse
         this.averageQueryCountSecond = averageQueryCountSecond;
     }
 
+    @JsonProperty
     public List<DistributionChart> getDistributionChart()
     {
         return distributionChart;
@@ -144,6 +143,7 @@ public class DistributionResponse
         this.distributionChart = distributionChart;
     }
 
+    @JsonProperty
     public Map<String, List<LineChart>> getLineChart()
     {
         return lineChart;
@@ -160,6 +160,7 @@ public class DistributionResponse
         private Long queryCount;
         private String name;
 
+        @JsonProperty
         public String getBackendUrl()
         {
             return backendUrl;
@@ -170,6 +171,7 @@ public class DistributionResponse
             this.backendUrl = backendUrl;
         }
 
+        @JsonProperty
         public Long getQueryCount()
         {
             return queryCount;
@@ -180,6 +182,7 @@ public class DistributionResponse
             this.queryCount = queryCount;
         }
 
+        @JsonProperty
         public String getName()
         {
             return name;
@@ -198,6 +201,7 @@ public class DistributionResponse
         private Long queryCount;
         private String name;
 
+        @JsonProperty
         public String getMinute()
         {
             return minute;
@@ -208,6 +212,7 @@ public class DistributionResponse
             this.minute = minute;
         }
 
+        @JsonProperty
         public String getBackendUrl()
         {
             return backendUrl;
@@ -218,6 +223,7 @@ public class DistributionResponse
             this.backendUrl = backendUrl;
         }
 
+        @JsonProperty
         public Long getQueryCount()
         {
             return queryCount;
@@ -228,6 +234,7 @@ public class DistributionResponse
             this.queryCount = queryCount;
         }
 
+        @JsonProperty
         public String getName()
         {
             return name;

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/LoginResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/LoginResource.java
@@ -83,7 +83,7 @@ public class LoginResource
     {
         if (formAuthManager == null) {
             if (oauthManager == null) {
-                return Response.ok(Result.ok(Map.of("token", loginForm.getUsername()))).build();
+                return Response.ok(Result.ok(Map.of("token", loginForm.username()))).build();
             }
             throw new WebApplicationException("Form authentication is not setup");
         }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
@@ -98,18 +98,18 @@ public class HaQueryHistoryManager
     @Override
     public TableData<QueryDetail> findQueryHistory(QueryHistoryRequest query)
     {
-        int start = PageUtil.getStart(query.getPage(), query.getSize());
+        int start = PageUtil.getStart(query.page(), query.size());
         String condition = "";
-        if (!Strings.isNullOrEmpty(query.getUser())) {
-            condition += " and user_name = '" + query.getUser() + "'";
+        if (!Strings.isNullOrEmpty(query.user())) {
+            condition += " and user_name = '" + query.user() + "'";
         }
-        if (!Strings.isNullOrEmpty(query.getBackendUrl())) {
-            condition += " and backend_url = '" + query.getBackendUrl() + "'";
+        if (!Strings.isNullOrEmpty(query.backendUrl())) {
+            condition += " and backend_url = '" + query.backendUrl() + "'";
         }
-        if (!Strings.isNullOrEmpty(query.getQueryId())) {
-            condition += " and query_id = '" + query.getQueryId() + "'";
+        if (!Strings.isNullOrEmpty(query.queryId())) {
+            condition += " and query_id = '" + query.queryId() + "'";
         }
-        List<QueryHistory> histories = dao.pageQueryHistory(condition, query.getSize(), start);
+        List<QueryHistory> histories = dao.pageQueryHistory(condition, query.size(), start);
         List<QueryDetail> rows = upcast(histories);
         Long total = dao.count(condition);
         return TableData.build(rows, total);

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/ResourceGroupsManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/ResourceGroupsManager.java
@@ -13,6 +13,7 @@
  */
 package io.trino.gateway.ha.router;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
@@ -106,6 +107,7 @@ public interface ResourceGroupsManager
             }
         }
 
+        @JsonProperty
         public long getResourceGroupId()
         {
             return this.resourceGroupId;
@@ -117,6 +119,7 @@ public interface ResourceGroupsManager
         }
 
         @Nonnull
+        @JsonProperty
         public String getName()
         {
             return this.name;
@@ -127,6 +130,7 @@ public interface ResourceGroupsManager
             this.name = name;
         }
 
+        @JsonProperty
         public Long getParent()
         {
             return this.parent;
@@ -137,6 +141,7 @@ public interface ResourceGroupsManager
             this.parent = parent;
         }
 
+        @JsonProperty
         public Boolean getJmxExport()
         {
             return this.jmxExport;
@@ -147,6 +152,7 @@ public interface ResourceGroupsManager
             this.jmxExport = jmxExport;
         }
 
+        @JsonProperty
         public String getSchedulingPolicy()
         {
             return this.schedulingPolicy;
@@ -157,16 +163,19 @@ public interface ResourceGroupsManager
             this.schedulingPolicy = schedulingPolicy;
         }
 
+        @JsonProperty
         public Integer getSchedulingWeight()
         {
             return this.schedulingWeight;
         }
 
+        @JsonProperty
         public void setSchedulingWeight(Integer schedulingWeight)
         {
             this.schedulingWeight = schedulingWeight;
         }
 
+        @JsonProperty
         @Nonnull
         public String getSoftMemoryLimit()
         {
@@ -178,6 +187,7 @@ public interface ResourceGroupsManager
             this.softMemoryLimit = softMemoryLimit;
         }
 
+        @JsonProperty
         public int getMaxQueued()
         {
             return this.maxQueued;
@@ -188,6 +198,7 @@ public interface ResourceGroupsManager
             this.maxQueued = maxQueued;
         }
 
+        @JsonProperty
         public int getHardConcurrencyLimit()
         {
             return this.hardConcurrencyLimit;
@@ -198,6 +209,7 @@ public interface ResourceGroupsManager
             this.hardConcurrencyLimit = hardConcurrencyLimit;
         }
 
+        @JsonProperty
         public Integer getSoftConcurrencyLimit()
         {
             return this.softConcurrencyLimit;
@@ -208,6 +220,7 @@ public interface ResourceGroupsManager
             this.softConcurrencyLimit = softConcurrencyLimit;
         }
 
+        @JsonProperty
         public String getSoftCpuLimit()
         {
             return this.softCpuLimit;
@@ -218,6 +231,7 @@ public interface ResourceGroupsManager
             this.softCpuLimit = softCpuLimit;
         }
 
+        @JsonProperty
         public String getHardCpuLimit()
         {
             return this.hardCpuLimit;
@@ -228,6 +242,7 @@ public interface ResourceGroupsManager
             this.hardCpuLimit = hardCpuLimit;
         }
 
+        @JsonProperty
         public String getEnvironment()
         {
             return this.environment;
@@ -322,6 +337,7 @@ public interface ResourceGroupsManager
             }
         }
 
+        @JsonProperty
         public long getResourceGroupId()
         {
             return this.resourceGroupId;
@@ -332,6 +348,7 @@ public interface ResourceGroupsManager
             this.resourceGroupId = resourceGroupId;
         }
 
+        @JsonProperty
         public long getPriority()
         {
             return this.priority;
@@ -342,6 +359,7 @@ public interface ResourceGroupsManager
             this.priority = priority;
         }
 
+        @JsonProperty
         public String getUserRegex()
         {
             return this.userRegex;
@@ -352,6 +370,7 @@ public interface ResourceGroupsManager
             this.userRegex = userRegex;
         }
 
+        @JsonProperty
         public String getSourceRegex()
         {
             return this.sourceRegex;
@@ -362,6 +381,7 @@ public interface ResourceGroupsManager
             this.sourceRegex = sourceRegex;
         }
 
+        @JsonProperty
         public String getQueryType()
         {
             return this.queryType;
@@ -372,6 +392,7 @@ public interface ResourceGroupsManager
             this.queryType = queryType;
         }
 
+        @JsonProperty
         public String getClientTags()
         {
             return this.clientTags;
@@ -382,6 +403,7 @@ public interface ResourceGroupsManager
             this.clientTags = clientTags;
         }
 
+        @JsonProperty
         public String getSelectorResourceEstimate()
         {
             return this.selectorResourceEstimate;
@@ -453,6 +475,7 @@ public interface ResourceGroupsManager
         }
 
         @Nonnull
+        @JsonProperty
         public String getName()
         {
             return this.name;
@@ -463,6 +486,7 @@ public interface ResourceGroupsManager
             this.name = name;
         }
 
+        @JsonProperty
         public String getValue()
         {
             return this.value;
@@ -530,6 +554,7 @@ public interface ResourceGroupsManager
             return 0;
         }
 
+        @JsonProperty
         @Nonnull
         public String getResourceGroupId()
         {
@@ -541,6 +566,7 @@ public interface ResourceGroupsManager
             this.resourceGroupId = resourceGroupId;
         }
 
+        @JsonProperty
         @Nonnull
         public String getUpdateTime()
         {
@@ -552,6 +578,7 @@ public interface ResourceGroupsManager
             this.updateTime = updateTime;
         }
 
+        @JsonProperty
         @Nonnull
         public String getSource()
         {
@@ -563,6 +590,7 @@ public interface ResourceGroupsManager
             this.source = source;
         }
 
+        @JsonProperty
         public String getEnvironment()
         {
             return this.environment;
@@ -573,6 +601,7 @@ public interface ResourceGroupsManager
             this.environment = environment;
         }
 
+        @JsonProperty
         public String getQueryType()
         {
             return this.queryType;

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbFormAuthManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbFormAuthManager.java
@@ -79,8 +79,8 @@ public class LbFormAuthManager
      */
     public Result<?> processRESTLogin(RestLoginRequest loginForm)
     {
-        if (authenticate(new BasicCredentials(loginForm.getUsername(), loginForm.getPassword()))) {
-            String token = getSelfSignedToken(loginForm.getUsername());
+        if (authenticate(new BasicCredentials(loginForm.username(), loginForm.password()))) {
+            String token = getSelfSignedToken(loginForm.username());
             return Result.ok(Map.of("token", token));
         }
         return Result.fail("Authentication failed.");

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbOAuthManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbOAuthManager.java
@@ -165,17 +165,11 @@ public class LbOAuthManager
     @JsonIgnoreProperties(ignoreUnknown = true)
     static final class OidcTokens
     {
-        @JsonProperty
         private final String accessToken;
-        @JsonProperty
         private final String idToken;
-        @JsonProperty
         private final String scope;
-        @JsonProperty
         private final String refreshToken;
-        @JsonProperty
         private final String tokenType;
-        @JsonProperty
         private final String expiresIn;
 
         @JsonCreator
@@ -194,31 +188,37 @@ public class LbOAuthManager
             this.refreshToken = refreshToken;
         }
 
+        @JsonProperty
         public String getAccessToken()
         {
             return this.accessToken;
         }
 
+        @JsonProperty
         public String getIdToken()
         {
             return this.idToken;
         }
 
+        @JsonProperty
         public String getScope()
         {
             return this.scope;
         }
 
+        @JsonProperty
         public String getRefreshToken()
         {
             return this.refreshToken;
         }
 
+        @JsonProperty
         public String getTokenType()
         {
             return this.tokenType;
         }
 
+        @JsonProperty
         public String getExpiresIn()
         {
             return this.expiresIn;

--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyServerConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyServerConfiguration.java
@@ -13,6 +13,8 @@
  */
 package io.trino.gateway.proxyserver;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class ProxyServerConfiguration
 {
     private String name;
@@ -100,11 +102,13 @@ public class ProxyServerConfiguration
         return responseBufferSize;
     }
 
+    @JsonProperty
     public String getName()
     {
         return this.name;
     }
 
+    @JsonProperty
     public String getProxyTo()
     {
         return this.proxyTo;

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestObjectSerializable.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestObjectSerializable.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.json.ObjectMapperProvider;
+import io.trino.gateway.ha.clustermonitor.ServerInfo;
+import io.trino.gateway.ha.config.ProxyBackendConfiguration;
+import io.trino.gateway.ha.domain.Result;
+import io.trino.gateway.ha.domain.TableData;
+import io.trino.gateway.ha.domain.request.GlobalPropertyRequest;
+import io.trino.gateway.ha.domain.request.QueryDistributionRequest;
+import io.trino.gateway.ha.domain.request.QueryGlobalPropertyRequest;
+import io.trino.gateway.ha.domain.request.QueryHistoryRequest;
+import io.trino.gateway.ha.domain.request.QueryResourceGroupsRequest;
+import io.trino.gateway.ha.domain.request.QuerySelectorsRequest;
+import io.trino.gateway.ha.domain.request.ResourceGroupsRequest;
+import io.trino.gateway.ha.domain.request.RestLoginRequest;
+import io.trino.gateway.ha.domain.request.SelectorsRequest;
+import io.trino.gateway.ha.domain.response.BackendResponse;
+import io.trino.gateway.ha.domain.response.DistributionResponse;
+import io.trino.gateway.ha.router.ResourceGroupsManager;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestObjectSerializable
+{
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    @Test
+    public void testServerInfo()
+            throws JsonProcessingException
+    {
+        assertThat(objectMapper.writeValueAsString(new ServerInfo(true)))
+                .contains("starting");
+    }
+
+    @Test
+    public void testProxyBackendConfiguration()
+            throws JsonProcessingException
+    {
+        ProxyBackendConfiguration proxyBackendConfiguration = new ProxyBackendConfiguration();
+        proxyBackendConfiguration.setExternalUrl("http://localhost:8080");
+        proxyBackendConfiguration.setActive(false);
+        proxyBackendConfiguration.setRoutingGroup("batch-1");
+        assertThat(objectMapper.writeValueAsString(proxyBackendConfiguration))
+                .contains(ImmutableList.of("externalUrl", "active", "routingGroup"));
+    }
+
+    @Test
+    public void testResult()
+            throws JsonProcessingException
+    {
+        assertThat(objectMapper.writeValueAsString(Result.ok()))
+                .contains(ImmutableList.of("code", "msg"));
+        assertThat(objectMapper.writeValueAsString(Result.ok("some_msg")))
+                .contains(ImmutableList.of("code", "msg"));
+        assertThat(objectMapper.writeValueAsString(Result.ok(123)))
+                .contains(ImmutableList.of("code", "msg", "data"));
+    }
+
+    @Test
+    public void testTableData()
+            throws JsonProcessingException
+    {
+        TableData<String> tableData = new TableData<>(ImmutableList.of("t1", "t2"), 2);
+        assertThat(objectMapper.writeValueAsString(tableData))
+                .contains(ImmutableList.of("total", "rows"));
+    }
+
+    @Test
+    public void testGlobalPropertyRequest()
+            throws JsonProcessingException
+    {
+        ResourceGroupsManager.GlobalPropertiesDetail data = new ResourceGroupsManager.GlobalPropertiesDetail("cpu_quota_period");
+        assertThat(objectMapper.writeValueAsString(new GlobalPropertyRequest(null, data)))
+                .contains("data");
+        assertThat(objectMapper.writeValueAsString(new GlobalPropertyRequest("some_schema", data)))
+                .contains(ImmutableList.of("useSchema", "data"));
+    }
+
+    @Test
+    public void testQueryDistributionRequest()
+            throws JsonProcessingException
+    {
+        assertThat(objectMapper.writeValueAsString(new QueryDistributionRequest(null)))
+                .contains("\"latestHour\":1");
+        assertThat(objectMapper.writeValueAsString(new QueryDistributionRequest(3)))
+                .contains("\"latestHour\":3");
+    }
+
+    @Test
+    public void testQueryGlobalPropertyRequest()
+            throws JsonProcessingException
+    {
+        assertThat(objectMapper.writeValueAsString(new QueryGlobalPropertyRequest(null, null)))
+                .isEqualTo("{}");
+        assertThat(objectMapper.writeValueAsString(new QueryGlobalPropertyRequest("some_schema", null)))
+                .contains("\"useSchema\":\"some_schema\"");
+        assertThat(objectMapper.writeValueAsString(new QueryGlobalPropertyRequest("some_schema", "some_name")))
+                .contains(ImmutableList.of("\"useSchema\":\"some_schema\"", "\"name\":\"some_name\""));
+    }
+
+    @Test
+    public void testQueryHistoryRequest()
+            throws JsonProcessingException
+    {
+        assertThat(objectMapper.writeValueAsString(new QueryHistoryRequest(null, null, "user1", "url1", "query_id")))
+                .contains(ImmutableList.of("\"page\":1", "\"size\":10", "user", "backendUrl", "queryId"));
+        assertThat(objectMapper.writeValueAsString(new QueryHistoryRequest(5, 6, "user1", "url1", "query_id")))
+                .contains(ImmutableList.of("\"page\":5", "\"size\":6", "user", "backendUrl", "queryId"));
+    }
+
+    @Test
+    public void testQueryResourceGroupsRequest()
+            throws JsonProcessingException
+    {
+        assertThat(objectMapper.writeValueAsString(new QueryResourceGroupsRequest(null, 123L)))
+                .contains("resourceGroupId");
+        assertThat(objectMapper.writeValueAsString(new QueryResourceGroupsRequest("some_schema", 123L)))
+                .contains(ImmutableList.of("useSchema", "resourceGroupId"));
+    }
+
+    @Test
+    public void testQuerySelectorsRequest()
+            throws JsonProcessingException
+    {
+        assertThat(objectMapper.writeValueAsString(new QuerySelectorsRequest(null, 123L)))
+                .contains("resourceGroupId");
+        assertThat(objectMapper.writeValueAsString(new QuerySelectorsRequest("some_schema", 123L)))
+                .contains(ImmutableList.of("useSchema", "resourceGroupId"));
+    }
+
+    @Test
+    public void testResourceGroupsRequest()
+            throws JsonProcessingException
+    {
+        ResourceGroupsManager.ResourceGroupsDetail data = new ResourceGroupsManager.ResourceGroupsDetail();
+        assertThat(objectMapper.writeValueAsString(new ResourceGroupsRequest(null, data)))
+                .contains(ImmutableList.of("data", "resourceGroupId"));
+        assertThat(objectMapper.writeValueAsString(new ResourceGroupsRequest("some_schema", data)))
+                .contains(ImmutableList.of("useSchema", "data", "resourceGroupId"));
+    }
+
+    @Test
+    public void testRestLoginRequest()
+            throws JsonProcessingException
+    {
+        assertThat(objectMapper.writeValueAsString(new RestLoginRequest("user", "pass")))
+                .contains(ImmutableList.of("username", "password"));
+    }
+
+    @Test
+    public void testSelectorsRequest()
+            throws JsonProcessingException
+    {
+        ResourceGroupsManager.SelectorsDetail data = new ResourceGroupsManager.SelectorsDetail();
+        ResourceGroupsManager.SelectorsDetail oldData = new ResourceGroupsManager.SelectorsDetail();
+        assertThat(objectMapper.writeValueAsString(new SelectorsRequest(null, data, oldData)))
+                .contains(ImmutableList.of("data", "oldData"));
+        assertThat(objectMapper.writeValueAsString(new SelectorsRequest("some_schema", data, oldData)))
+                .contains(ImmutableList.of("useSchema", "data", "oldData"));
+    }
+
+    @Test
+    public void testBackendResponse()
+            throws JsonProcessingException
+    {
+        BackendResponse backendResponse = new BackendResponse();
+        backendResponse.setQueued(4);
+        backendResponse.setRunning(5);
+        backendResponse.setName("foo");
+        backendResponse.setProxyTo("example.com");
+        backendResponse.setActive(false);
+        backendResponse.setRoutingGroup("batch-1");
+        backendResponse.setExternalUrl("example.com");
+        assertThat(objectMapper.writeValueAsString(backendResponse))
+                .contains(ImmutableList.of("queued", "running", "active", "routingGroup", "externalUrl", "name", "proxyTo"));
+    }
+
+    @Test
+    public void testDistributionResponse()
+            throws JsonProcessingException
+    {
+        DistributionResponse.LineChart lineChart = new DistributionResponse.LineChart();
+        lineChart.setMinute("11:22");
+        lineChart.setBackendUrl("example.com");
+        lineChart.setName("name1");
+        lineChart.setQueryCount(6L);
+        DistributionResponse.DistributionChart distributionChart = new DistributionResponse.DistributionChart();
+        distributionChart.setName("name2");
+        distributionChart.setBackendUrl("example.com");
+        distributionChart.setQueryCount(1L);
+        DistributionResponse distributionResponse = new DistributionResponse();
+        distributionResponse.setTotalBackendCount(5);
+        distributionResponse.setOfflineBackendCount(3);
+        distributionResponse.setOnlineBackendCount(2);
+        distributionResponse.setLineChart(ImmutableMap.of("k1", ImmutableList.of(lineChart)));
+        distributionResponse.setDistributionChart(List.of(distributionChart));
+        distributionResponse.setTotalQueryCount(123L);
+        distributionResponse.setAverageQueryCountSecond(5.0);
+        distributionResponse.setAverageQueryCountMinute(10.0);
+        distributionResponse.setStartTime("2024-04-01 12:34:56");
+        assertThat(objectMapper.writeValueAsString(distributionResponse))
+                .contains(ImmutableList.of(
+                        "totalBackendCount",    // DistributionResponse
+                        "offlineBackendCount",
+                        "onlineBackendCount",
+                        "totalQueryCount",
+                        "averageQueryCountMinute",
+                        "averageQueryCountSecond",
+                        "distributionChart",
+                        "lineChart",
+                        "startTime",
+                        "minute",       // LineChart
+                        "backendUrl",
+                        "queryCount",
+                        "\"name\":\"name1\"",
+                        "\"name\":\"name2\"",   // DistributionChart
+                        "backendUrl",
+                        "queryCount"));
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbAuthenticator.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbAuthenticator.java
@@ -159,9 +159,7 @@ public class TestLbAuthenticator
                 "user2", new UserConfiguration("priv2, priv2", "pass2"));
 
         LbFormAuthManager lbFormAuthManager = new LbFormAuthManager(formAuthConfig, presetUsers, new HashMap<>());
-        RestLoginRequest restLoginRequest = new RestLoginRequest();
-        restLoginRequest.setUsername("user1");
-        restLoginRequest.setPassword("pass1");
+        RestLoginRequest restLoginRequest = new RestLoginRequest("user1", "pass1");
         Result<?> r = lbFormAuthManager.processRESTLogin(restLoginRequest);
         assertThat(Result.isSuccess(r)).isTrue();
         Map data = (Map) r.getData();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Part of #41 

Annotate JsonProperty on getter instead of field. This ensure objects are serializable without enable Jackson AUTO_DETECT_GETTERS feature. AUTO_DETECT_GETTERS is disabled by Airlift. This PR ensure the objects are serializable after switch to Airlift.

Without this change, we'll get a JsonMappingException error when AUTO_DETECT_GETTERS is disabled.
```
com.fasterxml.jackson.databind.JsonMappingException: class com.fasterxml.jackson.databind.ser.BeanPropertyWriter cannot access a member of class io.trino.gateway.ha.domain.response.BackendResponse with modifiers "private" (through reference chain: io.trino.gateway.ha.domain.response.BackendResponse["queued"])
```

All Request objects are converted to record to reduce boilerplate.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

