### PR TITLE
Update docs to add encoding header to be excluded

### DIFF
--- a/docs/routing-rules.md
+++ b/docs/routing-rules.md
@@ -33,11 +33,13 @@ routingRules:
         urlPath: https://router.example.com/gateway-rules # replace with your own API path
         excludeHeaders:
             - 'Authorization'
+            - 'Accept-Encoding'
 ```
 
 * Redirect URLs are not supported
 * Optionally add headers to the `excludeHeaders` list to exclude requests with corresponding header values
   from being sent in the POST request.
+* Check headers to exclude when making API requests, specifics depend on the network configuration.
 
 If there is error parsing the routing rules configuration file, an error is logged,
 and requests are routed using the routing group header `X-Trino-Routing-Group` as default.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! --> 
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

When decoding JSON response using `io.airlift.http.client#createJsonResponseHandler` at [external routing group selector code](https://github.com/trinodb/trino-gateway/blob/main/gateway-ha/src/main/java/io/trino/gateway/ha/router/ExternalRoutingGroupSelector.java#L98), 
JSON response could be compressed in GZIP (or whatever format) depending on the network configuration.

This is not expecected behaviour by Airlift as it read bytes.
- https://github.com/airlift/airlift/blob/master/http-client/src/main/java/io/airlift/http/client/JsonResponseHandler.java#L68-L91

So, I suggest adding `'Accept-Encoding'` to docs so that user can know they might need to exclude it when making API request to server. 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* 
```
