### PR TITLE
Rename QueryIdCachingProxyHandler to HttpUtils

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterStatsHttpMonitor.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterStatsHttpMonitor.java
@@ -34,9 +34,9 @@ import java.util.Map;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.airlift.http.client.HttpStatus.fromStatusCode;
-import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.UI_API_QUEUED_LIST_PATH;
-import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.UI_API_STATS_PATH;
-import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.UI_LOGIN_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.UI_API_QUEUED_LIST_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.UI_API_STATS_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.UI_LOGIN_PATH;
 import static java.util.Objects.requireNonNull;
 
 public class ClusterStatsHttpMonitor

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/HaGatewayConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/HaGatewayConfiguration.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.V1_STATEMENT_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.V1_STATEMENT_PATH;
 
 public class HaGatewayConfiguration
 {

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/HttpUtils.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/HttpUtils.java
@@ -13,7 +13,7 @@
  */
 package io.trino.gateway.ha.handler;
 
-public class QueryIdCachingProxyHandler
+public class HttpUtils
 {
     public static final String V1_STATEMENT_PATH = "/v1/statement";
     public static final String V1_QUERY_PATH = "/v1/query";
@@ -26,5 +26,5 @@ public class QueryIdCachingProxyHandler
     public static final String OAUTH_PATH = "/oauth2";
     public static final String USER_HEADER = "X-Trino-User";
 
-    private QueryIdCachingProxyHandler() {}
+    private HttpUtils() {}
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/ProxyUtils.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/ProxyUtils.java
@@ -24,8 +24,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.TRINO_UI_PATH;
-import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.V1_QUERY_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.TRINO_UI_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.V1_QUERY_PATH;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Locale.ENGLISH;
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
@@ -29,15 +29,15 @@ import java.util.regex.Pattern;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.gateway.ha.handler.HttpUtils.OAUTH_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.TRINO_UI_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.UI_API_STATS_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.USER_HEADER;
+import static io.trino.gateway.ha.handler.HttpUtils.V1_INFO_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.V1_NODE_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.V1_QUERY_PATH;
 import static io.trino.gateway.ha.handler.ProxyUtils.buildUriWithNewBackend;
 import static io.trino.gateway.ha.handler.ProxyUtils.extractQueryIdIfPresent;
-import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.OAUTH_PATH;
-import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.TRINO_UI_PATH;
-import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.UI_API_STATS_PATH;
-import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.USER_HEADER;
-import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.V1_INFO_PATH;
-import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.V1_NODE_PATH;
-import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.V1_QUERY_PATH;
 import static java.util.Objects.requireNonNull;
 
 public class RoutingTargetHandler

--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/RouteToBackendResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/RouteToBackendResource.java
@@ -27,7 +27,7 @@ import jakarta.ws.rs.core.Context;
 
 import java.net.URI;
 
-import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.V1_STATEMENT_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.V1_STATEMENT_PATH;
 import static io.trino.gateway.proxyserver.RouterPreMatchContainerRequestFilter.ROUTE_TO_BACKEND;
 import static java.util.Objects.requireNonNull;
 

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/config/TestHaGatewayConfiguration.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/config/TestHaGatewayConfiguration.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.V1_STATEMENT_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.V1_STATEMENT_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelectorExternal.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelectorExternal.java
@@ -46,7 +46,7 @@ import java.util.Optional;
 import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
 import static io.airlift.http.client.Request.Builder.preparePost;
 import static io.airlift.json.JsonCodec.jsonCodec;
-import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.USER_HEADER;
+import static io.trino.gateway.ha.handler.HttpUtils.USER_HEADER;
 import static io.trino.gateway.ha.router.RoutingGroupSelector.ROUTING_GROUP_HEADER;
 import static io.trino.gateway.ha.router.TrinoQueryProperties.TRINO_CATALOG_HEADER_NAME;
 import static io.trino.gateway.ha.router.TrinoQueryProperties.TRINO_SCHEMA_HEADER_NAME;

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestTrinoRequestUser.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestTrinoRequestUser.java
@@ -26,7 +26,7 @@ import java.util.Date;
 import java.util.Optional;
 
 import static com.auth0.jwt.algorithms.Algorithm.HMAC256;
-import static io.trino.gateway.ha.handler.QueryIdCachingProxyHandler.USER_HEADER;
+import static io.trino.gateway.ha.handler.HttpUtils.USER_HEADER;
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
## Description

Supersedes #504
Fixes https://github.com/trinodb/trino-gateway/issues/480

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.