### PR TITLE
Run build with Java 21 and 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [21, 22]
     timeout-minutes: 20
     steps:
       - name: Checkout source
@@ -28,7 +31,7 @@ jobs:
       - name: Install required Java distribution
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
       - name: Build with Maven
         run: $MAVEN clean verify


### PR DESCRIPTION
## Description

Attempting to run build with 21 and 22 like in Trino to enable some safety and move to 22 next. 

## Additional context and related issues

required for https://github.com/trinodb/trino-gateway/pull/441 in my opinion

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
