### PR TITLE
Add commonLabels to helm chart

### DIFF
--- a/helm/trino-gateway/templates/_helpers.tpl
+++ b/helm/trino-gateway/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "trino-gateway.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels }}
+{{ tpl (toYaml .Values.commonLabels) . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/trino-gateway/values.yaml
+++ b/helm/trino-gateway/values.yaml
@@ -54,6 +54,7 @@ config:
 
 service:
   type: ClusterIP
+  port: 8080
 
 ingress:
   enabled: false
@@ -109,6 +110,10 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# -- Labels that get applied to every resource's metadata
+commonLabels: {}
+  # example: "some label"
 
 podAnnotations: {}
 


### PR DESCRIPTION
## Description
This PR adds commonLabels to all resources. For some kubernetes instances, it is required to have custom labels.


## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
Add commonLabels to helm chart 
```
