### PR TITLE
Remove redundant `dep.trino.version` declaration and inline `dep.mysqlconnector.version`

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -24,7 +24,6 @@
         <dep.jeasy.version>4.1.0</dep.jeasy.version>
         <dep.mockito.version>5.13.0</dep.mockito.version>
         <dep.okhttp3.version>4.12.0</dep.okhttp3.version>
-        <dep.mysqlconnector.version>8.3.0</dep.mysqlconnector.version>
         <dep.trino.version>454</dep.trino.version>
     </properties>
 
@@ -280,7 +279,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>${dep.mysqlconnector.version}</version>
+            <version>8.3.0</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -25,7 +25,7 @@
         <dep.mockito.version>5.13.0</dep.mockito.version>
         <dep.okhttp3.version>4.12.0</dep.okhttp3.version>
         <dep.mysqlconnector.version>8.3.0</dep.mysqlconnector.version>
-        <dep.trino.version>446</dep.trino.version>
+        <dep.trino.version>454</dep.trino.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
 
         <!-- Dependency versions, keep sorted -->
         <dep.errorprone.version>2.29.2</dep.errorprone.version>
-        <dep.trino.version>454</dep.trino.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Release notes

- (x) This is not user-visible or is docs only, and no release notes are required.
