### PR TITLE
Add release notes for Trino Gateway 11 and related changes

### DIFF
--- a/docs/operation.md
+++ b/docs/operation.md
@@ -55,14 +55,16 @@ monitor:
   taskDelaySeconds: 10
 ```
 
-## Monitoring
+## Monitoring <a name="monitoring"></a>
 
-Prometheus can be configured to hit the OpenMetrics endpoint using:
+Trino Gateway provides a metrics endpoint that uses the OpenMetrics format at 
+`/metrics`. Use it to monitor Trino Gateway instances with Prometheus and 
+other compatible systems with the following Prometheus configuration:
 
-```
+```yaml
 scrape_configs:
 - job_name: trino_gateway
   static_configs:
     - targets:
-        - localhost:8080
+        - gateway1.example.com:8080
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,7 +22,7 @@ It  copies the following, necessary files to current directory:
 ```shell
 #!/usr/bin/env sh
 
-VERSION=10
+VERSION=11
 
 # Copy necessary files to current directory
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,44 @@
 # Release notes
 
+## Trino Gateway 11 (12 Sep 2024)
+
+[JAR file gateway-ha-11-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/11/gateway-ha-11-jar-with-dependencies.jar),
+Container image `trinodb/trino-gateway:11`
+
+* [:warning: Breaking change:](#breaking) Require Java 22 for build and runtime.
+  ([#441](https://github.com/trinodb/trino-gateway/pull/441))
+* Add support for determining routing group in an external service.
+  ([#423](https://github.com/trinodb/trino-gateway/pull/423))
+* Add an option to forward requests without adding `X-Forwarded-*` HTTP headers
+  with the `addXForwardedHeaders: false` configuration in `routing`.
+  ([#417](https://github.com/trinodb/trino-gateway/pull/417))
+* Add OpenMetrics endpoint to
+  [enable monitoring](operation.md#monitoring) with Prometheus and compatible systems.
+  ([#429](https://github.com/trinodb/trino-gateway/pull/429))
+* Add option to [deactivate hostname verification for the certificate 
+  of the Trino clusters](security.md#cert-trino).
+  ([#436](https://github.com/trinodb/trino-gateway/pull/436))
+* Add option to use additional paths as Trino client REST API endpoints.
+  ([#326](https://github.com/trinodb/trino-gateway/pull/326))
+* Add timeout parameters for INFO_API and JDBC health checks.
+  ([#424](https://github.com/trinodb/trino-gateway/pull/424))
+* Add support for specifying custom labels in the Helm chart `commonLabels`.
+  ([#448](https://github.com/trinodb/trino-gateway/pull/448))
+* Enable routing for requests to kill query processing.
+  ([#427](https://github.com/trinodb/trino-gateway/issues/427))
+* Fix routing functionality and query history issues caused by lowercase 
+  HTTP headers in HTTP/2 connections.
+  ([#450](https://github.com/trinodb/trino-gateway/issues/450))
+* Fix failures when clients use HTTP/2.
+  ([#451](https://github.com/trinodb/trino-gateway/issues/451))
+* Ensure that the user history dashboard displays the correct user name.
+  ([#370](https://github.com/trinodb/trino-gateway/issues/370))
+* Fix incorrect routing of OAuth logout requests.
+  ([#455](https://github.com/trinodb/trino-gateway/pull/455))
+
+More details and a list of all merged pull requests are [available in the 
+milestone 11 list](https://github.com/trinodb/trino-gateway/pulls?q=is%3Apr+milestone%3A11+is%3Aclosed).
+
 ## Trino Gateway 10 (24 Jul 2024)
 
 [JAR file gateway-ha-10-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/10/gateway-ha-10-jar-with-dependencies.jar),

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Trino Gateway 10 (24 July 2024)
+## Trino Gateway 10 (24 Jul 2024)
 
 [JAR file gateway-ha-10-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/10/gateway-ha-10-jar-with-dependencies.jar),
 Docker container `trinodb/trino-gateway:10`

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -3,7 +3,7 @@
 ## Trino Gateway 10 (24 Jul 2024)
 
 [JAR file gateway-ha-10-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/10/gateway-ha-10-jar-with-dependencies.jar),
-Docker container `trinodb/trino-gateway:10`
+Container image `trinodb/trino-gateway:10`
 
 * [:warning: Breaking change:](#breaking) Remove support for Dropwizard and
   Jetty Proxy integration and usage. Add
@@ -38,14 +38,14 @@ Docker container `trinodb/trino-gateway:10`
 ## Trino Gateway 9 (8 May 2024)
 
 [JAR file gateway-ha-9-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/9/gateway-ha-9-jar-with-dependencies.jar),
-Docker container `trinodb/trino-gateway:9`
+Container image `trinodb/trino-gateway:9`
 
 * Ensure inclusion of UI in JAR and container artifacts. ([#337](https://github.com/trinodb/trino-gateway/pull/337))
 
 ## Trino Gateway 8 (6 May 2024)
 
 [JAR file gateway-ha-8-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/8/gateway-ha-8-jar-with-dependencies.jar),
-Docker container `trinodb/trino-gateway:8`
+Container image `trinodb/trino-gateway:8`
 
 * Add support for configurable router policies. ([#98](https://github.com/trinodb/trino-gateway/pull/98))
 * Add a router policy based on query count per cluster. ([#98](https://github.com/trinodb/trino-gateway/pull/98))
@@ -59,7 +59,7 @@ Docker container `trinodb/trino-gateway:8`
 ## Trino Gateway 7 (21 Mar 2024)
 
 [JAR file gateway-ha-7-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/7/gateway-ha-7-jar-with-dependencies.jar),
-Docker container `trinodb/trino-gateway:7`
+Container image `trinodb/trino-gateway:7`
 
 * Replace user interface with a new modern UI. ([#116](https://github.com/trinodb/trino-gateway/pull/116))
 * Improve logging configurability. Users must update to the 
@@ -73,7 +73,7 @@ Docker container `trinodb/trino-gateway:7`
 ## Trino Gateway 6 (16 Feb 2024)
 
 [JAR file gateway-ha-6-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/6/gateway-ha-6-jar-with-dependencies.jar),
-Docker container `trinodb/trino-gateway:6`
+Container image `trinodb/trino-gateway:6`
 
 * Add Docker container build, publishing, and usage setup and instructions. ([#86](https://github.com/trinodb/trino-gateway/issues/86))
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -179,6 +179,7 @@ To limit page access, you can set page permissions by pages
 and `_` as separator field.
 
 The following pages are available:
+
 - `dashboard`
 - `cluster`
 - `resource-group`
@@ -202,7 +203,7 @@ If Trino Gateway is using a self-signed certificate, client should use the
 java -jar trino-cli-executable.jar --server https://localhost:8443 --insecure
 ```
 
-## Extra: Self signed certificate in Trino
+## Extra: Self-signed certificate in Trino <a name="cert-trino"></a>
 
 If Trino is using a self-signed certificate, the following JVM config for
 Trino Gateway should be added:
@@ -213,9 +214,10 @@ Trino Gateway should be added:
 ```
 
 If you want to skip the hostname validation for a self-signed certificate, 
-the `serverConfig` configuration file should contain the following:
+the `serverConfig` configuration should contain the following:
 
-```
-proxy.http-client.https.hostname-verification: false
-monitor.http-client.https.hostname-verification: false
+```yaml
+serverConfig:
+  proxy.http-client.https.hostname-verification: false
+  monitor.http-client.https.hostname-verification: false
 ```

--- a/helm/trino-gateway/Chart.yaml
+++ b/helm/trino-gateway/Chart.yaml
@@ -1,24 +1,8 @@
 apiVersion: v2
 name: trino-gateway
-description: A Helm chart for Kubernetes
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+description: A Helm chart for Trino Gateway
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
+# Trino Gateway Helm chart version. Should be appVersion with .0.0 appended.
 version: "10.0.0"
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
+# Trino Gateway version
 appVersion: "10"

--- a/helm/trino-gateway/Chart.yaml
+++ b/helm/trino-gateway/Chart.yaml
@@ -3,6 +3,6 @@ name: trino-gateway
 description: A Helm chart for Trino Gateway
 type: application
 # Trino Gateway Helm chart version. Should be appVersion with .0.0 appended.
-version: "10.0.0"
+version: "11.0.0"
 # Trino Gateway version
-appVersion: "10"
+appVersion: "11"


### PR DESCRIPTION
## Description

Assemble the release notes for Trino Gateway 11 release.

Also adjust rest of docs to version 11

Requirement for #459

Any dates missing in the list just had no merged PRs.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Verification for each pull request

Format: PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

## 25 Jul 2024

* #421 ✅ rn ✅ docs

## 1 Aug 2024

* #426 ✅ rn ✅ docs

## 11 Aug 2024

* #430 ✅ rn ✅ docs

## 14 Aug 2024

* #436 ✅ rn ✅ docs

## 15 Aug 2024

* #375 ✅ rn ✅ docs

## 20 Aug 2024

* #429 ✅ rn ✅ docs

## 21 Aug 2024

* #431 ✅ rn ✅ docs
* #438 ✅ rn ✅ docs
* #417 ✅ rn ✅ docs
* #443 ✅ rn ✅ docs
* #445 ✅ rn ✅ docs
* #444 ✅ rn ✅ docs

## 26 Aug 2024

* #442 ✅ rn ✅ docs

## 30 Aug 2024

* #457 ✅ rn ✅ docs 
* #456 ✅ rn ✅ docs
* #448 ✅ rn ✅ docs

## 2 Sep 2024

* #439 ✅ rn ✅ docs

## 3 Sep 2024

* #441 ✅ rn ✅ docs

## 4 Sep 2024

* #460 ✅ rn ✅ docs
* #462 ✅ rn ✅ docs

## 5 Sep 2024

* #326 ✅ rn ✅ docs
* #455 ✅ rn ✅ docs 
* #423 ✅ rn ✅ docs

## 9 Sep 2024

* #464 ✅ rn ✅ docs

## 10 Sep 2024

* #424 ✅ rn ✅ docs