### PR TITLE
Set X-Forwarded-Host when client using HTTP/2

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
@@ -45,7 +45,6 @@ import java.util.HashMap;
 import java.util.concurrent.ExecutorService;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.net.HttpHeaders.HOST;
 import static com.google.common.net.HttpHeaders.VIA;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_FOR;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_HOST;
@@ -290,9 +289,9 @@ public class ProxyRequestHandler
         requestBuilder.addHeader(X_FORWARDED_FOR, servletRequest.getRemoteAddr());
         requestBuilder.addHeader(X_FORWARDED_PROTO, servletRequest.getScheme());
         requestBuilder.addHeader(X_FORWARDED_PORT, String.valueOf(servletRequest.getServerPort()));
-        String hostHeader = servletRequest.getHeader(HOST);
-        if (hostHeader != null) {
-            requestBuilder.addHeader(X_FORWARDED_HOST, hostHeader);
+        String serverName = servletRequest.getServerName();
+        if (serverName != null) {
+            requestBuilder.addHeader(X_FORWARDED_HOST, serverName);
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Set X-Forwarded-Host when client using HTTP/2.
Fix #451 


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
![image](https://github.com/user-attachments/assets/70904a03-9123-4c4c-ab04-977428274677)
OkHttp convert `Host` header into HTTP/2 `:authority` header, thus the test is valid.

Ref:
https://github.com/square/okhttp/blob/28075d78310e895b4673cd5433a69b80d42433c2/okhttp/src/main/kotlin/okhttp3/internal/http2/Http2ExchangeCodec.kt#L139-L143
https://github.com/square/okhttp/blob/28075d78310e895b4673cd5433a69b80d42433c2/okhttp/src/main/kotlin/okhttp3/internal/http2/Http2ExchangeCodec.kt#L172-L175


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes
(x) Release notes are required, with the following suggested text:

```markdown
* Fix X-Forwarded-Host not being set when client using HTTP/2
```
