### PR TITLE
Add Helm chart for k8s deployment

### DIFF
--- a/helm/trino-gateway/.helmignore
+++ b/helm/trino-gateway/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/trino-gateway/Chart.yaml
+++ b/helm/trino-gateway/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: trino-gateway
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: "8"
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "8"

--- a/helm/trino-gateway/templates/NOTES.txt
+++ b/helm/trino-gateway/templates/NOTES.txt
@@ -1,0 +1,28 @@
+You can get the Trino Gateway endpoints by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export REQUEST_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath='{.spec.ports[?(@.name == "request")].nodePort}' services {{ include "trino-gateway.fullname" . }})
+  export APP_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath='{.spec.ports[?(@.name == "app")].nodePort}' services {{ include "trino-gateway.fullname" . }})
+  export ADMIN_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath='{.spec.ports[?(@.name == "admin")].nodePort}' services {{ include "trino-gateway.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
+  echo http://$NODE_IP:$REQUEST_NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "trino-gateway.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "trino-gateway.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "trino-gateway.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export REQUEST_PORT=$(kubectl get pod --namespace test $POD_NAME -o jsonpath='{.spec.containers[0].ports[?(@.name == "request")].containerPort}')
+  export APP_PORT=$(kubectl get pod --namespace test $POD_NAME -o jsonpath='{.spec.containers[0].ports[?(@.name == "app")].containerPort}')
+  export ADMIN_PORT=$(kubectl get pod --namespace test $POD_NAME -o jsonpath='{.spec.containers[0].ports[?(@.name == "admin")].containerPort}')
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$REQUEST_PORT
+{{- end }}
+
+Happy Helming!

--- a/helm/trino-gateway/templates/_helpers.tpl
+++ b/helm/trino-gateway/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "trino-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "trino-gateway.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "trino-gateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "trino-gateway.labels" -}}
+helm.sh/chart: {{ include "trino-gateway.chart" . }}
+{{ include "trino-gateway.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "trino-gateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "trino-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "trino-gateway.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "trino-gateway.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/trino-gateway/templates/deployment.yaml
+++ b/helm/trino-gateway/templates/deployment.yaml
@@ -1,0 +1,112 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "trino-gateway.fullname" . }}
+  labels:
+    {{- include "trino-gateway.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "trino-gateway.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+          # Include the version of trino-gateway-configuration as an input to the deployment checksum. This causes pods to restart on helm update
+          # whether the chart `config` is updated or if one of the configuration secrets is updated. Helm template must be run with the
+          # --dry-run=server option to prevent a nil pointer
+          checksum/config: {{ (lookup "v1" "Secret" .Release.Namespace "trino-gateway-configuration").metadata.resourceVersion | sha256sum}}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "trino-gateway.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "trino-gateway.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+              - "java"
+              - "--add-opens=java.base/java.lang=ALL-UNNAMED"
+              - "--add-opens=java.base/java.net=ALL-UNNAMED"
+              - "-XX:MinRAMPercentage=80.0"
+              - "-XX:MaxRAMPercentage=80.0"
+              - "-jar"
+              - "/usr/lib/trino/gateway-ha-jar-with-dependencies.jar"
+              - "server"
+              - "/etc/gateway/config.yaml"
+          ports:
+            - name: request
+              containerPort: {{ .Values.config.requestRouter.port }}
+              protocol: TCP
+            {{- range $index, $connector := $.Values.config.server.adminConnectors}}
+            - name: {{print "admin-" $index }}
+              protocol: TCP
+              containerPort: {{ $connector.port }}
+            {{- end }}
+            {{- range $index, $connector := $.Values.config.server.applicationConnectors}}
+            - name: {{print "app-" $index }}
+              protocol: TCP
+              containerPort: {{ $connector.port }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+                path: /
+                port: {{ (index .Values.config.server.adminConnectors 0).port}}
+            initialDelaySeconds: .Values.livenessProbe.initialDelaySeconds
+            periodSeconds: .Values.livenessProbe.periodSeconds
+            failureThreshold: .Values.livenessProbe.failureThreshold
+            timeoutSeconds: .Values.livenessProbe.timeoutSeconds
+          readinessProbe:
+            httpGet:
+                path: /
+                port: {{ (index .Values.config.server.adminConnectors 0).port}}
+            initialDelaySeconds: .Values.readinessProbe.initialDelaySeconds
+            periodSeconds: .Values.readinessProbe.periodSeconds
+            failureThreshold: .Values.readinessProbe.failureThreshold
+            timeoutSeconds: .Values.readinessProbe.timeoutSeconds
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: trino-gateway-configuration
+              mountPath: "/etc/gateway/config.yaml"
+              subPath: "config.yaml"
+              readOnly: true
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: trino-gateway-configuration
+          secret:
+              secretName: trino-gateway-configuration
+              optional: false
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/trino-gateway/templates/hpa.yaml
+++ b/helm/trino-gateway/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "trino-gateway.fullname" . }}
+  labels:
+    {{- include "trino-gateway.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "trino-gateway.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/trino-gateway/templates/ingress.yaml
+++ b/helm/trino-gateway/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "trino-gateway.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "trino-gateway.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/trino-gateway/templates/secrets.yaml
+++ b/helm/trino-gateway/templates/secrets.yaml
@@ -1,0 +1,22 @@
+{{ $dataStoreDict :=  dict}}
+{{ if .Values.dataStoreSecret.name }}
+{{ $dataStoreDict = (index (lookup "v1" "Secret" .Release.Namespace .Values.dataStoreSecret.name).data .Values.dataStoreSecret.key) | b64dec | fromYaml }}
+{{ end }}
+{{ $backendStateDict := dict }}
+{{ if .Values.backendStateSecret.name }}
+{{ $backendStateDict = (index (lookup "v1" "Secret" .Release.Namespace .Values.backendStateSecret.name).data .Values.backendStateSecret.key) | b64dec | fromYaml }}
+{{ end }}
+{{ $authenticationDict := dict }}
+{{ if .Values.authenticationSecret.name }}
+# {{.Values.authenticationSecret.name }} #
+# {{ index (lookup "v1" "Secret" .Release.Namespace .Values.authenticationSecret.name).data .Values.authenticationSecret.key }} #
+{{ $authenticationDict = (index (lookup "v1" "Secret" .Release.Namespace .Values.authenticationSecret.name).data .Values.authenticationSecret.key) | b64dec | fromYaml  }}
+{{ end }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+    name: trino-gateway-configuration
+type: "Opaque"
+data:
+    config.yaml: "{{toYaml (merge .Values.config $authenticationDict $dataStoreDict $backendStateDict ) | b64enc}}"

--- a/helm/trino-gateway/templates/service.yaml
+++ b/helm/trino-gateway/templates/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "trino-gateway.fullname" . }}
+  labels:
+    {{- include "trino-gateway.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.config.requestRouter.port }}
+      protocol: TCP
+      name: request
+    {{- range $index, $connector := $.Values.config.server.applicationConnectors}}
+    - port: {{ $connector.port }}
+      protocol: TCP
+      name: {{print "app-" $index }}
+    {{- end }}
+    {{- range $index, $connector := $.Values.config.server.adminConnectors}}
+    - port: {{ $connector.port }}
+      protocol: TCP
+      name: {{print "admin-" $index }}
+    {{- end }}
+  selector:
+    {{- include "trino-gateway.selectorLabels" . | nindent 4 }}

--- a/helm/trino-gateway/templates/serviceaccount.yaml
+++ b/helm/trino-gateway/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "trino-gateway.serviceAccountName" . }}
+  labels:
+    {{- include "trino-gateway.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm/trino-gateway/templates/tests/test-connection.yaml
+++ b/helm/trino-gateway/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "trino-gateway.fullname" . }}-test-connection"
+  labels:
+    {{- include "trino-gateway.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "trino-gateway.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/helm/trino-gateway/values.yaml
+++ b/helm/trino-gateway/values.yaml
@@ -1,0 +1,145 @@
+replicaCount: 1
+
+image:
+    repository: "trinodb/trino-gateway"
+    pullPolicy: IfNotPresent
+    # Override the image tag whose default is the chart appVersion.
+    # tag: "8-SNAPSHOT"
+
+    # For local testing
+    #repository: "trino-gateway"
+    #pullPolicy: IfNotPresent
+    #tag: "8-SNAPSHOT"
+
+imagePullSecrets: []
+
+# Provide configuration for the Trino Gateway dataStore in dataStoreSecret. This node can
+# be left undefined if dataStore is defined under the config node. For production deployments
+# sensitive values should be stored in a Secret
+dataStoreSecret:
+    name: ""
+    key: ""
+
+# Provide configuration for the Trino Gateway backendState in backendStateSecret. This should
+# be used with health check configurations that require backend credentials. This node can
+# be left undefined if dataStore is defined under the config node.
+backendStateSecret:
+    name: ""
+    key: ""
+
+# Provide configuration for the Trino Gateway authentication configuration in authenticationSecret.
+# This node can be left undefined if dataStore is defined under the config node.
+authenticationSecret:
+    name: ""
+    key: ""
+
+config:
+    logging:
+        type: "external"
+    requestRouter:
+        #SQL clients connect to the request port
+        port: 9080
+        name: testTrinoRouter
+        historySize: 1000
+    server:
+        applicationConnectors:
+            - type: http
+              port: 9081
+              useForwardedHeaders: true
+        adminConnectors:
+            - type: http
+              port: 9082
+              useForwardedHeaders: true
+    clusterStatsConfiguration:
+        monitorType: INFO_API
+    modules:
+        - io.trino.gateway.ha.module.HaGatewayProviderModule
+        - io.trino.gateway.ha.module.ClusterStateListenerModule
+        - io.trino.gateway.ha.module.ClusterStatsMonitorModule
+    managedApps:
+        - io.trino.gateway.ha.GatewayManagedApp
+        - io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor
+
+service:
+  type: ClusterIP
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+ limits:
+   cpu: 2
+   memory: 4Gi
+ requests:
+   cpu: 2
+   memory: 4Gi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+livenessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  failureThreshold: 3
+  timeoutSeconds: 1
+  scheme: HTTP
+
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  failureThreshold: 12
+  timeoutSeconds: 1
+  scheme: HTTP
+
+volumes: {}
+
+volumeMounts: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+podAnnotations: {}
+
+podLabels: {}
+
+podSecurityContext: {}
+# fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+# runAsUser: 1000
+
+serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Automatically mount a ServiceAccount's API credentials?
+    automount: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add a Helm chart. This chart passes configuration directly from the values.yaml to the gateway config.yaml, loosely coupling the chart structure with the configuration of the gateway itself. Secrets for configurations that contain sensitive data are also supported.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This chart is only compatible with version 7 of the Trino Gateway docker image. Before this chart is released, we should release a public image with https://github.com/trinodb/trino-gateway/pull/318. This chart can then be updated to remove the version number from the executable path, making it compatible with all versions of the docker image going forward.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X ) Release notes are required, with the following suggested text:

```markdown
Add a Helm Chart for deployment
```
