### PR TITLE
Add destination cluster info to response cookie

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/HaGatewayConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/HaGatewayConfiguration.java
@@ -41,6 +41,7 @@ public class HaGatewayConfiguration
     private OAuth2GatewayCookieConfiguration oauth2GatewayCookieConfiguration = new OAuth2GatewayCookieConfiguration();
     private GatewayCookieConfiguration gatewayCookieConfiguration = new GatewayCookieConfiguration();
     private List<String> statementPaths = ImmutableList.of(V1_STATEMENT_PATH);
+    private boolean includeClusterHostInResponse;
 
     private RequestAnalyzerConfig requestAnalyzerConfig = new RequestAnalyzerConfig();
 
@@ -242,6 +243,16 @@ public class HaGatewayConfiguration
         // remove trailing slashes to ensure predictable behavior when splitting on "/"
         this.statementPaths = Streams.concat(ImmutableList.of(V1_STATEMENT_PATH).stream(),
                 statementPaths.stream().peek(s -> validateStatementPath(s, statementPaths)).map(s -> s.replaceAll("/+$", ""))).toList();
+    }
+
+    public boolean isIncludeClusterHostInResponse()
+    {
+        return includeClusterHostInResponse;
+    }
+
+    public void setIncludeClusterHostInResponse(boolean includeClusterHostInResponse)
+    {
+        this.includeClusterHostInResponse = includeClusterHostInResponse;
     }
 
     private void validateStatementPath(String statementPath, List<String> statementPaths)

--- a/gateway-ha/src/test/resources/test-config-template.yml
+++ b/gateway-ha/src/test/resources/test-config-template.yml
@@ -2,6 +2,7 @@ serverConfig:
   node.environment: test
   http-server.http.port: REQUEST_ROUTER_PORT
 
+includeClusterHostInResponse: true
 dataStore:
   jdbcUrl: jdbc:h2:DB_FILE_PATH
   user: sa


### PR DESCRIPTION
## Description
Add destination cluster a query is routed to in the cookie. More details here of the use-case here: https://github.com/trinodb/trino-gateway/issues/465

Fixes https://github.com/trinodb/trino-gateway/issues/465


## Release notes

```markdown
* The cookie data for requests to `/v1/statement` API would include the cluster to which a query got routed named as `trinoClusterHost`.
```
