### PR TITLE
support reading log properties from file

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -100,14 +100,15 @@ configuration YAML file.
 
 Find more information in the [routing rules documentation](routing-rules.md).
 
-
 ### Configure logging <a name="logging">
 
-Path to `log.properties` must be set via `log.levels-file` JVM options
-like `-Dlog.levels-file=etc/log.properties`.
+To configure the logging level for various classes, specify the path to the 
+`log.properties` file using the `log.levels-file` JVM options, such as 
+`-Dlog.levels-file=etc/log.properties`, when the logging type is `external`.
 
-Use the `log.*` properties from the [Trino logging properties
-documentation](https://trino.io/docs/current/admin/properties-logging.html) for further configuration.
+For additional configurations, use the `log.*` properties from the 
+[Trino logging properties documentation](https://trino.io/docs/current/admin/properties-logging.html) and specify the path to `config.properties` 
+file using the `config` JVM options, such as `-Dconfig=var/config.properties`.
 
 ### Proxying additional paths
 

--- a/gateway-ha/etc/config.properties
+++ b/gateway-ha/etc/config.properties
@@ -1,0 +1,4 @@
+% https://trino.io/docs/current/admin/properties-logging.html
+log.max-size=100MB
+log.max-total-size=1GB
+log.compression=GZIP

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/HaGatewayLauncher.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/HaGatewayLauncher.java
@@ -23,7 +23,7 @@ import io.trino.gateway.ha.config.HaGatewayConfiguration;
 
 import java.util.Map;
 
-import static io.airlift.configuration.ConfigurationLoader.getSystemProperties;
+import static io.airlift.configuration.ConfigurationLoader.loadProperties;
 
 public class HaGatewayLauncher
         extends BaseApp
@@ -40,7 +40,7 @@ public class HaGatewayLauncher
             throws Exception
     {
         Logging.initialize();
-        Map<String, String> properties = getSystemProperties();
+        Map<String, String> properties = loadProperties();
         ConfigurationFactory configurationFactory = new ConfigurationFactory(properties);
         LoggingConfiguration configuration = configurationFactory.build(LoggingConfiguration.class);
         Logging logging = Logging.initialize();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Support reading log properties from file instead of command line using `-Dlog.<config>`.
- use [loadProperties](https://github.com/airlift/airlift/blob/master/configuration/src/main/java/io/airlift/configuration/ConfigurationLoader.java#L35-L47) instead of [getSystemProperties](https://github.com/airlift/airlift/blob/master/configuration/src/main/java/io/airlift/configuration/ConfigurationLoader.java#L68C39-L71)

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Support reading log properties from file
```
