### PR TITLE
Update JWKS RSA to 0.22.1

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>jwks-rsa</artifactId>
-            <version>0.9.0</version>
+            <version>0.22.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Part of #41 

Update JWKS RSA to 0.22.1.

Resolve the following error when updating to Airlift.
This error happens when we drop dropwizard-dependencies.
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.4.1:enforce (default) on project gateway-ha: 
[ERROR] Rule 2: org.apache.maven.enforcer.rules.dependency.RequireUpperBoundDeps failed with message:
[ERROR] Failed while enforcing RequireUpperBoundDeps. The error(s) are [
[ERROR] Require upper bound dependencies error for commons-codec:commons-codec:1.13 paths to dependency are:
[ERROR] +-io.trino.gateway:gateway-ha:8-SNAPSHOT
[ERROR]   +-com.auth0:jwks-rsa:0.9.0
[ERROR]     +-commons-codec:commons-codec:1.13
[ERROR] and
[ERROR] +-io.trino.gateway:gateway-ha:8-SNAPSHOT
[ERROR]   +-org.apache.directory.api:api-all:2.1.5
[ERROR]     +-commons-codec:commons-codec:1.16.0
[ERROR] ]
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
