### PR TITLE
Fix broken renderings of code blocks in docs

### DIFF
--- a/docs/gateway-api.md
+++ b/docs/gateway-api.md
@@ -2,7 +2,7 @@
 
 ## Add or update a backend
 
-```$xslt
+```bash
 curl -X POST http://localhost:8080/entity?entityType=GATEWAY_BACKEND \
  -d '{  "name": "trino-3",
         "proxyTo": "http://localhost:8083",
@@ -15,7 +15,7 @@ If the backend URL is different from the `proxyTo` URL (for example if they are
 internal vs. external hostnames). You can use the optional `externalUrl` field
 to override the link in the Active Backends page.
 
-```$xslt
+```bash
 curl -X POST http://localhost:8080/entity?entityType=GATEWAY_BACKEND \
  -d '{  "name": "trino-3",
         "proxyTo": "http://localhost:8083",
@@ -28,7 +28,7 @@ curl -X POST http://localhost:8080/entity?entityType=GATEWAY_BACKEND \
 ## Get all backends
 
 `curl -X GET http://localhost:8080/entity/GATEWAY_BACKEND`
-```$xslt
+```json
 [
     {
         "name": "trino-1",
@@ -56,21 +56,24 @@ curl -X POST http://localhost:8080/entity?entityType=GATEWAY_BACKEND \
 
 ## Delete a backend
 
-```$xslt
+```bash
 curl -X POST -d "trino3" http://localhost:8080/gateway/backend/modify/delete
 ```
 
 ## Deactivate a backend
 
-```$xslt
+```bash
 curl -X POST http://localhost:8080/gateway/backend/deactivate/trino-2
 ```
 
 ## Get all active backends
 
-`curl -X GET http://localhost:8080/gateway/backend/active`
-
+```bash
+curl -X GET http://localhost:8080/gateway/backend/active
 ```
+
+Will return a JSON array of active Trino cluster backends:
+```json
 [
     {
         "name": "trino-1",
@@ -84,5 +87,7 @@ curl -X POST http://localhost:8080/gateway/backend/deactivate/trino-2
 
 ## Activate a backend
 
-`curl -X POST http://localhost:8080/gateway/backend/activate/trino-2`
+```bash
+curl -X POST http://localhost:8080/gateway/backend/activate/trino-2
+```
 

--- a/docs/resource-groups-api.md
+++ b/docs/resource-groups-api.md
@@ -7,7 +7,7 @@ resource groups and selector tables. To use this, just specify the query
 parameter ?useSchema=<schemaname> to the request. Example, to list all resource
 groups,
 
-```$xslt
+```bash
 curl -X GET http://localhost:8080/trino/resourcegroup/read/{INSERT_ID_HERE}?useSchema=newdatabasename
 ```
 
@@ -17,7 +17,7 @@ To add a single resource group, specify all relevant fields in the body.
 Resource group id should not be specified since the database should
 autoincrement it.
 
-```$xslt
+```bash
 curl -X POST http://localhost:8080/trino/resourcegroup/create \
  -d '{
         "name": "resourcegroup1", \
@@ -40,7 +40,7 @@ curl -X POST http://localhost:8080/trino/resourcegroup/create \
 If no resourceGroupId (type long) is specified, then all existing resource
 groups are fetched.
 
-```$xslt
+```bash
 curl -X GET http://localhost:8080/trino/resourcegroup/read/{INSERT_ID_HERE}
 ```
 
@@ -49,7 +49,7 @@ curl -X GET http://localhost:8080/trino/resourcegroup/read/{INSERT_ID_HERE}
 Specify all columns in the body, which will overwrite properties for the
 resource group with that specific resourceGroupId.
 
-```$xslt
+```bash
 curl -X POST http://localhost:8080/trino/resourcegroup/update \
  -d '{  "resourceGroupId": 1, \
         "name": "resourcegroup_updated", \
@@ -72,7 +72,7 @@ curl -X POST http://localhost:8080/trino/resourcegroup/update \
 To delete a resource group, specify the corresponding resourceGroupId (type
 long).
 
-```$xslt
+```bash
 curl -X POST http://localhost:8080/trino/resourcegroup/delete/{INSERT_ID_HERE}
 ```
 
@@ -81,7 +81,7 @@ curl -X POST http://localhost:8080/trino/resourcegroup/delete/{INSERT_ID_HERE}
 To add a single selector, specify all relevant fields in the body. Resource
 group id should not be specified since the database should autoincrement it.
 
-```$xslt
+```bash
 curl -X POST http://localhost:8080/trino/selector/create \
  -d '{
         "priority": 1, \
@@ -96,7 +96,7 @@ curl -X POST http://localhost:8080/trino/selector/create \
 If no resourceGroupId (type long) is specified, then all existing selectors are
 fetched.
 
-```$xslt
+```bash
 curl -X GET http://localhost:8080/trino/selector/read/{INSERT_ID_HERE}
 ```
 
@@ -108,7 +108,7 @@ fields under "current". The updated version of that selector is specified under
 does not exist, a new selector will be created with the details under "update".
 Both "current" and "update" must be included to update a selector.
 
-```$xslt
+```bash
 curl -X POST http://localhost:8080/trino/selector/update \
  -d '{  "current": {
             "resourceGroupId": 1, \
@@ -131,7 +131,7 @@ curl -X POST http://localhost:8080/trino/selector/update \
 
 To delete a selector, specify all relevant fields in the body.
 
-```$xslt
+```bash
 curl -X POST http://localhost:8080/trino/selector/delete \
  -d '{  "resourceGroupId": 1, \
         "priority": 2, \
@@ -145,7 +145,7 @@ curl -X POST http://localhost:8080/trino/selector/delete \
 
 To add a single global property, specify all relevant fields in the body.
 
-```$xslt
+```bash
 curl -X POST http://localhost:8080/trino/globalproperty/create \
  -d '{
         "name": "cpu_quota_period", \
@@ -158,7 +158,7 @@ curl -X POST http://localhost:8080/trino/globalproperty/create \
 If no name (type String) is specified, then all existing global properties are
 fetched.
 
-```$xslt
+```bash
 curl -X GET http://localhost:8080/trino/globalproperty/read/{INSERT_NAME_HERE}
 ```
 
@@ -167,7 +167,7 @@ curl -X GET http://localhost:8080/trino/globalproperty/read/{INSERT_NAME_HERE}
 Specify all columns in the body, which will overwrite properties for the global
 property with that specific name.
 
-```$xslt
+```bash
 curl -X POST http://localhost:8080/trino/globalproperty/update \
  -d '{
         "name": "cpu_quota_period", \
@@ -179,6 +179,6 @@ curl -X POST http://localhost:8080/trino/globalproperty/update \
 
 To delete a global property, specify the corresponding name (type String).
 
-```$xslt
+```bash
 curl -X POST http://localhost:8080/trino/globalproperty/delete/{INSERT_NAME_HERE}
 ```


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Two docs pages were leveraging the `$xslt` tag for syntax highlighting of fenced code blocks which broke mkdocs rendering. It appears that the **```$xslt** line is treated like a regular line of text. The syntax tags have been updated to leverage bash and json instead.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* 
```

## Validation

### Before

<img src="https://github.com/trinodb/trino-gateway/assets/10821555/fc14c4e2-9f75-497a-81f3-f977b7e827b2" width="300" height="800">

<img src="https://github.com/trinodb/trino-gateway/assets/10821555/e7de4ef6-afdb-463d-b096-5c21e16ec4fb" width="200" height="800">

### After

<img src="https://github.com/trinodb/trino-gateway/assets/10821555/b6f5e53f-371c-4adf-a326-360f07beab9d" width="300" height="800">

<img src="https://github.com/trinodb/trino-gateway/assets/10821555/3cdea6c7-4eef-4268-8707-1d3a6c5d5991" width="200" height="800">
