### PR TITLE
Standardize the path for the gateway jar on the docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,12 +45,9 @@ RUN \
 
 COPY --chown=trino:trino gateway-ha /usr/lib/trino
 
-ARG TRINO_GATEWAY_VERSION
-ENV GATEWAY_JAR_PATH "/usr/lib/trino/gateway-ha-${TRINO_GATEWAY_VERSION}-jar-with-dependencies.jar"
-
 EXPOSE 8080
 USER trino:trino
-CMD java --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED -jar "${GATEWAY_JAR_PATH}" "server" "/opt/trino/gateway-ha-config.yml"
+CMD java --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED -jar /usr/lib/trino/gateway-ha-jar-with-dependencies.jar "server" "/opt/trino/gateway-ha-config.yml"
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=10s \
   CMD /usr/lib/trino/bin/health-check

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -110,7 +110,7 @@ echo "🧱 Preparing the image build context directory"
 WORK_DIR="$(mktemp -d)"
 GATEWAY_WORK_DIR="${WORK_DIR}/gateway-ha"
 mkdir "${GATEWAY_WORK_DIR}"
-cp "$trino_gateway_ha" "${GATEWAY_WORK_DIR}"
+cp "$trino_gateway_ha" "${GATEWAY_WORK_DIR}/gateway-ha-jar-with-dependencies.jar"
 cp -R bin "${GATEWAY_WORK_DIR}"
 cp "${SCRIPT_DIR}/Dockerfile" "${WORK_DIR}"
 
@@ -126,7 +126,6 @@ for arch in "${ARCHITECTURES[@]}"; do
         --pull \
         --build-arg JDK_VERSION="${JDK_VERSION}" \
         --build-arg JDK_DOWNLOAD_LINK="$(temurin_jdk_link "${JDK_VERSION}" "${arch}")" \
-        --build-arg TRINO_GATEWAY_VERSION="${TRINO_GATEWAY_VERSION}" \
         --build-arg TRINO_GATEWAY_BASE_IMAGE="${TRINO_GATEWAY_BASE_IMAGE}" \
         --platform "linux/$arch" \
         -f Dockerfile \


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This removes the version number from the gateway jar path in order to prepare for Helm chart development. 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The docker image locates the gateway executable jar at
```
"/usr/lib/trino/gateway-ha-${TRINO_GATEWAY_VERSION}-jar-with-dependencies.jar"
```
This is inconvenient for implementing a Helm chart that will not use the image's `CMD` directive.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: