### PR TITLE
Add parsing error message field to TrinoQueryProperties

### DIFF
--- a/docs/routing-rules.md
+++ b/docs/routing-rules.md
@@ -195,9 +195,10 @@ added to the list of tables in all contexts, including  statements such as
 A routing rule can call the following methods on the `trinoQueryProperties`
 object:
 
+* `String errorMessage()`: the error message only if there was any error while
+  creating `trinoQueryProperties` object. 
 * `boolean isNewQuerySubmission()`: is the request a POST to the `v1/statement`
-  query endpoint.
-* `boolean isQueryParsingSuccessful()`: was the request successfully parsed. 
+  query endpoint. 
 * `String getQueryType()`: the class name of the `Statement`, e.g. `ShowCreate`.
   Note that these are not mapped to the `ResourceGroup` query types. For a full
   list of potential query types, see the classes in

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestTrinoQueryProperties.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestTrinoQueryProperties.java
@@ -38,7 +38,7 @@ final class TestTrinoQueryProperties
                 ImmutableSet.of("s"),
                 ImmutableSet.of("c.s"),
                 true,
-                true);
+                Optional.empty());
 
         String trinoQueryPropertiesJson = codec.toJson(trinoQueryProperties);
         TrinoQueryProperties deserializedTrinoQueryProperties = codec.fromJson(trinoQueryPropertiesJson);
@@ -54,5 +54,6 @@ final class TestTrinoQueryProperties
         assertThat(deserializedTrinoQueryProperties.getCatalogSchemas()).isEqualTo(trinoQueryProperties.getCatalogSchemas());
         assertThat(deserializedTrinoQueryProperties.isNewQuerySubmission()).isEqualTo(trinoQueryProperties.isNewQuerySubmission());
         assertThat(deserializedTrinoQueryProperties.isQueryParsingSuccessful()).isEqualTo(trinoQueryProperties.isQueryParsingSuccessful());
+        assertThat(deserializedTrinoQueryProperties.getErrorMessage()).isEqualTo(trinoQueryProperties.getErrorMessage());
     }
 }


### PR DESCRIPTION
## Description

Add a field (private Optional<String> ParseErrorMessage) to TrinoQueryProperties class that stores `e.getMessage()` when there is error.
https://github.com/trinodb/trino-gateway/blob/main/gateway-ha/src/main/java/io/trino/gateway/ha/router/TrinoQueryProperties.java#L213-L224

We have server connected with gateway that runs explain before actually running the query.
But not all queries need to be sent with explain.

For example there are cases where queries with parsing failure (no need to run explain cause it is highly likely to fail anyway due to syntax error)
- we need to tell user on WHY query has failed, but running another sql parser or explain is waste of resource
- since gateway already does query parsing, why not use that failure info.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
