### PR TITLE
Initialize the null userQueueCount map

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/QueryCountBasedRouter.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/QueryCountBasedRouter.java
@@ -63,6 +63,9 @@ public class QueryCountBasedRouter
             if (stats.userQueuedCount() != null) {
                 userQueuedCount = new HashMap<String, Integer>(stats.userQueuedCount());
             }
+            else {
+                userQueuedCount = new HashMap<String, Integer>();
+            }
         }
 
         public String clusterId()

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryCountBasedRouter.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryCountBasedRouter.java
@@ -47,7 +47,7 @@ public class TestQueryCountBasedRouter
     // Helper function to generate the ClusterStat list
     private static List<ClusterStats> getClusterStatsList(String routingGroup)
     {
-        ImmutableList.Builder<ClusterStats> clustersBuilder = new ImmutableList.Builder();
+        ImmutableList.Builder<ClusterStats> clustersBuilder = new ImmutableList.Builder<ClusterStats>();
         // Set Cluster1 stats
         {
             ClusterStats.Builder cluster = ClusterStats.builder("c1");
@@ -130,11 +130,10 @@ public class TestQueryCountBasedRouter
         cluster.routingGroup("adhoc");
         cluster.runningQueryCount(5);
         cluster.queuedQueryCount(LEAST_QUEUED_COUNT);
-        cluster.userQueuedCount(new HashMap<String, Integer>());
         return cluster.build();
     }
 
-    static ClusterStats getClusterWithMinRunnningQueries()
+    static ClusterStats getClusterWithMinRunningQueries()
     {
         ClusterStats.Builder cluster = ClusterStats.builder("c-Minimal-Running");
         cluster.proxyTo(BACKEND_URL_5);
@@ -150,7 +149,7 @@ public class TestQueryCountBasedRouter
     public void init()
     {
         //Have a adoc and an etl routing groups - 2 sets of clusters
-        clusters = new ImmutableList.Builder()
+        clusters = new ImmutableList.Builder<ClusterStats>()
                 .addAll(getClusterStatsList("adhoc"))
                 .addAll(getClusterStatsList("etl"))
                 .build();
@@ -211,7 +210,7 @@ public class TestQueryCountBasedRouter
     }
 
     @Test
-    public void testAdhocroutingGroupFailOver()
+    public void testAdhocRoutingGroupFailOver()
     {
         // The ETL routing group doesn't exist
         String proxyTo = queryCountBasedRouter.provideBackendForRoutingGroup("NonExisting", "u1");
@@ -223,7 +222,7 @@ public class TestQueryCountBasedRouter
     public void testClusterWithLeastQueueCount()
     {
         // Add a cluster with minimal queuelength
-        clusters = new ImmutableList.Builder()
+        clusters = new ImmutableList.Builder<ClusterStats>()
                 .addAll(clusters)
                 .add(getClusterWithNoUserQueueAndMinQueueCount())
                 .build();
@@ -238,10 +237,10 @@ public class TestQueryCountBasedRouter
     public void testClusterWithLeastRunningCount()
     {
         // Add a cluster with minimal queuelength
-        clusters = new ImmutableList.Builder()
+        clusters = new ImmutableList.Builder<ClusterStats>()
                 .addAll(clusters)
                 .add(getClusterWithNoUserQueueAndMinQueueCount())
-                .add(getClusterWithMinRunnningQueries())
+                .add(getClusterWithMinRunningQueries())
                 .build();
 
         queryCountBasedRouter.updateBackEndStats(clusters);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The new QueryCountBasedRouter router fails to route any request due to uninitialized userQueryCount map attribute.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
My guess is that the refactoring for Record to store the cluster stats removed the initialization.
This PR fixes the initialization of the userQueryCount map in the QueryCountBasedRouter. 
Also, modified the tests to take care of the scenario.




<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
This is a bug fix
() Release notes are required. Please propose a release note for me.
() Release notes are required, with the following suggested text:

```markdown
* 
```
