### PR TITLE
Remove leading `-` from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,9 +16,9 @@ and contact us on #trino-gateway-dev in Slack. -->
 More info at https://trino.io/development/process#release-note -->
 ## Release notes
 
-- ( ) This is not user-visible or is docs only, and no release notes are required.
-- ( ) Release notes are required. Please propose a release note for me.
-- ( ) Release notes are required, with the following suggested text:
+( ) This is not user-visible or is docs only, and no release notes are required.
+( ) Release notes are required. Please propose a release note for me.
+( ) Release notes are required, with the following suggested text:
 
 ```markdown
 * Fix some things. ({issue}`issuenumber`)


### PR DESCRIPTION
## Description

No reason to use a different style from Trino. 

## Release notes

- (x) This is not user-visible or is docs only, and no release notes are required.
