### PR TITLE
Fix create new resource group

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/ResourceGroupsDao.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/ResourceGroupsDao.java
@@ -40,6 +40,36 @@ public interface ResourceGroupsDao
 
     @SqlUpdate("""
             INSERT INTO resource_groups (
+                name,
+                parent,
+                jmx_export,
+                scheduling_policy,
+                scheduling_weight,
+                soft_memory_limit,
+                max_queued,
+                hard_concurrency_limit,
+                soft_concurrency_limit,
+                soft_cpu_limit,
+                hard_cpu_limit,
+                environment)
+            VALUES (
+                :name,
+                :parent,
+                :jmxExport,
+                :schedulingPolicy,
+                :schedulingWeight,
+                :softMemoryLimit,
+                :maxQueued,
+                :hardConcurrencyLimit,
+                :softConcurrencyLimit,
+                :softCpuLimit,
+                :hardCpuLimit,
+                :environment)
+            """)
+    void create(@BindBean ResourceGroupsManager.ResourceGroupsDetail resourceGroupsDetail);
+
+    @SqlUpdate("""
+            INSERT INTO resource_groups (
                 resource_group_id,
                 name,
                 parent,

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaResourceGroupsManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaResourceGroupsManager.java
@@ -51,7 +51,7 @@ public class HaResourceGroupsManager
     public ResourceGroupsDetail createResourceGroup(ResourceGroupsDetail resourceGroup,
             @Nullable String routingGroupDatabase)
     {
-        getResourceGroupsDao(routingGroupDatabase).insert(resourceGroup);
+        getResourceGroupsDao(routingGroupDatabase).create(resourceGroup);
         return resourceGroup;
     }
 
@@ -92,7 +92,7 @@ public class HaResourceGroupsManager
         ResourceGroupsDao dao = getResourceGroupsDao(routingGroupDatabase);
         ResourceGroups model = dao.findFirstById(resourceGroup.getResourceGroupId());
         if (model == null) {
-            dao.insert(resourceGroup);
+            dao.create(resourceGroup);
         }
         else {
             dao.update(resourceGroup);

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestTrinoResource.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestTrinoResource.java
@@ -77,7 +77,6 @@ public class TestTrinoResource
     {
         // First resource group and selector(s)
         ResourceGroupsDetail firstResourceGroup = new ResourceGroupsDetail();
-        firstResourceGroup.setResourceGroupId(1234);
         firstResourceGroup.setName("admins");
         firstResourceGroup.setHardConcurrencyLimit(1);
         firstResourceGroup.setSoftMemoryLimit("2%");
@@ -86,14 +85,13 @@ public class TestTrinoResource
         resourceGroupManager.createResourceGroup(firstResourceGroup, null);
 
         SelectorsDetail firstGroupSelector = new SelectorsDetail();
-        firstGroupSelector.setResourceGroupId(1234);
+        firstGroupSelector.setResourceGroupId(1);
         firstGroupSelector.setPriority(5L);
 
         resourceGroupManager.createSelector(firstGroupSelector, null);
 
         // Second resource group and selector(s)
         ResourceGroupsDetail secondResourceGroup = new ResourceGroupsDetail();
-        secondResourceGroup.setResourceGroupId(3456);
         secondResourceGroup.setName("services");
         secondResourceGroup.setHardConcurrencyLimit(34);
         secondResourceGroup.setSoftMemoryLimit("5GB");
@@ -102,14 +100,13 @@ public class TestTrinoResource
         resourceGroupManager.createResourceGroup(secondResourceGroup, null);
 
         SelectorsDetail secondGroupSelector = new SelectorsDetail();
-        secondGroupSelector.setResourceGroupId(3456);
+        secondGroupSelector.setResourceGroupId(2);
         secondGroupSelector.setPriority(9L);
 
         resourceGroupManager.createSelector(secondGroupSelector, null);
 
         // Third resource group (no selectors)
         ResourceGroupsDetail thirdResourceGroup = new ResourceGroupsDetail();
-        thirdResourceGroup.setResourceGroupId(5678);
         thirdResourceGroup.setName("users");
         thirdResourceGroup.setHardConcurrencyLimit(5);
         thirdResourceGroup.setSoftMemoryLimit("67%");
@@ -143,9 +140,9 @@ public class TestTrinoResource
         assertThat(groups.length).isEqualTo(3);
 
         Arrays.sort(groups, (x, y) -> Long.compare(x.getResourceGroupId(), y.getResourceGroupId()));
-        assertThat(groups[0].getResourceGroupId()).isEqualTo(1234);
-        assertThat(groups[1].getResourceGroupId()).isEqualTo(3456);
-        assertThat(groups[2].getResourceGroupId()).isEqualTo(5678);
+        assertThat(groups[0].getResourceGroupId()).isEqualTo(1);
+        assertThat(groups[1].getResourceGroupId()).isEqualTo(2);
+        assertThat(groups[2].getResourceGroupId()).isEqualTo(3);
     }
 
     @Test
@@ -155,7 +152,7 @@ public class TestTrinoResource
     {
         Request request =
                 new Request.Builder()
-                        .url("http://localhost:" + routerPort + "/trino/resourcegroup/read/1234")
+                        .url("http://localhost:" + routerPort + "/trino/resourcegroup/read/1")
                         .get()
                         .build();
         Response response = httpClient.newCall(request).execute();
@@ -165,7 +162,7 @@ public class TestTrinoResource
                 objectMapper.readValue(response.body().string(), ResourceGroupsDetail[].class);
         assertThat(resourceGroups.length).isEqualTo(1);
 
-        assertThat(resourceGroups[0].getResourceGroupId()).isEqualTo(1234);
+        assertThat(resourceGroups[0].getResourceGroupId()).isEqualTo(1);
     }
 
     @Test
@@ -186,8 +183,8 @@ public class TestTrinoResource
         assertThat(selectors.length).isEqualTo(2);
 
         Arrays.sort(selectors, (x, y) -> Long.compare(x.getResourceGroupId(), y.getResourceGroupId()));
-        assertThat(selectors[0].getResourceGroupId()).isEqualTo(1234);
-        assertThat(selectors[1].getResourceGroupId()).isEqualTo(3456);
+        assertThat(selectors[0].getResourceGroupId()).isEqualTo(1);
+        assertThat(selectors[1].getResourceGroupId()).isEqualTo(2);
     }
 
     @Test
@@ -197,7 +194,7 @@ public class TestTrinoResource
     {
         Request request =
                 new Request.Builder()
-                        .url("http://localhost:" + routerPort + "/trino/selector/read/3456")
+                        .url("http://localhost:" + routerPort + "/trino/selector/read/2")
                         .get()
                         .build();
         Response response = httpClient.newCall(request).execute();
@@ -207,7 +204,7 @@ public class TestTrinoResource
                 objectMapper.readValue(response.body().string(), SelectorsDetail[].class);
         assertThat(selectors.length).isEqualTo(1);
 
-        assertThat(selectors[0].getResourceGroupId()).isEqualTo(3456);
+        assertThat(selectors[0].getResourceGroupId()).isEqualTo(2);
     }
 
     @Test
@@ -219,7 +216,7 @@ public class TestTrinoResource
                 RequestBody.create(MediaType.parse("application/json; charset=utf-8"), "");
         Request request =
                 new Request.Builder()
-                        .url("http://localhost:" + routerPort + "/trino/resourcegroup/delete/5678")
+                        .url("http://localhost:" + routerPort + "/trino/resourcegroup/delete/3")
                         .post(requestBody)
                         .build();
         Response response = httpClient.newCall(request).execute();

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestResourceGroupsManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestResourceGroupsManager.java
@@ -50,17 +50,23 @@ public class TestResourceGroupsManager
     {
         ResourceGroupsDetail resourceGroup = new ResourceGroupsDetail();
 
-        resourceGroup.setResourceGroupId(0L);
         resourceGroup.setName("admin");
         resourceGroup.setHardConcurrencyLimit(20);
         resourceGroup.setMaxQueued(200);
         resourceGroup.setJmxExport(true);
         resourceGroup.setSoftMemoryLimit("80%");
-
-        ResourceGroupsDetail newResourceGroup = resourceGroupManager.createResourceGroup(resourceGroup,
+        ResourceGroupsDetail adminResourceGroup = resourceGroupManager.createResourceGroup(resourceGroup,
                 null);
+        assertThat(adminResourceGroup).isEqualTo(resourceGroup);
 
-        assertThat(newResourceGroup).isEqualTo(resourceGroup);
+        resourceGroup.setName("user");
+        resourceGroup.setHardConcurrencyLimit(10);
+        resourceGroup.setMaxQueued(100);
+        resourceGroup.setJmxExport(true);
+        resourceGroup.setSoftMemoryLimit("50%");
+        ResourceGroupsDetail userResourceGroup = resourceGroupManager.createResourceGroup(resourceGroup,
+                null);
+        assertThat(userResourceGroup).isEqualTo(resourceGroup);
     }
 
     @Test
@@ -68,9 +74,9 @@ public class TestResourceGroupsManager
     public void testReadResourceGroup()
     {
         List<ResourceGroupsDetail> resourceGroups = resourceGroupManager.readAllResourceGroups(null);
-        assertThat(resourceGroups).hasSize(1);
+        assertThat(resourceGroups).hasSize(2);
 
-        assertThat(resourceGroups.get(0).getResourceGroupId()).isEqualTo(0L);
+        assertThat(resourceGroups.get(0).getResourceGroupId()).isEqualTo(1L);
         assertThat(resourceGroups.get(0).getName()).isEqualTo("admin");
         assertThat(resourceGroups.get(0).getHardConcurrencyLimit()).isEqualTo(20);
         assertThat(resourceGroups.get(0).getMaxQueued()).isEqualTo(200);
@@ -83,7 +89,7 @@ public class TestResourceGroupsManager
     public void testUpdateResourceGroup()
     {
         ResourceGroupsDetail resourceGroup = new ResourceGroupsDetail();
-        resourceGroup.setResourceGroupId(0L);
+        resourceGroup.setResourceGroupId(1L);
         resourceGroup.setName("admin");
         resourceGroup.setHardConcurrencyLimit(50);
         resourceGroup.setMaxQueued(50);
@@ -92,11 +98,11 @@ public class TestResourceGroupsManager
 
         ResourceGroupsDetail updated = resourceGroupManager.updateResourceGroup(resourceGroup, null);
         List<ResourceGroupsDetail> resourceGroups = resourceGroupManager.readAllResourceGroups(null);
-        assertThat(resourceGroups).containsExactly(updated);
+        assertThat(resourceGroups).contains(updated);
 
         /* Update resourceGroups that do not exist yet.
          *  In this case, new resourceGroups should be created. */
-        resourceGroup.setResourceGroupId(1L);
+        resourceGroup.setResourceGroupId(3L);
         resourceGroup.setName("localization-eng");
         resourceGroup.setHardConcurrencyLimit(50);
         resourceGroup.setMaxQueued(70);
@@ -105,7 +111,7 @@ public class TestResourceGroupsManager
         resourceGroup.setSoftConcurrencyLimit(20);
         resourceGroupManager.updateResourceGroup(resourceGroup, null);
 
-        resourceGroup.setResourceGroupId(3L);
+        resourceGroup.setResourceGroupId(4L);
         resourceGroup.setName("resource_group_3");
         resourceGroup.setHardConcurrencyLimit(10);
         resourceGroup.setMaxQueued(150);
@@ -116,22 +122,29 @@ public class TestResourceGroupsManager
 
         resourceGroups = resourceGroupManager.readAllResourceGroups(null);
 
-        assertThat(resourceGroups).hasSize(3); // updated 2 non-existing groups, so count should be 3
+        assertThat(resourceGroups).hasSize(4); // updated 2 non-existing groups, so count should be 4
 
-        assertThat(resourceGroups.get(0).getResourceGroupId()).isEqualTo(0L);
+        assertThat(resourceGroups.get(0).getResourceGroupId()).isEqualTo(1L);
         assertThat(resourceGroups.get(0).getName()).isEqualTo("admin");
         assertThat(resourceGroups.get(0).getHardConcurrencyLimit()).isEqualTo(50);
         assertThat(resourceGroups.get(0).getMaxQueued()).isEqualTo(50);
         assertThat(resourceGroups.get(0).getJmxExport()).isEqualTo(Boolean.FALSE);
         assertThat(resourceGroups.get(0).getSoftMemoryLimit()).isEqualTo("20%");
 
-        assertThat(resourceGroups.get(1).getResourceGroupId()).isEqualTo(1L);
-        assertThat(resourceGroups.get(1).getName()).isEqualTo("localization-eng");
-        assertThat(resourceGroups.get(1).getHardConcurrencyLimit()).isEqualTo(50);
-        assertThat(resourceGroups.get(1).getMaxQueued()).isEqualTo(70);
+        assertThat(resourceGroups.get(1).getResourceGroupId()).isEqualTo(2L);
+        assertThat(resourceGroups.get(1).getName()).isEqualTo("user");
+        assertThat(resourceGroups.get(1).getHardConcurrencyLimit()).isEqualTo(10);
+        assertThat(resourceGroups.get(1).getMaxQueued()).isEqualTo(100);
         assertThat(resourceGroups.get(1).getJmxExport()).isEqualTo(Boolean.TRUE);
-        assertThat(resourceGroups.get(1).getSoftMemoryLimit()).isEqualTo("20%");
-        assertThat(resourceGroups.get(1).getSoftConcurrencyLimit()).isEqualTo(Integer.valueOf(20));
+        assertThat(resourceGroups.get(1).getSoftMemoryLimit()).isEqualTo("50%");
+
+        assertThat(resourceGroups.get(2).getResourceGroupId()).isEqualTo(3L);
+        assertThat(resourceGroups.get(2).getName()).isEqualTo("localization-eng");
+        assertThat(resourceGroups.get(2).getHardConcurrencyLimit()).isEqualTo(50);
+        assertThat(resourceGroups.get(2).getMaxQueued()).isEqualTo(70);
+        assertThat(resourceGroups.get(2).getJmxExport()).isEqualTo(Boolean.TRUE);
+        assertThat(resourceGroups.get(2).getSoftMemoryLimit()).isEqualTo("20%");
+        assertThat(resourceGroups.get(2).getSoftConcurrencyLimit()).isEqualTo(Integer.valueOf(20));
     }
 
     @Test
@@ -139,18 +152,20 @@ public class TestResourceGroupsManager
     public void testDeleteResourceGroup()
     {
         List<ResourceGroupsDetail> resourceGroups = resourceGroupManager.readAllResourceGroups(null);
-        assertThat(resourceGroups).hasSize(3);
+        assertThat(resourceGroups).hasSize(4);
 
-        assertThat(resourceGroups.get(0).getResourceGroupId()).isEqualTo(0L);
-        assertThat(resourceGroups.get(1).getResourceGroupId()).isEqualTo(1L);
+        assertThat(resourceGroups.get(0).getResourceGroupId()).isEqualTo(1L);
+        assertThat(resourceGroups.get(1).getResourceGroupId()).isEqualTo(2L);
         assertThat(resourceGroups.get(2).getResourceGroupId()).isEqualTo(3L);
+        assertThat(resourceGroups.get(3).getResourceGroupId()).isEqualTo(4L);
 
         resourceGroupManager.deleteResourceGroup(resourceGroups.get(1).getResourceGroupId(), null);
         resourceGroups = resourceGroupManager.readAllResourceGroups(null);
 
-        assertThat(resourceGroups).hasSize(2);
-        assertThat(resourceGroups.get(0).getResourceGroupId()).isEqualTo(0L);
+        assertThat(resourceGroups).hasSize(3);
+        assertThat(resourceGroups.get(0).getResourceGroupId()).isEqualTo(1L);
         assertThat(resourceGroups.get(1).getResourceGroupId()).isEqualTo(3L);
+        assertThat(resourceGroups.get(2).getResourceGroupId()).isEqualTo(4L);
     }
 
     @Test
@@ -158,7 +173,7 @@ public class TestResourceGroupsManager
     public void testCreateSelector()
     {
         SelectorsDetail selector = new SelectorsDetail();
-        selector.setResourceGroupId(0L);
+        selector.setResourceGroupId(1L);
         selector.setPriority(0L);
         selector.setUserRegex("data-platform-admin");
         selector.setSourceRegex("admin");
@@ -178,7 +193,7 @@ public class TestResourceGroupsManager
         List<SelectorsDetail> selectors = resourceGroupManager.readAllSelectors(null);
 
         assertThat(selectors).hasSize(1);
-        assertThat(selectors.get(0).getResourceGroupId()).isEqualTo(0L);
+        assertThat(selectors.get(0).getResourceGroupId()).isEqualTo(1L);
         assertThat(selectors.get(0).getPriority()).isEqualTo(0L);
         assertThat(selectors.get(0).getUserRegex()).isEqualTo("data-platform-admin");
         assertThat(selectors.get(0).getSourceRegex()).isEqualTo("admin");
@@ -193,7 +208,7 @@ public class TestResourceGroupsManager
     {
         SelectorsDetail selector = new SelectorsDetail();
 
-        selector.setResourceGroupId(0L);
+        selector.setResourceGroupId(1L);
         selector.setPriority(0L);
         selector.setUserRegex("data-platform-admin_updated");
         selector.setSourceRegex("admin_updated");
@@ -246,7 +261,7 @@ public class TestResourceGroupsManager
     {
         List<SelectorsDetail> selectors = resourceGroupManager.readAllSelectors(null);
         assertThat(selectors).hasSize(3);
-        assertThat(selectors.get(0).getResourceGroupId()).isEqualTo(0L);
+        assertThat(selectors.get(0).getResourceGroupId()).isEqualTo(1L);
         resourceGroupManager.deleteSelector(selectors.get(0), null);
         selectors = resourceGroupManager.readAllSelectors(null);
 

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestSpecificDbResourceGroupsManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestSpecificDbResourceGroupsManager.java
@@ -53,12 +53,12 @@ public class TestSpecificDbResourceGroupsManager
         super.resourceGroupManager = new HaResourceGroupsManager(connectionManager);
     }
 
-    private void createResourceGroup()
+    private void createResourceGroup(String groupName)
     {
         ResourceGroupsDetail resourceGroup = new ResourceGroupsDetail();
 
         resourceGroup.setResourceGroupId(1L);
-        resourceGroup.setName("admin2");
+        resourceGroup.setName(groupName);
         resourceGroup.setHardConcurrencyLimit(20);
         resourceGroup.setMaxQueued(200);
         resourceGroup.setJmxExport(true);
@@ -77,7 +77,7 @@ public class TestSpecificDbResourceGroupsManager
     @Test
     public void testReadSpecificDbResourceGroup()
     {
-        this.createResourceGroup();
+        this.createResourceGroup("admin2");
         List<ResourceGroupsDetail> resourceGroups = resourceGroupManager
                 .readAllResourceGroups(specificDb);
         assertThat(resourceGroups).isNotNull();
@@ -87,7 +87,7 @@ public class TestSpecificDbResourceGroupsManager
     @Test
     public void testReadSpecificDbSelector()
     {
-        this.createResourceGroup();
+        this.createResourceGroup("admin3");
         ResourceGroupsManager.SelectorsDetail selector = new ResourceGroupsManager.SelectorsDetail();
         selector.setResourceGroupId(1L);
         selector.setPriority(0L);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Create resource group was broken after #287.
`resource_group_id` should be generated by database with AUTO_INCREMENT in DDL.
Tests didn't cover create multiple resource groups so we missed that.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes
(X) Release notes are required, with the following suggested text:

```markdown
* Fix create new resource group
```
