### PR TITLE
Make ClusterStatsMonitor http client options can configurable

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -211,3 +211,11 @@ Trino Gateway should be added:
 -Djavax.net.ssl.trustStore=<truststore file>
 -Djavax.net.ssl.trustStorePassword=<truststore password>
 ```
+
+If you want to skip the hostname validation for a self-signed certificate, 
+the `serverConfig` configuration file should contain the following:
+
+```
+proxy.http-client.https.hostname-verification: false
+monitor.http-client.https.hostname-verification: false
+```

--- a/gateway-ha/src/main/java/io/trino/gateway/baseapp/BaseApp.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/baseapp/BaseApp.java
@@ -18,6 +18,7 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 import io.airlift.log.Logger;
+import io.trino.gateway.ha.clustermonitor.ForMonitor;
 import io.trino.gateway.ha.config.HaGatewayConfiguration;
 import io.trino.gateway.ha.handler.ProxyHandlerStats;
 import io.trino.gateway.ha.module.RouterBaseModule;
@@ -166,5 +167,6 @@ public class BaseApp
         jaxrsBinder(binder).bind(RouterPreMatchContainerRequestFilter.class);
         jaxrsBinder(binder).bind(ProxyRequestHandler.class);
         httpClientBinder(binder).bindHttpClient("proxy", ForProxy.class);
+        httpClientBinder(binder).bindHttpClient("monitor", ForMonitor.class);
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterStatsInfoApiMonitor.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterStatsInfoApiMonitor.java
@@ -14,10 +14,8 @@
 package io.trino.gateway.ha.clustermonitor;
 
 import io.airlift.http.client.HttpClient;
-import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.JsonResponseHandler;
 import io.airlift.http.client.Request;
-import io.airlift.http.client.jetty.JettyHttpClient;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,14 +26,19 @@ import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
 import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.json.JsonCodec.jsonCodec;
+import static java.util.Objects.requireNonNull;
 
 public class ClusterStatsInfoApiMonitor
         implements ClusterStatsMonitor
 {
-    //TODO: make client options configurable
-    private static final HttpClient client = new JettyHttpClient(new HttpClientConfig());
     private static final Logger log = LoggerFactory.getLogger(ClusterStatsInfoApiMonitor.class);
     private static final JsonResponseHandler<ServerInfo> SERVER_INFO_JSON_RESPONSE_HANDLER = createJsonResponseHandler(jsonCodec(ServerInfo.class));
+    private final HttpClient client;
+
+    public ClusterStatsInfoApiMonitor(HttpClient client)
+    {
+        this.client = requireNonNull(client, "client is null");
+    }
 
     @Override
     public ClusterStats monitor(ProxyBackendConfiguration backend)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ForMonitor.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ForMonitor.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.clustermonitor;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface ForMonitor
+{
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/module/ClusterStatsMonitorModule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/module/ClusterStatsMonitorModule.java
@@ -16,10 +16,12 @@ package io.trino.gateway.ha.module;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import io.airlift.http.client.HttpClient;
 import io.trino.gateway.ha.clustermonitor.ClusterStatsHttpMonitor;
 import io.trino.gateway.ha.clustermonitor.ClusterStatsInfoApiMonitor;
 import io.trino.gateway.ha.clustermonitor.ClusterStatsJdbcMonitor;
 import io.trino.gateway.ha.clustermonitor.ClusterStatsMonitor;
+import io.trino.gateway.ha.clustermonitor.ForMonitor;
 import io.trino.gateway.ha.clustermonitor.NoopClusterStatsMonitor;
 import io.trino.gateway.ha.config.ClusterStatsConfiguration;
 import io.trino.gateway.ha.config.HaGatewayConfiguration;
@@ -38,14 +40,14 @@ public class ClusterStatsMonitorModule
 
     @Provides
     @Singleton
-    public ClusterStatsMonitor getClusterStatsMonitor()
+    public ClusterStatsMonitor getClusterStatsMonitor(@ForMonitor HttpClient httpClient)
     {
         ClusterStatsConfiguration clusterStatsConfig = config.getClusterStatsConfiguration();
         if (config.getBackendState() == null) {
-            return new ClusterStatsInfoApiMonitor();
+            return new ClusterStatsInfoApiMonitor(httpClient);
         }
         return switch (clusterStatsConfig.getMonitorType()) {
-            case INFO_API -> new ClusterStatsInfoApiMonitor();
+            case INFO_API -> new ClusterStatsInfoApiMonitor(httpClient);
             case UI_API -> new ClusterStatsHttpMonitor(config.getBackendState());
             case JDBC -> new ClusterStatsJdbcMonitor(config.getBackendState());
             case NOOP -> new NoopClusterStatsMonitor();

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/clustermonitor/TestClusterStatsMonitor.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/clustermonitor/TestClusterStatsMonitor.java
@@ -13,6 +13,8 @@
  */
 package io.trino.gateway.ha.clustermonitor;
 
+import io.airlift.http.client.HttpClientConfig;
+import io.airlift.http.client.jetty.JettyHttpClient;
 import io.trino.gateway.ha.config.BackendStateConfiguration;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 import org.junit.jupiter.api.AfterAll;
@@ -61,7 +63,7 @@ public class TestClusterStatsMonitor
     @Test
     public void testInfoApiMonitor()
     {
-        testClusterStatsMonitor(ignored -> new ClusterStatsInfoApiMonitor());
+        testClusterStatsMonitor(ignored -> new ClusterStatsInfoApiMonitor(new JettyHttpClient(new HttpClientConfig())));
     }
 
     private void testClusterStatsMonitor(Function<BackendStateConfiguration, ClusterStatsMonitor> monitorFactory)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Make ClusterStatsMonitor http client options can configurable.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
#434 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* 
```
