### PR TITLE
Update github actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install required Java distribution
         uses: actions/setup-java@v4
         with:
@@ -32,16 +32,16 @@ jobs:
           distribution: 'temurin'
       - name: Build with Maven
         run: $MAVEN clean verify
-      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-qemu-action@v3
         with:
           platforms: amd64,arm64,ppc64le
       - name: Build and Test Docker Image
         run: docker/build.sh
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4.2.0
         with:
           version: v3.12.1
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           check-latest: true


### PR DESCRIPTION
## Description

Just a mainteance task .. hoping to get rid of the node20 warning 

```
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, docker/setup-qemu-action@v2, azure/setup-helm@v3, actions/setup-python@v4. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

Follow up - seems to work. No more warnings at https://github.com/trinodb/trino-gateway/actions/runs/10497055629 for example

## Additional context and related issues

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

