### PR TITLE
Make startup command configurable

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -248,10 +248,22 @@ helm install tg --values values-override.yaml helm/trino-gateway
 Secrets for `authenticationSecret` and `backendState` can be provisioned
 similarly. Alternatively,  you can directly define the `config.backEndState` 
 node in `values-override.yaml` and leave `backendStateSecret` undefined. 
-However, a [Secret](https://kubernetes.
-io/docs/concepts/configuration/secret/)
-is recommended to protect the  database credentials required for this 
+However, a [Secret](https://kubernetes.io/docs/concepts/configuration/secret/)
+is recommended to protect the database credentials required for this 
 configuration.
+
+By default, the Trino Gateway process is started with the following command:
+
+```shell
+java -XX:MinRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -jar /usr/lib/trino/gateway-ha-jar-with-dependencies.jar /etc/gateway/config.yaml
+```
+
+You can customize details with the `command` node. It accepts a list, that must
+begin with an executable such as `java` or `bash` that is available on the PATH.
+The following list elements are provided as arguments to the executable. It is
+not typically necessary to modify this node. You can use it to change of JVM
+startup parameters to control memory settings and other aspects, or to use other
+configuration file names.
 
 #### Additional options
 

--- a/helm/trino-gateway/templates/deployment.yaml
+++ b/helm/trino-gateway/templates/deployment.yaml
@@ -43,12 +43,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-              - "java"
-              - "-XX:MinRAMPercentage=80.0"
-              - "-XX:MaxRAMPercentage=80.0"
-              - "-jar"
-              - "/usr/lib/trino/gateway-ha-jar-with-dependencies.jar"
-              - "/etc/gateway/config.yaml"
+            {{- toYaml .Values.command | nindent 12}}
           ports:
             - name: request
               containerPort: {{ index .Values "config" "serverConfig" "http-server.http.port" }}

--- a/helm/trino-gateway/values.yaml
+++ b/helm/trino-gateway/values.yaml
@@ -52,7 +52,7 @@ config:
     managedApps:
         - io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor
 
-# Startup command for Trino Gateway process. Add additional java options here if required
+# Startup command for Trino Gateway process. Add additional Java options and other modifications as desired.
 command:
   - "java"
   - "-XX:MinRAMPercentage=80.0"

--- a/helm/trino-gateway/values.yaml
+++ b/helm/trino-gateway/values.yaml
@@ -52,6 +52,15 @@ config:
     managedApps:
         - io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor
 
+# Startup command for Trino Gateway process. Add additional java options here if required
+command:
+  - "java"
+  - "-XX:MinRAMPercentage=80.0"
+  - "-XX:MaxRAMPercentage=80.0"
+  - "-jar"
+  - "/usr/lib/trino/gateway-ha-jar-with-dependencies.jar"
+  - "/etc/gateway/config.yaml"
+
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Make the startup command configurable

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This allows users to set java options such as `-Djavax.net.ssl.truststore=/path/to/truststore`, run short scripts, and otherwise customize startup. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

- ( ) This is not user-visible or is docs only, and no release notes are 
  required.
- ( ) Release notes are required. Please propose a release note for me.
- ( x) Release notes are required, with the following suggested text:
### Helm Chart
Make the startup command configurable
