### PR TITLE
Remove docs for TLS 1.0 and 1.1

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -40,38 +40,6 @@ java -jar gateway-ha-{{VERSION}}-jar-with-dependencies.jar ../gateway-ha-config.
 Follow the separate instructions for building the container and running Trino
 Gateway with docker compose from the `README.md` file in the `docker` folder.
 
-#### Common Run Failures
-
-If you encounter a `Failed to connect to JDBC URL` error with the MySQL backend,
-this may be due to newer versions of Java disabling certain algorithms when
-using SSL/TLS, in particular `TLSv1` and `TLSv1.1`. This causes `Bad handshake`
-errors when connecting to the MySQL server. You can avoid this by enabling
-`TLSv1` and `TLSv1.1` in your JDK, or by adding `sslMode=DISABLED` to your
-connection string.
-
-To enable TLS1 and 1.1, in
-
-```
-${JAVA_HOME}/jre/lib/security/java.security
-```
-
-search for `jdk.tls.disabledAlgorithms`, it should look something like this:
-
-```
-jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
-    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
-    include jdk.disabled.namedCurves
-```
-
-Remove `TLSv1, TLSv1.1` and redo the above steps to build and run
-`trino-gateway`.
-
-If you see test failures while building `trino-gateway` or in an IDE, please run
-`mvn process-classes` to instrument javalite models which are used by the tests.
-Refer to the
-[javalite-examples](https://github.com/javalite/javalite-examples/tree/master/simple-example#instrumentation)
-for more details.
-
 ## Contributing
 
 Want to help build Trino Gateway? Check out our [contributing


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Remove docs for TLS 1.0 and 1.1.
TLS 1.0 and TLS 1.1 were deprecated since 2021.

Refs:
* https://datatracker.ietf.org/doc/html/rfc8996
* https://techcommunity.microsoft.com/t5/windows-it-pro-blog/tls-1-0-and-tls-1-1-soon-to-be-disabled-in-windows/ba-p/3887947

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

