### PR TITLE
Correct OAuth cookie logout behavior

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/GatewayCookie.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/GatewayCookie.java
@@ -177,10 +177,6 @@ public class GatewayCookie
 
     public boolean matchesRoutingPath(String path)
     {
-        if (matchesDeletePath(path)) {
-            return false;
-        }
-
         return unsignedGatewayCookie.getRoutingPaths().stream().anyMatch(path::startsWith);
     }
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/OAuth2GatewayCookie.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/OAuth2GatewayCookie.java
@@ -14,7 +14,10 @@
 package io.trino.gateway.ha.router;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
 import io.trino.gateway.ha.config.OAuth2GatewayCookieConfigurationPropertiesProvider;
+
+import java.util.stream.Stream;
 
 public class OAuth2GatewayCookie
         extends GatewayCookie
@@ -28,7 +31,7 @@ public class OAuth2GatewayCookie
                 NAME,
                 null,
                 backend,
-                ImmutableList.of(OAUTH2_PATH),
+                ImmutableList.copyOf(Streams.concat(Stream.of(OAUTH2_PATH), OAuth2GatewayCookieConfigurationPropertiesProvider.getInstance().getDeletePaths().stream()).toList()),
                 OAuth2GatewayCookieConfigurationPropertiesProvider.getInstance().getDeletePaths(),
                 OAuth2GatewayCookieConfigurationPropertiesProvider.getInstance().getLifetime(),
                 0);

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaMultipleBackend.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaMultipleBackend.java
@@ -49,6 +49,8 @@ public class TestGatewayHaMultipleBackend
     public static final String CUSTOM_RESPONSE = "123";
     public static final String CUSTOM_PATH = "/v1/custom/extra";
 
+    public static final String CUSTOM_LOGOUT = "/custom/logout"; //defined in src/test/resources/test-config-template.yml
+
     private TrinoContainer adhocTrino;
     private TrinoContainer scheduledTrino;
 
@@ -82,7 +84,8 @@ public class TestGatewayHaMultipleBackend
         HaGatewayTestUtils.setPathSpecificResponses(customBackend, ImmutableMap.of(
                 oauthInitiatePath, oauthInitialResponse,
                 oauthCallbackPath, oauthCallbackResponse,
-                CUSTOM_PATH, CUSTOM_RESPONSE));
+                CUSTOM_PATH, CUSTOM_RESPONSE,
+                CUSTOM_LOGOUT, ""));
 
         // seed database
         HaGatewayTestUtils.TestConfig testConfig =
@@ -242,7 +245,7 @@ public class TestGatewayHaMultipleBackend
 
         Request logoutRequest =
                 new Request.Builder()
-                        .url("http://localhost:" + routerPort + "/custom/logout")
+                        .url("http://localhost:" + routerPort + CUSTOM_LOGOUT)
                         .post(requestBody)
                         .addHeader("Cookie", initiateResponse.header("set-cookie"))
                         .build();


### PR DESCRIPTION
## Description

The cookie used for maintaining stickiness during an OAuth2 handshake forwards requests to a path in the `deleteCookiePath` list such as `/logout` to a random backend. The requests should be forwarded to the same backend to allow any server side sessions to be cleaned up. 

## Additional context and related issues



## Release notes

(x ) Release notes are required, with the following suggested text:

```markdown
* Ensure OAuth logout requests are forwarded to the Trino cluster that initiated the handshake.
```
