### PR TITLE
Remove non-null restriction for QueryHistory

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/QueryHistory.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/QueryHistory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.gateway.ha.persistence.dao;
 
+import jakarta.annotation.Nullable;
 import org.jdbi.v3.core.mapper.reflect.ColumnName;
 
 import static java.util.Objects.requireNonNull;
@@ -21,8 +22,8 @@ public record QueryHistory(
         @ColumnName("query_id") String queryId,
         @ColumnName("query_text") String queryText,
         @ColumnName("backend_url") String backendUrl,
-        @ColumnName("user_name") String userName,
-        @ColumnName("source") String source,
+        @ColumnName("user_name") @Nullable String userName,
+        @ColumnName("source") @Nullable String source,
         @ColumnName("created") long created)
 {
     public QueryHistory
@@ -30,7 +31,5 @@ public record QueryHistory(
         requireNonNull(queryId, "queryId is null");
         requireNonNull(queryText, "queryText is null");
         requireNonNull(backendUrl, "backendUrl is null");
-        requireNonNull(userName, "userName is null");
-        requireNonNull(source, "source is null");
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Both `userName` and `source` in QueryHistory are nullable.

`userName` (ie. `X-Trino-User`) is optional in request. If not supplied, the session user is automatically determined via user mapping by coordinator. Trino-gateway won't be able to know the user determined by user mapping.

`source` is optional in Trino:
https://github.com/trinodb/trino/blob/edd5d5bec766e90053e7c28ff9c9dc254790fdb0/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryContext.java#L45


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.