### PR TITLE
Add external routing group selector

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/RoutingRulesConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/RoutingRulesConfiguration.java
@@ -16,7 +16,9 @@ package io.trino.gateway.ha.config;
 public class RoutingRulesConfiguration
 {
     private boolean rulesEngineEnabled;
+    private RulesType rulesType = RulesType.FILE;
     private String rulesConfigPath;
+    private RulesExternalConfiguration rulesExternalConfiguration;
 
     public RoutingRulesConfiguration() {}
 
@@ -30,6 +32,16 @@ public class RoutingRulesConfiguration
         this.rulesEngineEnabled = rulesEngineEnabled;
     }
 
+    public RulesType getRulesType()
+    {
+        return rulesType;
+    }
+
+    public void setRulesType(RulesType rulesType)
+    {
+        this.rulesType = rulesType;
+    }
+
     public String getRulesConfigPath()
     {
         return this.rulesConfigPath;
@@ -38,5 +50,15 @@ public class RoutingRulesConfiguration
     public void setRulesConfigPath(String rulesConfigPath)
     {
         this.rulesConfigPath = rulesConfigPath;
+    }
+
+    public RulesExternalConfiguration getRulesExternalConfiguration()
+    {
+        return this.rulesExternalConfiguration;
+    }
+
+    public void setRulesExternalConfiguration(RulesExternalConfiguration rulesExternalConfiguration)
+    {
+        this.rulesExternalConfiguration = rulesExternalConfiguration;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/RulesExternalConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/RulesExternalConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.config;
+
+import java.util.List;
+
+public class RulesExternalConfiguration
+{
+    private String urlPath;
+    private List<String> blackListHeaders;
+
+    public String getUrlPath()
+    {
+        return urlPath;
+    }
+
+    public void setUrlPath(String urlPath)
+    {
+        this.urlPath = urlPath;
+    }
+
+    public List<String> getBlackListHeaders()
+    {
+        return this.blackListHeaders;
+    }
+
+    public void setBlackListHeaders(List<String> blackListHeaders)
+    {
+        this.blackListHeaders = blackListHeaders;
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/RulesType.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/RulesType.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.config;
+
+/**
+ * Specifies the sources of routing rules in the Trino Gateway's routing rules engine.
+ *
+ * <p>By default, requests are routed based on the `X-Trino-Routing-Group` header,
+ * or to the default routing group (adhoc) if the header is absent.</p>
+ *
+ * <p>Routing rules can be defined in two ways:</p>
+ * <ul>
+ *   <li><strong>FILE:</strong> Rules are specified in a configuration file.</li>
+ *   <li><strong>EXTERNAL:</strong> Rules are fetched from an external service via an HTTP POST request.</li>
+ * </ul>
+ */
+public enum RulesType
+{
+    /**
+     * Routing rules defined in a configuration file.
+     */
+    FILE,
+
+    /**
+     * Routing rules obtained from an external service.
+     * The service URL can implement dynamic rule changes.
+     */
+    EXTERNAL,
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/ExternalRoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/ExternalRoutingGroupSelector.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.HttpClientConfig;
+import io.airlift.http.client.JsonBodyGenerator;
+import io.airlift.http.client.JsonResponseHandler;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.jetty.JettyHttpClient;
+import io.airlift.json.JsonCodec;
+import io.airlift.log.Logger;
+import io.trino.gateway.ha.config.RequestAnalyzerConfig;
+import io.trino.gateway.ha.config.RulesExternalConfiguration;
+import io.trino.gateway.ha.router.schema.RoutingGroupExternalBody;
+import io.trino.gateway.ha.router.schema.RoutingGroupExternalResponse;
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
+import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static io.airlift.http.client.Request.Builder.preparePost;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static java.util.Collections.list;
+import static java.util.Objects.requireNonNull;
+
+public class ExternalRoutingGroupSelector
+        implements RoutingGroupSelector
+{
+    private static final Logger log = Logger.get(ExternalRoutingGroupSelector.class);
+    private final Set<String> blacklistHeaders;
+    private final URI uri;
+    private final HttpClient httpClient;
+    private final RequestAnalyzerConfig requestAnalyzerConfig;
+    private final TrinoRequestUser.TrinoRequestUserProvider trinoRequestUserProvider;
+    private static final JsonCodec<RoutingGroupExternalBody> ROUTING_GROUP_EXTERNAL_BODY_JSON_CODEC = jsonCodec(RoutingGroupExternalBody.class);
+    private static final JsonResponseHandler<RoutingGroupExternalResponse> ROUTING_GROUP_EXTERNAL_RESPONSE_JSON_RESPONSE_HANDLER =
+            createJsonResponseHandler(jsonCodec(RoutingGroupExternalResponse.class));
+
+    @VisibleForTesting
+    ExternalRoutingGroupSelector(RulesExternalConfiguration rulesExternalConfiguration, RequestAnalyzerConfig requestAnalyzerConfig)
+    {
+        Set<String> defaultBlacklistHeaders = ImmutableSet.of("Content-Length");
+        this.blacklistHeaders = ImmutableSet.<String>builder()
+                .addAll(defaultBlacklistHeaders)
+                .addAll(rulesExternalConfiguration.getBlackListHeaders())
+                .build();
+
+        this.requestAnalyzerConfig = requestAnalyzerConfig;
+        trinoRequestUserProvider = new TrinoRequestUser.TrinoRequestUserProvider(requestAnalyzerConfig);
+        try {
+            this.uri = new URI(requireNonNull(rulesExternalConfiguration.getUrlPath(),
+                    "Invalid URL provided, using routing group header as default."));
+        }
+        catch (URISyntaxException e) {
+            throw new RuntimeException("Invalid URL provided, using "
+                    + "routing group header as default.", e);
+        }
+        httpClient = new JettyHttpClient(new HttpClientConfig());
+    }
+
+    @Override
+    public String findRoutingGroup(HttpServletRequest servletRequest)
+    {
+        Request request;
+        JsonBodyGenerator<RoutingGroupExternalBody> requestBodyGenerator;
+        try {
+            RoutingGroupExternalBody requestBody = createRequestBody(servletRequest);
+            requestBodyGenerator = jsonBodyGenerator(ROUTING_GROUP_EXTERNAL_BODY_JSON_CODEC, requestBody);
+            request = preparePost()
+                    .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                    .addHeaders(getValidHeaders(servletRequest))
+                    .setUri(uri)
+                    .setBodyGenerator(requestBodyGenerator)
+                    .build();
+
+            // Execute the request and get the response
+            RoutingGroupExternalResponse response = httpClient.execute(request, ROUTING_GROUP_EXTERNAL_RESPONSE_JSON_RESPONSE_HANDLER);
+
+            // Check the response and return the routing group
+            if (response == null) {
+                throw new RuntimeException("Unexpected response: null");
+            }
+            else if (response.getErrors() != null && !response.getErrors().isEmpty()) {
+                throw new RuntimeException("Response with error: " + String.join(", ", response.getErrors()));
+            }
+            return response.getRoutingGroup();
+        }
+        catch (Exception e) {
+            log.error(e, "Error occurred while retrieving routing group "
+                    + "from external routing rules processing at " + uri);
+        }
+        return servletRequest.getHeader(ROUTING_GROUP_HEADER);
+    }
+
+    private RoutingGroupExternalBody createRequestBody(HttpServletRequest request)
+    {
+        TrinoQueryProperties trinoQueryProperties = null;
+        TrinoRequestUser trinoRequestUser = null;
+        if (requestAnalyzerConfig.isAnalyzeRequest()) {
+            trinoQueryProperties = new TrinoQueryProperties(request, requestAnalyzerConfig);
+            trinoRequestUser = trinoRequestUserProvider.getInstance(request);
+        }
+
+        return new RoutingGroupExternalBody(
+                Optional.ofNullable(trinoQueryProperties),
+                Optional.ofNullable(trinoRequestUser),
+                "application/json",
+                request.getRemoteUser(),
+                request.getMethod(),
+                request.getRequestURI(),
+                request.getQueryString(),
+                request.getSession(false),
+                request.getRemoteAddr(),
+                request.getRemoteHost(),
+                request.getParameterMap());
+    }
+
+    private Multimap<String, String> getValidHeaders(HttpServletRequest servletRequest)
+    {
+        Multimap<String, String> headers = ArrayListMultimap.create();
+        for (String name : list(servletRequest.getHeaderNames())) {
+            for (String value : list(servletRequest.getHeaders(name))) {
+                // Add all headers to ListMultimap except those in blacklist
+                if (!blacklistHeaders.contains(name)) {
+                    headers.put(name, value);
+                }
+            }
+        }
+        return headers;
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingGroupSelector.java
@@ -14,6 +14,7 @@
 package io.trino.gateway.ha.router;
 
 import io.trino.gateway.ha.config.RequestAnalyzerConfig;
+import io.trino.gateway.ha.config.RulesExternalConfiguration;
 import jakarta.servlet.http.HttpServletRequest;
 
 /**
@@ -39,6 +40,15 @@ public interface RoutingGroupSelector
     static RoutingGroupSelector byRoutingRulesEngine(String rulesConfigPath, RequestAnalyzerConfig requestAnalyzerConfig)
     {
         return new RuleReloadingRoutingGroupSelector(rulesConfigPath, requestAnalyzerConfig);
+    }
+
+    /**
+     * Routing group selector that uses RESTful API
+     * to determine the right routing group.
+     */
+    static RoutingGroupSelector byRoutingExternal(RulesExternalConfiguration rulesExternalConfiguration, RequestAnalyzerConfig requestAnalyzerConfig)
+    {
+        return new ExternalRoutingGroupSelector(rulesExternalConfiguration, requestAnalyzerConfig);
     }
 
     /**

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RuleReloadingRoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RuleReloadingRoutingGroupSelector.java
@@ -60,8 +60,9 @@ public class RuleReloadingRoutingGroupSelector
             lastUpdatedTime = attr.lastModifiedTime().toMillis();
         }
         catch (Exception e) {
-            log.error(e, "Error opening rules configuration file, using "
-                    + "routing group header as default.");
+            throw new RuntimeException("Error opening rules configuration file at "
+                    + rulesConfigPath + "\n"
+                    + "Using routing group header as default.", e);
         }
     }
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingGroupExternalBody.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingGroupExternalBody.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router.schema;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.gateway.ha.router.TrinoQueryProperties;
+import io.trino.gateway.ha.router.TrinoRequestUser;
+import jakarta.servlet.http.HttpSession;
+
+import java.util.Map;
+import java.util.Optional;
+
+public record RoutingGroupExternalBody(
+        Optional<TrinoQueryProperties> trinoQueryProperties,
+        Optional<TrinoRequestUser> trinoRequestUser,
+        String contentType,
+        String remoteUser,
+        String method,
+        String requestURI,
+        String queryString,
+        HttpSession session,
+        String remoteAddr,
+        String remoteHost,
+        Map<String, String[]> parameters)
+{
+    @JsonCreator
+    public RoutingGroupExternalBody(
+            @JsonProperty("trinoQueryProperties") Optional<TrinoQueryProperties> trinoQueryProperties,
+            @JsonProperty("trinoRequestUser") Optional<TrinoRequestUser> trinoRequestUser,
+            @JsonProperty("contentType") String contentType,
+            @JsonProperty("remoteUser") String remoteUser,
+            @JsonProperty("method") String method,
+            @JsonProperty("requestURI") String requestURI,
+            @JsonProperty("queryString") String queryString,
+            @JsonProperty("session") HttpSession session,
+            @JsonProperty("remoteAddr") String remoteAddr,
+            @JsonProperty("remoteHost") String remoteHost,
+            @JsonProperty("parameters") Map<String, String[]> parameters)
+    {
+        this.trinoQueryProperties = trinoQueryProperties;
+        this.trinoRequestUser = trinoRequestUser;
+        this.contentType = contentType;
+        this.remoteUser = remoteUser;
+        this.method = method;
+        this.requestURI = requestURI;
+        this.queryString = queryString;
+        this.session = session;
+        this.remoteAddr = remoteAddr;
+        this.remoteHost = remoteHost;
+        this.parameters = parameters;
+    }
+
+    @Override
+    @JsonProperty
+    public Optional<TrinoQueryProperties> trinoQueryProperties()
+    {
+        return trinoQueryProperties;
+    }
+
+    @Override
+    @JsonProperty
+    public Optional<TrinoRequestUser> trinoRequestUser()
+    {
+        return trinoRequestUser;
+    }
+
+    @Override
+    @JsonProperty
+    public String contentType()
+    {
+        return contentType;
+    }
+
+    @Override
+    @JsonProperty
+    public String remoteUser()
+    {
+        return remoteUser;
+    }
+
+    @Override
+    @JsonProperty
+    public String method()
+    {
+        return method;
+    }
+
+    @Override
+    @JsonProperty
+    public String requestURI()
+    {
+        return requestURI;
+    }
+
+    @Override
+    @JsonProperty
+    public String queryString()
+    {
+        return queryString;
+    }
+
+    @Override
+    @JsonProperty
+    public HttpSession session()
+    {
+        return session;
+    }
+
+    @Override
+    @JsonProperty
+    public String remoteAddr()
+    {
+        return remoteAddr;
+    }
+
+    @Override
+    @JsonProperty
+    public String remoteHost()
+    {
+        return remoteHost;
+    }
+
+    @Override
+    @JsonProperty
+    public Map<String, String[]> parameters()
+    {
+        return parameters;
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingGroupExternalResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingGroupExternalResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router.schema;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class RoutingGroupExternalResponse
+{
+    private final String routingGroup;
+    private final List<String> errors;
+
+    @JsonCreator
+    public RoutingGroupExternalResponse(
+            @JsonProperty("routingGroup") String routingGroup,
+            @JsonProperty("errors") List<String> errors)
+    {
+        this.routingGroup = routingGroup;
+        this.errors = errors;
+    }
+
+    @JsonProperty
+    public String getRoutingGroup()
+    {
+        return routingGroup;
+    }
+
+    @JsonProperty
+    public List<String> getErrors()
+    {
+        return errors;
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbFormAuthManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbFormAuthManager.java
@@ -76,7 +76,7 @@ public class LbFormAuthManager
     }
 
     /**
-     * Login REST API
+     * Login API
      *
      * @param loginForm {@link RestLoginRequest}
      * @return token

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelector.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelector.java
@@ -53,7 +53,7 @@ public class TestRoutingGroupSelector
     RequestAnalyzerConfig requestAnalyzerConfig = new RequestAnalyzerConfig();
 
     @BeforeAll
-    void inititalize()
+    void initialize()
     {
         requestAnalyzerConfig.setAnalyzeRequest(true);
     }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelectorExternal.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelectorExternal.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import com.google.common.collect.Multimap;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.JsonBodyGenerator;
+import io.airlift.http.client.JsonResponseHandler;
+import io.airlift.http.client.Request;
+import io.airlift.json.JsonCodec;
+import io.trino.gateway.ha.config.RequestAnalyzerConfig;
+import io.trino.gateway.ha.config.RulesExternalConfiguration;
+import io.trino.gateway.ha.router.schema.RoutingGroupExternalBody;
+import io.trino.gateway.ha.router.schema.RoutingGroupExternalResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.HttpMethod;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static io.airlift.http.client.Request.Builder.preparePost;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.USER_HEADER;
+import static io.trino.gateway.ha.router.RoutingGroupSelector.ROUTING_GROUP_HEADER;
+import static io.trino.gateway.ha.router.TrinoQueryProperties.TRINO_CATALOG_HEADER_NAME;
+import static io.trino.gateway.ha.router.TrinoQueryProperties.TRINO_SCHEMA_HEADER_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TestRoutingGroupSelectorExternal
+{
+    RequestAnalyzerConfig requestAnalyzerConfig = new RequestAnalyzerConfig();
+    private HttpClient httpClient;
+    private static final JsonResponseHandler<RoutingGroupExternalResponse> ROUTING_GROUP_REST_API_JSON_RESPONSE_HANDLER =
+            createJsonResponseHandler(jsonCodec(RoutingGroupExternalResponse.class));
+
+    @BeforeAll
+    void initialize()
+            throws Exception
+    {
+        requestAnalyzerConfig.setAnalyzeRequest(true);
+        httpClient = Mockito.mock(HttpClient.class);
+    }
+
+    static Stream<RulesExternalConfiguration> provideRoutingRuleExternalConfig()
+    {
+        RulesExternalConfiguration restConfig = new RulesExternalConfiguration();
+        restConfig.setUrlPath("http://localhost:8080/api/public/gateway_rules");
+        restConfig.setBlackListHeaders(new ArrayList<>(List.of("Authorization")));
+        return Stream.of(restConfig);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideRoutingRuleExternalConfig")
+    void testByRoutingRulesExternalEngine(RulesExternalConfiguration rulesExternalConfiguration)
+            throws URISyntaxException
+    {
+        HttpServletRequest mockRequest = prepareMockRequest();
+
+        // Create a mock response
+        RoutingGroupExternalResponse mockResponse = new RoutingGroupExternalResponse("test-group", null);
+
+        // Create ArgumentCaptor
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<JsonResponseHandler<RoutingGroupExternalResponse>> handlerCaptor = ArgumentCaptor.forClass(JsonResponseHandler.class);
+
+        // Mock the behavior of httpClient.execute
+        when(httpClient.execute(requestCaptor.capture(), handlerCaptor.capture())).thenReturn(mockResponse);
+
+        // Create a request body generator
+        RoutingGroupExternalBody requestBody = createRequestBody(mockRequest);
+        JsonBodyGenerator<RoutingGroupExternalBody> requestBodyGenerator = JsonBodyGenerator.jsonBodyGenerator(JsonCodec.jsonCodec(RoutingGroupExternalBody.class), requestBody);
+
+        // Create a request
+        Request request = preparePost()
+                .addHeader("Content-Type", "application/json; charset=utf-8")
+                .setUri(new URI(rulesExternalConfiguration.getUrlPath()))  // Replace with actual URI
+                .setBodyGenerator(requestBodyGenerator)
+                .build();
+
+        // Execute the request
+        RoutingGroupExternalResponse response = httpClient.execute(request, ROUTING_GROUP_REST_API_JSON_RESPONSE_HANDLER);
+
+        // Verify the response
+        assertThat(response.getRoutingGroup())
+                .isEqualTo("test-group");
+
+        // Verify that the execute method was called with the correct parameters
+        verify(httpClient, times(1)).execute(any(Request.class), eq(ROUTING_GROUP_REST_API_JSON_RESPONSE_HANDLER));
+
+        // Verify the captured arguments if needed
+        assertThat(request.getUri()).isEqualTo(requestCaptor.getValue().getUri());
+        assertThat(ROUTING_GROUP_REST_API_JSON_RESPONSE_HANDLER).isEqualTo(handlerCaptor.getValue());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideRoutingRuleExternalConfig")
+    void testApiFailure(RulesExternalConfiguration rulesExternalConfiguration)
+    {
+        RoutingGroupSelector routingGroupSelector =
+                RoutingGroupSelector.byRoutingExternal(rulesExternalConfiguration, requestAnalyzerConfig);
+
+        HttpServletRequest mockRequest = prepareMockRequest();
+        setMockHeaders(mockRequest);
+        // Set a mock header for ROUTING_GROUP_HEADER
+        when(mockRequest.getHeader(ROUTING_GROUP_HEADER)).thenReturn("default-group-api-failure");
+        // Create a mock response that returns error in List<String>
+        RoutingGroupExternalResponse mockResponse = new RoutingGroupExternalResponse("fail-group", List.of("test-api-failure", "400 error"));
+
+        // Create ArgumentCaptor
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<JsonResponseHandler<RoutingGroupExternalResponse>> handlerCaptor = ArgumentCaptor.forClass(JsonResponseHandler.class);
+
+        // Mock the behavior of httpClient.execute
+        when(httpClient.execute(requestCaptor.capture(), handlerCaptor.capture())).thenReturn(mockResponse);
+
+        // Verify the response
+        assertThat(routingGroupSelector.findRoutingGroup(mockRequest))
+                .isEqualTo("default-group-api-failure");
+    }
+
+    @Test
+    void testNullUri()
+    {
+        RulesExternalConfiguration restConfig = new RulesExternalConfiguration();
+        restConfig.setBlackListHeaders(new ArrayList<>(List.of("Authorization")));
+
+        // Assert that a RuntimeException is thrown with message
+        assertThatThrownBy(() -> RoutingGroupSelector.byRoutingExternal(restConfig, requestAnalyzerConfig))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Invalid URL provided, using routing group header as default.");
+    }
+
+    @Test
+    void testBlackListHeader()
+            throws IllegalAccessException, NoSuchMethodException, InvocationTargetException
+    {
+        // set custom RulesExternalConfiguration config
+        RulesExternalConfiguration restConfig = new RulesExternalConfiguration();
+        restConfig.setUrlPath("http://localhost:8080/api/public/gateway_rules");
+        restConfig.setBlackListHeaders(new ArrayList<>(List.of("test-blackList-header")));
+
+        RoutingGroupSelector routingGroupSelector =
+                RoutingGroupSelector.byRoutingExternal(restConfig, requestAnalyzerConfig);
+
+        // Mock headers to be read by mockRequest
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        List<String> customHeaderNames = List.of("test-blackList-header", "not-blacklisted-header");
+        List<String> customBlackListHeaderValues = List.of("test-blacklist-value");
+        List<String> customValidHeaderValues = List.of("not-blacklist-value");
+        Enumeration<String> headerNamesEnumeration = Collections.enumeration(customHeaderNames);
+        when(mockRequest.getHeaderNames()).thenReturn(headerNamesEnumeration);
+        when(mockRequest.getHeaders("test-blackList-header")).thenReturn(Collections.enumeration(customBlackListHeaderValues));
+        when(mockRequest.getHeaders("not-blacklisted-header")).thenReturn(Collections.enumeration(customValidHeaderValues));
+
+        // Use reflection to get valid headers after removing blacklist headers
+        Method getValidHeaders = ExternalRoutingGroupSelector.class.getDeclaredMethod("getValidHeaders", HttpServletRequest.class);
+        getValidHeaders.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        Multimap<String, String> validHeaders = (Multimap<String, String>) getValidHeaders.invoke(routingGroupSelector, mockRequest);
+        assertThat(validHeaders.size()).isEqualTo(1);
+    }
+
+    private HttpServletRequest prepareMockRequest()
+    {
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getMethod()).thenReturn(HttpMethod.POST);
+        return mockRequest;
+    }
+
+    private void setMockHeaders(HttpServletRequest mockRequest)
+    {
+        when(mockRequest.getHeader(TRINO_CATALOG_HEADER_NAME)).thenReturn("default");
+        when(mockRequest.getHeader(TRINO_SCHEMA_HEADER_NAME)).thenReturn("test");
+        when(mockRequest.getHeader(USER_HEADER)).thenReturn("user");
+
+        List<String> defaultHeaderNames = List.of("Accept-Encoding");
+        List<String> defaultAcceptEncodingValues = Arrays.asList("gzip", "deflate", "br");
+        Enumeration<String> headerNamesEnumeration = Collections.enumeration(defaultHeaderNames);
+
+        when(mockRequest.getHeaderNames()).thenReturn(headerNamesEnumeration);
+        for (String name : defaultHeaderNames) {
+            when(mockRequest.getHeaders(name)).thenReturn(Collections.enumeration(defaultAcceptEncodingValues));
+        }
+    }
+
+    private RoutingGroupExternalBody createRequestBody(HttpServletRequest request)
+    {
+        TrinoQueryProperties trinoQueryProperties = null;
+        TrinoRequestUser trinoRequestUser = null;
+        if (requestAnalyzerConfig.isAnalyzeRequest()) {
+            trinoQueryProperties = new TrinoQueryProperties(request, requestAnalyzerConfig);
+            trinoRequestUser = new TrinoRequestUser.TrinoRequestUserProvider(requestAnalyzerConfig).getInstance(request);
+        }
+
+        return new RoutingGroupExternalBody(
+                Optional.ofNullable(trinoQueryProperties),
+                Optional.ofNullable(trinoRequestUser),
+                "application/json",
+                request.getRemoteUser(),
+                request.getMethod(),
+                request.getRequestURI(),
+                request.getQueryString(),
+                request.getSession(false),
+                request.getRemoteAddr(),
+                request.getRemoteHost(),
+                request.getParameterMap());
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add ~RESTful API method of~ external selecting routing group
Allows user to set a RESTful API endpoint that would return routing group.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://trinodb.slack.com/archives/C059KUNPTSP/p1720619490704499
![image](https://github.com/user-attachments/assets/9e54fbbe-00f1-41fb-81d6-997f56c3b248)


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Added external routing group selector. Users can now set a RESTful API endpoint that returns a routing group to be routed.

```