### PR TITLE
Add http-server.process-forwarded to Trino test container

### DIFF
--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaSingleBackend.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaSingleBackend.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.testcontainers.containers.TrinoContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class TestGatewayHaSingleBackend
@@ -41,6 +42,7 @@ public class TestGatewayHaSingleBackend
             throws Exception
     {
         trino = new TrinoContainer("trinodb/trino");
+        trino.withCopyFileToContainer(forClasspathResource("trino-config.properties"), "/etc/trino/config.properties");
         trino.start();
 
         int backendPort = trino.getMappedPort(8080);

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/clustermonitor/TestClusterStatsMonitor.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/clustermonitor/TestClusterStatsMonitor.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
 @TestInstance(PER_CLASS)
 public class TestClusterStatsMonitor
@@ -35,6 +36,7 @@ public class TestClusterStatsMonitor
     public void setUp()
     {
         trino = new TrinoContainer("trinodb/trino");
+        trino.withCopyFileToContainer(forClasspathResource("trino-config.properties"), "/etc/trino/config.properties");
         trino.start();
     }
 

--- a/gateway-ha/src/test/resources/trino-config.properties
+++ b/gateway-ha/src/test/resources/trino-config.properties
@@ -1,0 +1,9 @@
+# COPY from https://github.com/trinodb/trino/blob/master/core/docker/default/etc/config.properties
+coordinator=true
+node-scheduler.include-coordinator=true
+http-server.http.port=8080
+discovery.uri=http://localhost:8080
+catalog.management=${ENV:CATALOG_MANAGEMENT}
+
+# Customize
+http-server.process-forwarded=true


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fix #395 

Trino 451 reject `X-Forwarded-*` headers by default, which causes some tests to fail.
This PR adds `http-server.process-forwarded` to the Trino test container to make Trino accept X-Forwarded-* headers.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

