### PR TITLE
Add link to Trino docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,6 +83,8 @@ terminated at the Trino Gateway. Normally it refuses to authenticate plain HTTP
 requests, but if `http-server.process-forwarded=true` it authenticates over 
 HTTP if the request includes `X-Forwarded-Proto: HTTPS`.
 
+Find more information in [the related Trino documentation](https://trino.io/docs/current/security/tls.html#use-a-load-balancer-to-terminate-tls-https).
+
 ## Configuration
 
 After downloading or building the JAR, rename it to `gateway-ha.jar`,


### PR DESCRIPTION
## Description

- For process forwarded flag
- Related to using HTTPS terminating load balancer

## Additional context and related issues

* https://github.com/trinodb/trino/pull/22166

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
