### PR TITLE
Throw exception when no clusters are found for adhoc routing group

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -273,11 +273,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
         </dependency>

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/QueryCountBasedRouter.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/QueryCountBasedRouter.java
@@ -224,7 +224,7 @@ public class QueryCountBasedRouter
     @Override
     public String provideAdhocBackend(String user)
     {
-        return getBackendForRoutingGroup("adhoc", user).orElseThrow();
+        return getBackendForRoutingGroup("adhoc", user).orElseThrow(() -> new RouterException("did not find any cluster for the adhoc routing group"));
     }
 
     @Override

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/QueryCountBasedRouter.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/QueryCountBasedRouter.java
@@ -17,9 +17,8 @@ package io.trino.gateway.ha.router;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
+import io.airlift.log.Logger;
 import io.trino.gateway.ha.clustermonitor.ClusterStats;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,7 +31,7 @@ import java.util.stream.Collectors;
 public class QueryCountBasedRouter
         extends StochasticRoutingManager
 {
-    private static final Logger log = LoggerFactory.getLogger(QueryCountBasedRouter.class);
+    private static final Logger log = Logger.get(QueryCountBasedRouter.class);
     @GuardedBy("this")
     private List<LocalStats> clusterStats;
 
@@ -185,7 +184,7 @@ public class QueryCountBasedRouter
 
     private synchronized Optional<LocalStats> getClusterToRoute(String user, String routingGroup)
     {
-        log.debug("sorting cluster stats for {} {}", user, routingGroup);
+        log.debug("sorting cluster stats for %s %s", user, routingGroup);
         List<LocalStats> filteredList = clusterStats.stream()
                     .filter(stats -> stats.healthy())
                     .filter(stats -> routingGroup.equals(stats.routingGroup()))

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RouterException.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RouterException.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+public class RouterException
+        extends IllegalStateException
+{
+    public RouterException(String message)
+    {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Description

Adhoc routing group is the fallback routing group if no routing group is provided. If there are no clusters available for this group, we should log and throw an error


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
