### PR TITLE
Fixed analyze request

### DIFF
--- a/docs/routing-rules.md
+++ b/docs/routing-rules.md
@@ -48,7 +48,7 @@ You can use an external service for processing your routing by setting the
 `rulesType` to `EXTERNAL` and configuring the `rulesExternalConfiguration`.
 
 Trino Gateway then sends all headers as a map in the body of a POST request to the external service.
-Headers specified in `blacklistHeaders` are excluded. If `requestAnalyzerConfig.isAnalyzeRequest` is set to `true`, 
+Headers specified in `blacklistHeaders` are excluded. If `requestAnalyzerConfig.analyzeRequest` is set to `true`, 
 `TrinoRequestUser` and `TrinoQueryProperties` are also included. 
 
 Additionally, the following HTTP information is included:
@@ -164,7 +164,7 @@ username against the extracted user. It will return `False` if a user has not
 been extracted.
 
 User extraction is only available if enabled by configuring
-`requestAnalyzerConfig.isAnalyzeRequest = True`
+`requestAnalyzerConfig.analyzeRequest = True`
 
 ### TrinoQueryProperties
 
@@ -211,7 +211,7 @@ object:
 The `trinoQueryProperties`  are configured under the `requestAnalyzerConfig`
 configuration  node.
 
-#### isAnalyzeRequest
+#### analyzeRequest
 
 Set to `True` to make `trinoQueryProperties` and `trinoRequestUser` available
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes #468


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Objectmapper expects the boolean fields without the `is` prefix. Hence, instead of `isAnalyzeRequest`, `analyzeRequest` should be used for configuration.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
