### PR TITLE
Fix UI element reordering in the `/cluster` WebUI

### DIFF
--- a/webapp/src/components/cluster.tsx
+++ b/webapp/src/components/cluster.tsx
@@ -23,7 +23,7 @@ export function Cluster() {
   const list = () => {
     backendsApi({})
       .then(data => {
-        setBackendData(data);
+        setBackendData(data.sort((a, b) => a.name.localeCompare(b.name)));
       }).catch(() => { });
   }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fix #331 

UI render the cluster elements using the result from `/webapp/getAllBackends`.
The result from `/webapp/getAllBackends` doesn't guarantee the order of the clusters.
Sorting the clusters before rendering solves the issue.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
* Fix cluster reordering issue in the `/cluster` WebUI
```
