### PR TITLE
Centralize the place to log unhealthy clusters

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ActiveClusterMonitor.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ActiveClusterMonitor.java
@@ -79,6 +79,10 @@ public class ActiveClusterMonitor
                             List<ClusterStats> stats = new ArrayList<>();
                             for (Future<ClusterStats> clusterStatsFuture : futures) {
                                 ClusterStats clusterStats = clusterStatsFuture.get();
+                                if (!clusterStats.healthy()) {
+                                    log.error("cluster %s is unhealthy", clusterStats.clusterId());
+                                    log.debug("cluster stats: %s", clusterStats);
+                                }
                                 stats.add(clusterStats);
                             }
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ActiveClusterMonitor.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ActiveClusterMonitor.java
@@ -39,9 +39,9 @@ public class ActiveClusterMonitor
 
     private final int taskDelaySeconds;
     private final ClusterStatsMonitor clusterStatsMonitor;
-    private volatile boolean monitorActive = true;
     private final ExecutorService executorService = Executors.newFixedThreadPool(DEFAULT_THREAD_POOL_SIZE);
     private final ExecutorService singleTaskExecutor = Executors.newSingleThreadExecutor();
+    private volatile boolean monitorActive = true;
 
     @Inject
     public ActiveClusterMonitor(

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/HealthCheckObserver.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/HealthCheckObserver.java
@@ -15,6 +15,8 @@ package io.trino.gateway.ha.clustermonitor;
 
 import io.trino.gateway.ha.router.RoutingManager;
 
+import java.util.List;
+
 public class HealthCheckObserver
         implements TrinoClusterStatsObserver
 {
@@ -26,7 +28,7 @@ public class HealthCheckObserver
     }
 
     @Override
-    public void observe(java.util.List<ClusterStats> clustersStats)
+    public void observe(List<ClusterStats> clustersStats)
     {
         routingManager.updateBackEndStats(clustersStats);
     }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
@@ -126,7 +126,6 @@ public abstract class RoutingManager
 
     public void updateBackEndHealth(String backendId, Boolean value)
     {
-        log.info("backend %s isHealthy %s", backendId, value);
         backendToHealth.put(backendId, value);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

As different routing rules are implemented, `routingManager.updateBackEndStats` method could be overridden. An example is https://github.com/trinodb/trino-gateway/blob/c052bb237450d7fc2f2f7af1b06f7fc8f4cdee48/gateway-ha/src/main/java/io/trino/gateway/ha/router/QueryCountBasedRouter.java#L238-L241

Therefore, it will be more useful to log unhealthy clusters at `ActiveClusterMonitor` level instead of `RoutingManager` level 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* 
```
