### PR TITLE
Remove BackendState record

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
@@ -15,6 +15,7 @@ package io.trino.gateway.ha.resource;
 
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
+import io.trino.gateway.ha.clustermonitor.ClusterStats;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 import io.trino.gateway.ha.domain.Result;
 import io.trino.gateway.ha.domain.TableData;
@@ -86,11 +87,10 @@ public class GatewayWebAppResource
     {
         List<ProxyBackendConfiguration> allBackends = gatewayBackendManager.getAllBackends();
         List<BackendResponse> data = allBackends.stream().map(b -> {
-            BackendStateManager.BackendState backendState = backendStateManager.getBackendState(b);
-            Map<String, Integer> state = backendState.state();
+            ClusterStats backendState = backendStateManager.getBackendState(b);
             BackendResponse backendResponse = new BackendResponse();
-            backendResponse.setQueued(state.get("QUEUED"));
-            backendResponse.setRunning(state.get("RUNNING"));
+            backendResponse.setQueued(backendState.queuedQueryCount());
+            backendResponse.setRunning(backendState.runningQueryCount());
             backendResponse.setName(b.getName());
             backendResponse.setProxyTo(b.getProxyTo());
             backendResponse.setActive(b.isActive());

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/PublicResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/PublicResource.java
@@ -59,7 +59,7 @@ public class PublicResource
     public Response getBackendState(@PathParam("name") String name)
     {
         return gatewayBackendManager.getBackendByName(name).map(backendStateManager::getBackendState)
-                .map(state -> Response.ok(state.state()).build())
+                .map(state -> Response.ok(state).build())
                 .orElseGet(() -> Response.status(404).build());
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/BackendStateManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/BackendStateManager.java
@@ -13,14 +13,11 @@
  */
 package io.trino.gateway.ha.router;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.gateway.ha.clustermonitor.ClusterStats;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static java.util.Objects.requireNonNull;
 
 public class BackendStateManager
 {
@@ -31,27 +28,14 @@ public class BackendStateManager
         this.clusterStats = new HashMap<>();
     }
 
-    public BackendState getBackendState(ProxyBackendConfiguration backend)
+    public ClusterStats getBackendState(ProxyBackendConfiguration backend)
     {
         String name = backend.getName();
-        ClusterStats stats = clusterStats.getOrDefault(backend.getName(), ClusterStats.builder(name).build());
-        Map<String, Integer> state = new HashMap<>();
-        state.put("QUEUED", stats.queuedQueryCount());
-        state.put("RUNNING", stats.runningQueryCount());
-        return new BackendState(name, state);
+        return clusterStats.getOrDefault(name, ClusterStats.builder(name).build());
     }
 
     public void updateStates(String clusterId, ClusterStats stats)
     {
         clusterStats.put(clusterId, stats);
-    }
-
-    public record BackendState(String name, Map<String, Integer> state)
-    {
-        public BackendState
-        {
-            requireNonNull(name, "name is null");
-            state = ImmutableMap.copyOf(requireNonNull(state, "state is null"));
-        }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

BackendState record is a map of two fields that is used to return the `queuedQueryCount` and `runningQueryCount`. We have these information in `ClusterStats` class so we can simply use that.

## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
