### PR TITLE
Remove unnecessary CONCAT function

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/QueryHistoryDao.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/QueryHistoryDao.java
@@ -62,7 +62,7 @@ public interface QueryHistoryDao
     Long count(@Define("condition") String condition);
 
     @SqlQuery("""
-            SELECT CONCAT(FLOOR(created / 1000 / 60)) AS minute,
+            SELECT CONCAT(FLOOR(created / 1000 / 60)::text) AS minute,
                    backend_url AS backend_url,
                    COUNT(1) AS query_count
             FROM query_history

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/QueryHistoryDao.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/QueryHistoryDao.java
@@ -62,7 +62,7 @@ public interface QueryHistoryDao
     Long count(@Define("condition") String condition);
 
     @SqlQuery("""
-            SELECT CONCAT(FLOOR(created / 1000 / 60)::text) AS minute,
+            SELECT FLOOR(created / 1000 / 60) AS minute,
                    backend_url AS backend_url,
                    COUNT(1) AS query_count
             FROM query_history

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
@@ -122,7 +122,7 @@ public class HaQueryHistoryManager
         List<DistributionResponse.LineChart> resList = new ArrayList<>();
         for (Map<String, Object> model : results) {
             DistributionResponse.LineChart lineChart = new DistributionResponse.LineChart();
-            long minute = Long.parseLong(model.get("minute").toString());
+            long minute = (long) Float.parseFloat(model.get("minute").toString());
             Instant instant = Instant.ofEpochSecond(minute * 60L);
             LocalDateTime dateTime = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryHistoryManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryHistoryManager.java
@@ -15,12 +15,14 @@ package io.trino.gateway.ha.router;
 
 import io.trino.gateway.ha.domain.response.DistributionResponse;
 import io.trino.gateway.ha.persistence.JdbcConnectionManager;
+import io.trino.gateway.ha.persistence.dao.QueryHistoryDao;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static io.trino.gateway.ha.TestingJdbcConnectionManager.createTestingJdbcConnectionManager;
@@ -91,5 +93,21 @@ public class TestQueryHistoryManager
         // Should return 1 entry
         resList = queryHistoryManager.findDistribution(currentTime);
         assertThat(resList).hasSize(1);
+    }
+
+    @Test
+    public void testTimestampParsing()
+    {
+        long result = 30338640;
+
+        // postgres: minute -> {Double@9333} 3.033864E7
+        String postgresTimestamp = "3.033864E7";
+        long parsedLongTimestamp = (long) Float.parseFloat(postgresTimestamp);
+        assertThat(parsedLongTimestamp).isEqualTo(result);
+
+        // mysql: minute -> {BigDecimal@9775} "30338640"
+        String mysqlTimestamp = "30338640";
+        long parsedLongTimestamp2 = (long) Float.parseFloat(mysqlTimestamp);
+        assertThat(parsedLongTimestamp2).isEqualTo(result);
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryHistoryManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryHistoryManager.java
@@ -13,6 +13,7 @@
  */
 package io.trino.gateway.ha.router;
 
+import io.trino.gateway.ha.domain.response.DistributionResponse;
 import io.trino.gateway.ha.persistence.JdbcConnectionManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -68,5 +69,27 @@ public class TestQueryHistoryManager
         queryDetails = queryHistoryManager.fetchQueryHistory(Optional.of("other-user"));
         // Only 1 query when user is 'other-user'
         assertThat(queryDetails).hasSize(1);
+    }
+
+    @Test
+    public void testFindDistribution()
+    {
+        long currentTime = System.currentTimeMillis();
+        List<DistributionResponse.LineChart> resList = queryHistoryManager.findDistribution(currentTime);
+        // Should return empty list
+        assertThat(resList).isEmpty();
+
+        QueryHistoryManager.QueryDetail queryDetail = new QueryHistoryManager.QueryDetail();
+        queryDetail.setBackendUrl("http://localhost:9999");
+        queryDetail.setSource("sqlWorkbench");
+        queryDetail.setUser("test@ea.com");
+        queryDetail.setQueryText("select 1");
+        queryDetail.setQueryId(String.valueOf(System.currentTimeMillis()));
+        queryDetail.setCaptureTime(System.currentTimeMillis());
+        queryHistoryManager.submitQueryDetail(queryDetail);
+
+        // Should return 1 entry
+        resList = queryHistoryManager.findDistribution(currentTime);
+        assertThat(resList).hasSize(1);
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryHistoryManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryHistoryManager.java
@@ -15,14 +15,12 @@ package io.trino.gateway.ha.router;
 
 import io.trino.gateway.ha.domain.response.DistributionResponse;
 import io.trino.gateway.ha.persistence.JdbcConnectionManager;
-import io.trino.gateway.ha.persistence.dao.QueryHistoryDao;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static io.trino.gateway.ha.TestingJdbcConnectionManager.createTestingJdbcConnectionManager;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Resolves the following error when using Spanner by Explicitly Cast text values in [CONCAT function](https://cloud.google.com/spanner/docs/reference/postgresql/functions-and-operators#string_functions). 

`SELECT CONCAT(FLOOR(created / 1000 / 60)::text) AS minute,`

<details><summary>Resolved the following error</summary>

```
trino-gateway org.jdbi.v3.core.statement.UnableToExecuteStatementException: org.postgresql.util.PSQLException: ERROR: Postgres function concat(double precision) is not supported - Statement: 'SELECT CONCAT(FLOOR(created / 1000 / 60)) AS minute,
trino-gateway        backend_url AS backend_url,
trino-gateway        COUNT(1) AS query_count
trino-gateway FROM query_history
trino-gateway WHERE created > $1
trino-gateway GROUP BY minute, backend_url
trino-gateway ' [statement:"SELECT CONCAT(FLOOR(created / 1000 / 60)) AS minute,
trino-gateway        backend_url AS backend_url,
trino-gateway        COUNT(1) AS query_count
trino-gateway FROM query_history
trino-gateway WHERE created > :created
trino-gateway GROUP BY minute, backend_url
trino-gateway ", arguments:{positional:{0:1717180785232}, named:{created:1717180785232}, finder:[]}]
```

</details>

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* 
```
