### PR TITLE
Enable syntax highlight in documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,13 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
 
 nav:
   - Home:


### PR DESCRIPTION
## Description

https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#configuration

Before this change:
![Screenshot 2024-10-03 at 11 54 48](https://github.com/user-attachments/assets/f9fb90dd-555a-4745-955a-4c440cb114fb)

After this change:
![Screenshot 2024-10-03 at 11 54 07](https://github.com/user-attachments/assets/e2b8d4c8-8894-4558-9239-76b08f2dc5cc)


## Release notes

- (x) This is not user-visible or is docs only, and no release notes are required.
