### PR TITLE
Add proxy handler for DELETE method

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -328,6 +328,13 @@
         </dependency>
 
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-client</artifactId>
+            <version>444</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
@@ -53,6 +53,7 @@ import static com.google.common.net.HttpHeaders.X_FORWARDED_PORT;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.http.client.Request.Builder.prepareDelete;
 import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.http.client.Request.Builder.preparePost;
 import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
@@ -102,6 +103,15 @@ public class ProxyRequestHandler
     public void shutdown()
     {
         executor.shutdownNow();
+    }
+
+    public void deleteRequest(
+            HttpServletRequest servletRequest,
+            AsyncResponse asyncResponse,
+            URI remoteUri)
+    {
+        Request.Builder request = prepareDelete();
+        performRequest(remoteUri, servletRequest, asyncResponse, request);
     }
 
     public void getRequest(

--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/RouteToBackendResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/RouteToBackendResource.java
@@ -17,6 +17,7 @@ import com.google.inject.Inject;
 import io.trino.gateway.ha.handler.ProxyHandlerStats;
 import io.trino.gateway.ha.handler.RoutingTargetHandler;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -73,5 +74,14 @@ public class RouteToBackendResource
     {
         String remoteUri = routingTargetHandler.getRoutingDestination(servletRequest);
         proxyRequestHandler.getRequest(servletRequest, asyncResponse, URI.create(remoteUri));
+    }
+
+    @DELETE
+    public void deleteHandler(
+            @Context HttpServletRequest servletRequest,
+            @Suspended AsyncResponse asyncResponse)
+    {
+        String remoteUri = routingTargetHandler.getRoutingDestination(servletRequest);
+        proxyRequestHandler.deleteRequest(servletRequest, asyncResponse, URI.create(remoteUri));
     }
 }


### PR DESCRIPTION
## Description

- Add support for DELETE method on proxyserver


## Additional context and related issues
- Trino client REST API [use DELETE to nextUri terminates a running query](https://trino.io/docs/current/develop/client-protocol.html#http-methods)

## Release notes
( x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
