### PR TITLE
Add support for using OIDC claim for authorization

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -62,6 +62,8 @@ authentication:
       - s3
 ```
 
+Set the `privilegesField` to retrieve privileges from an OAuth claim.
+
 ### Note
 
 - For OAuth Trino Gateway uses `oidc/callback` where as Trino uses `oauth2` path
@@ -136,6 +138,8 @@ Trino Gateway supports the following roles in regex string format:
 Users with attributes next to the role will be giving those privileges the
 users. You can use the preset users defined in the yaml file. 
 LDAP Authorization is also supported by adding user attribute configs in file.
+An OAuth claim can be used by setting the `privilegesField` in the OAuth
+configuration.
 
 - Check out [LDAPTestConfig.yml](https://github.com/trinodb/trino-gateway/blob/main/gateway-ha/src/test/resources/auth/ldapTestConfig.yml) file for config details
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/OAuthConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/OAuthConfiguration.java
@@ -28,6 +28,7 @@ public class OAuthConfiguration
     private List<String> scopes;
     private URI redirectUrl;
     private String userIdField;
+    private String privilegesField;
     private List<String> audiences;
     private URI redirectWebUrl;
 
@@ -116,6 +117,16 @@ public class OAuthConfiguration
     public String getUserIdField()
     {
         return this.userIdField;
+    }
+
+    public String getPrivilegesField()
+    {
+        return privilegesField;
+    }
+
+    public void setPrivilegesField(String privilegesField)
+    {
+        this.privilegesField = privilegesField;
     }
 
     public void setUserIdField(String userIdField)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbOAuthManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbOAuthManager.java
@@ -78,6 +78,11 @@ public class LbOAuthManager
         return oauthConfig.getUserIdField();
     }
 
+    public Optional<String> getPrivilegesField()
+    {
+        return Optional.ofNullable(oauthConfig.getPrivilegesField());
+    }
+
     /**
      * Exchanges authorization code for access token.
      * Sets it in a cookie and redirects back to a location.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Close #322
Add support for using OIDC claim for authorization.
An OAuth claim can be used by setting the `privilegesField` in the OAuth configuration.
The privileges retrieved will be match with the `authorization` session.
Privileges field can be `List<String>` or `String`.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
The following example extract privileges from the claim `roles` and match it in authorization.

Config:
```
authentication:
  defaultType: "oauth"
  oauth:
    privilegesField: roles

authorization:
  admin: (.*)ADMIN(.*)
  user: (.*)USER(.*)
  api: (.*)API(.*)
```

Example 1: ID token with a privileges field using the `List<String>` type:
```
{
  "sub": "alice",
  "roles": [
    "ADMIN", "USER"
  ],
  ...
}
```

Example 2: ID token with a privileges field using the `String` type:
```
{
  "sub": "alice",
  "roles": "ADMIN_USER",
  ...
}
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes
(x) Release notes are required, with the following suggested text:

```markdown
* Add support for using OIDC claim for authorization
```
