### PR TITLE
Fix install and probe bugs

### DIFF
--- a/helm/trino-gateway/templates/deployment.yaml
+++ b/helm/trino-gateway/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
           # Include the version of trino-gateway-configuration as an input to the deployment checksum. This causes pods to restart on helm update
           # whether the chart `config` is updated or if one of the configuration secrets is updated. Helm template must be run with the
           # --dry-run=server option to prevent a nil pointer
-          checksum/config: {{ (lookup "v1" "Secret" .Release.Namespace "trino-gateway-configuration").metadata.resourceVersion | sha256sum}}
+          checksum/config: {{ (coalesce (lookup "v1" "Secret" .Release.Namespace "trino-gateway-configuration").metadata (dict "resourceVersion" "0")).resourceVersion | sha256sum}}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -68,18 +68,18 @@ spec:
             httpGet:
                 path: /
                 port: {{ (index .Values.config.server.adminConnectors 0).port}}
-            initialDelaySeconds: .Values.livenessProbe.initialDelaySeconds
-            periodSeconds: .Values.livenessProbe.periodSeconds
-            failureThreshold: .Values.livenessProbe.failureThreshold
-            timeoutSeconds: .Values.livenessProbe.timeoutSeconds
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
                 path: /
                 port: {{ (index .Values.config.server.adminConnectors 0).port}}
-            initialDelaySeconds: .Values.readinessProbe.initialDelaySeconds
-            periodSeconds: .Values.readinessProbe.periodSeconds
-            failureThreshold: .Values.readinessProbe.failureThreshold
-            timeoutSeconds: .Values.readinessProbe.timeoutSeconds
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This fixes a nil pointer issue when Helm evaluates the deployment template before the secrets template creates `trino-gateway-configuration`. It also fixes an issue with the liveness and readiness probe templates.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The nil pointer issue may result in an error message like
```
Error: template: trino-gateway/templates/deployment.yaml:20:71: executing "trino-gateway/templates/deployment.yaml" at <"trino-gateway-configuration">: nil pointer evaluating interface {}.resourceVersion
```

The templating issue results in a `livenessProbe` like:
```
livenessProbe:
            httpGet:
                path: /
                port: 9082
            initialDelaySeconds: .Values.livenessProbe.initialDelaySeconds
            periodSeconds: .Values.livenessProbe.periodSeconds
            failureThreshold: .Values.livenessProbe.failureThreshold
            timeoutSeconds: .Values.livenessProbe.timeoutSeconds
```
<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Fix issue with Helm deployment when configuration secret not create
* Pass template values through to readiness and liveness probes
```
