### PR TITLE
Add release notes for Trino Gateway 10

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,7 +22,7 @@ It  copies the following, necessary files to current directory:
 ```shell
 #!/usr/bin/env sh
 
-VERSION=7
+VERSION=10
 
 # Copy necessary files to current directory
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -94,3 +94,21 @@ The first release of Trino Gateway is based on the
 * Remove concurrency issue from repeated rules file loading. ([#9](https://github.com/trinodb/trino-gateway/pull/9))
 
 [Details about all merged pull requests](https://github.com/trinodb/trino-gateway/pull/52)
+
+## Breaking changes <a name="breaking">
+
+Starting with Trino Gateway 10, release note entries include a [:warning:
+Breaking change:](#breaking) prefix to highlight any changes as potentially 
+breaking changes. The following changes are considered and may require
+adjustments:
+
+* Removal or renaming of configuration properties that may prevent startup or 
+  require configuration changes.
+* Changes to default values for configuration properties that may significantly
+  change the behavior of a system.
+* Updates to the requirements for external systems or software used with 
+  Trino Gateway.
+* Non-backwards compatible changes which may require router modules to 
+  be updated.
+* Otherwise significant changes that requires specific attention from teams 
+  managing a Trino Gateway deployment.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,40 @@
 # Release notes
 
+## Trino Gateway 10 (24 July 2024)
+
+[JAR file gateway-ha-10-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/10/gateway-ha-10-jar-with-dependencies.jar),
+Docker container `trinodb/trino-gateway:10`
+
+* [:warning: Breaking change:](#breaking) Remove support for Dropwizard and
+  Jetty Proxy integration and usage. Add
+  [Airlift](https://github.com/airlift/airlift) as the base application
+  framework as
+  used in Trino. This changes the supported Trino Gateway startup, configuration
+  files, and relevant properties. Find details in the
+  [documentation](quickstart.md), and specifically refer to the
+  [upgrade guide](migration-to-airlift.md) when migrating from older releases.
+  ([#41](https://github.com/trinodb/trino-gateway/issues/41))
+* [:warning: Breaking change:](#breaking) Improve Helm chart reliability and
+  adjust to new Airlift base framework.
+  ([#401](https://github.com/trinodb/trino-gateway/pull/401))
+* Enable routing rules to use query and user details extracted from the HTTP
+  request.
+  ([#325](https://github.com/trinodb/trino-gateway/pull/325))
+* Add support for using an OIDC claim for authorization.
+  ([#322](https://github.com/trinodb/trino-gateway/pull/322))
+* Improve OIDC spec compliance, and add state and nonce verification.
+  ([#348](https://github.com/trinodb/trino-gateway/pull/339))
+* Allow null values for `userName` and `source` in the query history.
+  ([#381](https://github.com/trinodb/trino-gateway/pull/381))
+* Show times in query distribution graph in UI in local time instead of UTC.
+  ([#369](https://github.com/trinodb/trino-gateway/pull/369))
+* Fix problems with secrets, liveness, and readiness templates in Helm chart.
+  ([#348](https://github.com/trinodb/trino-gateway/pull/348))
+* Fix cluster reordering issue in the cluster user interface.
+  ([#331](https://github.com/trinodb/trino-gateway/pull/331))
+* Fix creation of new resource groups.
+  ([#379](https://github.com/trinodb/trino-gateway/pull/379))
+
 ## Trino Gateway 9 (8 May 2024)
 
 [JAR file gateway-ha-9-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/9/gateway-ha-9-jar-with-dependencies.jar),


### PR DESCRIPTION
## Description

Assemble the release notes for Trino Gateway 10 release.

Also adjust rest of docs to version 10

Requirement for #410 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Verification for each pull request

Format: PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

## 9 May 2024

- #341 ✅ rn ✅ docs

## 20 May 2024

- #343 ✅ rn ✅ docs
- #350 ✅ rn ✅ docs

## 23 May 2024

- #348 ✅ rn ✅ docs

## 24 May 2024

- #356 ✅ rn ✅ docs

## 25 May 2024

- #361 ✅ rn ✅ docs

## 27 May 2024

- #345 ✅ rn ✅ docs
- #363 ✅ rn ✅ docs

## 28 May 2024

- #364 ✅ rn ✅ docs
- #289 ✅ rn ✅ docs

## 29 May 2024

- #367 ✅ rn ✅ docs

## 30 May 2024

- #372 ✅ rn ✅ docs
- #329 ✅ rn ✅ docs
- #371 ✅ rn ✅ docs
- #374 ✅ rn ✅ docs

## 31 May 2024

- #352 ✅ rn ✅ docs
- #340 ✅ rn ✅ docs
- #373 ✅ rn ✅ docs

## 3 Jun 2024

- #376 ✅ rn ✅ docs

## 6 Jun 2024

- #381 ✅ rn ✅ docs

## 12 Jun 2024

- #384 ✅ rn ✅ docs

## 15 Jun 2024

- #317 ✅ rn ✅ docs
- #387 ✅ rn ✅ docs

## 17 Jun 2024

- #385 ✅ rn ✅ docs
- #389 ✅ rn ✅ docs

## 18 Jun 2024

- #390 ✅ rn ✅ docs

## 29 Jun 2024

- #382 ✅ rn ✅ docs
- #379 ✅ rn ✅ docs

## 1 Jul 2024

- #396 ✅ rn ✅ docs

## 2 Jul 2024

- #397 ✅ rn ✅ docs

## 3 Jul 2024

- #400 ✅ rn ✅ docs

## 5 Jul 2024

- #403 ✅ rn ✅ docs

## 10 Jul 2024

- #404 ✅ rn ✅ docs
- #405 ✅ rn ✅ docs

## 11 Jul 2024

- #399 ✅ rn ✅ docs

## 16 Jul 2024

- #325 ✅ rn ✅ docs

## 17 Jul 2024

- #413 ✅ rn ✅ docs

## 22 Jul 2024

- #414 ✅ rn ✅ docs
- #412 ✅ rn ✅ docs

## 23 Jul 2024

- #416 ✅ rn ✅ docs