### PR TITLE
Add http-server.process-forwarded to Trino in quickstart doc

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -85,8 +85,8 @@ to the Trino Gateway server started by the preceding script.
 #!/usr/bin/env sh
 
 #Start a pair of trino servers on different ports
-docker run --name trino1 -d -p 8081:8080 trinodb/trino
-docker run --name trino2 -d -p 8082:8080 trinodb/trino
+docker run --name trino1 -d -p 8081:8080 -e JAVA_TOOL_OPTIONS="-Dhttp-server.process-forwarded=true" trinodb/trino
+docker run --name trino2 -d -p 8082:8080 -e JAVA_TOOL_OPTIONS="-Dhttp-server.process-forwarded=true" trinodb/trino
 
 #Add the trino servers as Gateway backends
 curl -H "Content-Type: application/json" -X POST localhost:8080/gateway/backend/modify/add -d '{"name": "trino1",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Trino 451 reject X-Forwarded-* headers by default, so following quickstart guide doesn't work properly.
This PR guides `JAVA_TOOL_OPTIONS` when running Trino image.
- I find this much simpler than creating and mouting config.properties file 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino-gateway/pull/396

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* 
```
