### PR TITLE
Use Maven 3.9.9 for build

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.8/apache-maven-3.9.8-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip


### PR DESCRIPTION
## Description

Just a maintenance task... users might need to update mvnd if they use that.. but we dont document or talk about that anyway

## Additional context and related issues

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
