### PR TITLE
Set SameSite to LAX for OidcCookie

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/OidcCookie.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/OidcCookie.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.trino.gateway.ha.resource.LoginResource.CALLBACK_ENDPOINT;
-import static jakarta.ws.rs.core.NewCookie.SameSite.STRICT;
+import static jakarta.ws.rs.core.NewCookie.SameSite.LAX;
 
 public class OidcCookie
 {
@@ -42,7 +42,7 @@ public class OidcCookie
                 .value(String.join(DELIMITER, state, nonce))
                 .path(CALLBACK_ENDPOINT)
                 .maxAge(TOKEN_EXPIRATION_SECOND)
-                .sameSite(STRICT)
+                .sameSite(LAX)
                 .secure(true)
                 .httpOnly(true)
                 .build();
@@ -71,7 +71,7 @@ public class OidcCookie
                 .value("delete")
                 .path(CALLBACK_ENDPOINT)
                 .maxAge(0)
-                .sameSite(STRICT)
+                .sameSite(LAX)
                 .secure(true)
                 .httpOnly(true)
                 .build();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
OidcCookie should be using `SameSite=LAX` instead of `SameSite=STRICT`.
A redirect from OAuth provider to gateway will cause the cookie being blocked when `SameSite=STRICT`.
(See https://stackoverflow.com/a/42220786)

The tests missed this issue because Dropwizard ignored the SameSite setting and didn't set it at all (looks like a bug). I discovered this issue when I was testing it on Airlift.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://github.com/trinodb/trino-gateway/blob/5d7e30c2fd94ac3279cd77dec5724f9904f5690a/gateway-ha/src/main/java/io/trino/gateway/ha/security/OidcCookie.java#L45

`SameSite` is missing:
```
$ curl -vvvv -k -XPOST https://localhost:9080/sso
...
< HTTP/1.1 200 OK
< Date: Thu, 30 May 2024 05:34:14 GMT
< Strict-Transport-Security: max-age=2000; includeSubDomains
< Date: Thu, 30 May 2024 05:34:14 GMT
< Set-Cookie: __Secure-Trino-Gateway-OIDC=HQDoopcbIUUx-yqghjdWUVlm8EgTd3wC01FLVGLVWmA|JSUAeL158R-0vFIMwFmXyKS-00XRhTzlD_y6hiYlW2A;Version=1;Path=oidc/callback;Max-Age=900;Secure;HttpOnly
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
