### PR TITLE
Remove GitHub button in UI

### DIFF
--- a/webapp/src/components/layout.tsx
+++ b/webapp/src/components/layout.tsx
@@ -1,5 +1,5 @@
 import { Nav, Avatar, Layout, Dropdown, Button, Toast, Modal, Tag } from '@douyinfe/semi-ui';
-import { IconGithubLogo, IconDoubleChevronRight, IconDoubleChevronLeft, IconMoon, IconSun, IconMark, IconIdCard } from '@douyinfe/semi-icons';
+import { IconDoubleChevronRight, IconDoubleChevronLeft, IconMoon, IconSun, IconMark, IconIdCard } from '@douyinfe/semi-icons';
 import styles from './layout.module.scss';
 import { useEffect, useState } from 'react';
 import { Link, useLocation } from "react-router-dom";
@@ -73,10 +73,6 @@ export const RootLayout = (props: {
                   ) : null}
                   aria-label="Switch Theme"
                   onClick={nextTheme} />
-
-                <Button icon={<IconGithubLogo className={styles.semiIconsBell} />}
-                  aria-label="GitHub"
-                  onClick={() => window.open('https://github.com/trinodb/trino-gateway', '_blank')} />
 
                 <Dropdown
                   position={'bottomRight'}


### PR DESCRIPTION
## Description
Removed GitHub button in UI as a link to the src code.
A link to the src code within an application feels unnecessary, also the website also has a link to the src code already.

## Additional context and related issues



More info at https://trino.io/development/process#release-note -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
* Remove GitHub button from header in UI
```
