### PR TITLE
Support environment variables in Helm config and remove lookup (WIP)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
           platforms: amd64,arm64,ppc64le
       - name: Build and Test Docker Image
         run: docker/build.sh
+      - name: Build and Test Init Image
+        run: helm/init-container-image/build.sh
       - name: Set up Helm
         uses: azure/setup-helm@v4.2.0
         with:
@@ -56,10 +58,21 @@ jobs:
         with:
           cluster_name: tgw
       - name: load images
-        run: kind load docker-image --name tgw trino-gateway:$(cat ./trino-gateway-version.txt | tr -d '\n')-amd64
+        run: |
+          kind load docker-image --name tgw trino-gateway:$(cat ./trino-gateway-version.txt | tr -d '\n')-amd64 \
+          trino-gateway-init:$(cat ./trino-gateway-version.txt | tr -d '\n')-amd64
       - name: Run chart-testing (install)
-        run: helm install test helm/trino-gateway  --set "image.repository=trino-gateway" --set "image.tag=$(cat ./trino-gateway-version.txt | tr -d '\n')-amd64" --set "limits.memory=100Mi" --set "limits.cpu=0"
+        run: |
+          helm install test helm/trino-gateway  --set "image.repository=trino-gateway" \
+          --set "image.tag=$(cat ./trino-gateway-version.txt | tr -d '\n')-amd64" --set "limits.memory=100Mi" \
+          --set "limits.cpu=0"  --set "initContainer.repository=trino-gateway-init" \
+          --set "initContainer.tag=$(cat ./trino-gateway-version.txt | tr -d '\n')-amd64"
       - name: wait for deployment
+        id: waitForDeployment
         #the deployment name is the name of the installation from the helm install command above, concatenated with the name from Chart.yaml
         run: kubectl rollout status deployment test-trino-gateway
         timeout-minutes: 2
+        continue-on-error: true
+      - name: Check failed deployment
+        if: steps.waitForDeployment.outcome == 'failure'
+        run: kubectl describe pods && exit 1

--- a/helm/init-container-image/Dockerfile
+++ b/helm/init-container-image/Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+RUN microdnf install -y python3
+
+COPY ./bin/interpolate_env_vars.py /tmp/
+
+ENTRYPOINT ["python3", "/tmp/interpolate_env_vars.py"]

--- a/helm/init-container-image/bin/interpolate_env_vars.py
+++ b/helm/init-container-image/bin/interpolate_env_vars.py
@@ -1,0 +1,32 @@
+import argparse
+import re
+from os import getenv
+
+
+def do_interpolation(input_filename: str, output_filename: str):
+    env_pattern = re.compile('\\$\\{ENV:\s*([a-zA-Z0-0_]*)\s*\\}')
+
+    input = open(input_filename, 'r')
+    output = open(output_filename, 'w')
+
+    for line in input:
+        match = env_pattern.search(line)
+        if match:
+            print(f'Substituting environment variable {match.groups()[0]}')
+            replacement = getenv(match.groups()[0])
+            if replacement is None:
+                raise Exception(f'ENV {match.groups()[0]} not found')
+            line = re.sub(env_pattern, replacement, line)
+        output.write(line)
+
+    input.close()
+    output.close()
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input')
+    parser.add_argument('output')
+    args = parser.parse_args()
+    do_interpolation(args.input, args.output)

--- a/helm/init-container-image/build.sh
+++ b/helm/init-container-image/build.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat <<EOF 1>&2
+Usage: $0 [-h] [-a <ARCHITECTURES>] [-r <VERSION>]
+Builds the Trino Gateway Init Docker image
+
+-h       Display help
+-a       Build the specified comma-separated architectures, defaults to amd64,arm64,ppc64le
+EOF
+}
+
+# Retrieve the script directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+cd "${SCRIPT_DIR}" || exit 2
+
+SOURCE_DIR="${SCRIPT_DIR}/../.."
+MVNW_VERBOSE=false
+
+ARCHITECTURES=(amd64 arm64 ppc64le)
+TRINO_GATEWAY_VERSION=$("${SOURCE_DIR}/mvnw" -f "${SOURCE_DIR}/pom.xml" --quiet help:evaluate -Dexpression=project.version -DforceStdout)
+
+while getopts ":a:h:r:j:" o; do
+    case "${o}" in
+        a)
+            IFS=, read -ra ARCHITECTURES <<< "$OPTARG"
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+function test_image() {
+    IMAGE=$1
+    PLATFORM=$2
+
+    echo "Testing ${IMAGE}"
+    USERNAME=usr
+    PASSWORD=secret
+    cat > env_test.yaml << EOF
+dataStore:
+  #This stores the URLs of backend Trino servers and query history
+  jdbcUrl: jdbc:postgresql://env:5432/gateway
+  user: \${ENV:USERNAME}
+  password: "\${ENV:PASSWORD}"
+EOF
+    cat > env_test_expected.yaml << EOF
+dataStore:
+  #This stores the URLs of backend Trino servers and query history
+  jdbcUrl: jdbc:postgresql://env:5432/gateway
+  user: ${USERNAME}
+  password: "${PASSWORD}"
+EOF
+
+    touch output.yaml
+    docker run --platform "${PLATFORM}" --rm -e USERNAME="${USERNAME}" -e PASSWORD="${PASSWORD}" \
+    --user $(id -u):$(id -g) \
+    -v "${PWD}"/env_test.yaml:/tmp/env_test.yaml \
+    -v "${PWD}"/output.yaml:/tmp/output.yaml:rw \
+    "${IMAGE}" /tmp/env_test.yaml /tmp/output.yaml
+   if [[ -n "$(diff output.yaml env_test_expected.yaml)" ]]; then
+       echo "Interpolated output does not match expected:"
+       cat  env_test.yaml
+       exit 100
+   fi
+   rm  output.yaml env_test_expected.yaml env_test.yaml
+   echo "Test successful"
+}
+
+echo "🧱 Preparing the image build context directory"
+WORK_DIR="$(mktemp -d)"
+cp -r bin "${WORK_DIR}"
+
+TAG_PREFIX="trino-gateway-init:${TRINO_GATEWAY_VERSION}"
+
+for arch in "${ARCHITECTURES[@]}"; do
+    echo "🫙  Building the image for $arch"
+    DOCKER_BUILDKIT=1 \
+    docker build \
+        "${WORK_DIR}" \
+        --pull \
+        --platform "linux/$arch" \
+        -f Dockerfile \
+        -t "${TAG_PREFIX}-$arch"
+done
+
+echo "🧹 Cleaning up the build context directory"
+rm -r "${WORK_DIR}"
+
+echo "🏃 Testing built images"
+for arch in "${ARCHITECTURES[@]}"; do
+    docker image inspect -f '🚀 Built {{.RepoTags}} {{.Id}}' "${TAG_PREFIX}-$arch"
+    # TODO: remove when https://github.com/multiarch/qemu-user-static/issues/128 is fixed
+    if [[ "${arch}" != "ppc64le" ]]; then
+        test_image "${TAG_PREFIX}-${arch}" "linux/${arch}"
+    fi
+done

--- a/helm/trino-gateway/templates/deployment.yaml
+++ b/helm/trino-gateway/templates/deployment.yaml
@@ -14,12 +14,6 @@ spec:
   template:
     metadata:
       annotations:
-        # Include the version of trino-gateway-configuration as an input to the
-        # deployment checksum. This causes pods to restart on helm update
-        # whether the chart `config` is updated or if one of the configuration
-        # secrets is updated. Helm template must be run with the
-        # --dry-run=server option to prevent a nil pointer.
-        checksum/config: {{ (coalesce (lookup "v1" "Secret" .Release.Namespace "trino-gateway-configuration").metadata (dict "resourceVersion" "0")).resourceVersion | sha256sum}}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -36,6 +30,49 @@ spec:
       serviceAccountName: {{ include "trino-gateway.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: consolidate-config
+          image: "{{ .Values.initContainer.repository }}:{{ .Values.initContainer.tag }}"
+          volumeMounts:
+            - name: trino-gateway-configuration-secret
+              mountPath: "/etc/secret/config.yaml"
+              subPath: "config.yaml"
+              readOnly: true
+            - name: trino-gateway-configuration
+              mountPath: "/etc/gateway/"
+              readOnly: false
+            {{- with  .Values.dataStoreSecret.key }}
+            - name: trino-datastore-secret
+              mountPath: "/etc/secret/{{.}}"
+              subPath: "{{.}}"
+              readOnly: true
+            {{- end}}
+            {{- with  .Values.backendStateSecret.key }}
+            - name: trino-backend-state-secret
+              mountPath: "/etc/secret/{{.}}"
+              subPath: "{{.}}"
+              readOnly: true
+            {{- end}}
+            {{- with  .Values.authenticationSecret.key }}
+            - name: trino-authentication-secret
+              mountPath: "/etc/secret/{{.}}"
+              subPath: "{{.}}"
+              readOnly: true
+            {{- end}}
+          command:
+            - "bash"
+            - "-c"
+            - "cat /etc/secret/* > /etc/gateway/raw-config.yaml"
+        - name: interpolate-env
+          image: "{{ .Values.initContainer.repository }}:{{ .Values.initContainer.tag }}"
+          envFrom:
+            {{- toYaml .Values.envFrom | nindent 12}}
+          command:
+            {{- toYaml .Values.initContainer.command | nindent 12}}
+          volumeMounts:
+            - name: trino-gateway-configuration
+              mountPath: "/etc/gateway/"
+              readOnly: false
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -68,17 +105,37 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: trino-gateway-configuration
-              mountPath: "/etc/gateway/config.yaml"
-              subPath: "config.yaml"
+              mountPath: "/etc/gateway/"
               readOnly: true
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
-        - name: trino-gateway-configuration
+        - name: trino-gateway-configuration-secret
           secret:
               secretName: trino-gateway-configuration
               optional: false
+        - name: trino-gateway-configuration
+          emptyDir:
+              sizeLimit: 10Mi
+        {{- with  .Values.dataStoreSecret.name }}
+        - name: trino-datastore-secret
+          secret:
+              secretName: {{ . }}
+              optional: false
+        {{- end}}
+        {{- with  .Values.backendStateSecret.name }}
+        - name: trino-backend-state-secret
+          secret:
+              secretName: {{ . }}
+              optional: false
+        {{- end}}
+        {{- with  .Values.authenticationSecret.name }}
+        - name: trino-authentication-secret
+          secret:
+              secretName: {{ . }}
+              optional: false
+        {{- end}}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/trino-gateway/templates/secrets.yaml
+++ b/helm/trino-gateway/templates/secrets.yaml
@@ -1,22 +1,8 @@
-{{ $dataStoreDict :=  dict}}
-{{ if .Values.dataStoreSecret.name }}
-{{ $dataStoreDict = (index (lookup "v1" "Secret" .Release.Namespace .Values.dataStoreSecret.name).data .Values.dataStoreSecret.key) | b64dec | fromYaml }}
-{{ end }}
-{{ $backendStateDict := dict }}
-{{ if .Values.backendStateSecret.name }}
-{{ $backendStateDict = (index (lookup "v1" "Secret" .Release.Namespace .Values.backendStateSecret.name).data .Values.backendStateSecret.key) | b64dec | fromYaml }}
-{{ end }}
-{{ $authenticationDict := dict }}
-{{ if .Values.authenticationSecret.name }}
-# {{.Values.authenticationSecret.name }} #
-# {{ index (lookup "v1" "Secret" .Release.Namespace .Values.authenticationSecret.name).data .Values.authenticationSecret.key }} #
-{{ $authenticationDict = (index (lookup "v1" "Secret" .Release.Namespace .Values.authenticationSecret.name).data .Values.authenticationSecret.key) | b64dec | fromYaml  }}
-{{ end }}
-
 apiVersion: v1
 kind: Secret
 metadata:
     name: trino-gateway-configuration
 type: "Opaque"
 data:
-    config.yaml: "{{toYaml (merge .Values.config $authenticationDict $dataStoreDict $backendStateDict ) | b64enc}}"
+    # The newline is required so that this can be concatenated with other yamls in the consolidate-config initContainer
+    config.yaml: {{cat (toYaml .Values.config) "\n" | b64enc}}

--- a/helm/trino-gateway/values.yaml
+++ b/helm/trino-gateway/values.yaml
@@ -11,24 +11,61 @@ image:
     #pullPolicy: IfNotPresent
     #tag: "8-SNAPSHOT"
 
+initContainer:
+    repository: "trinodb/trino-gateway-init"
+    pullPolicy: IfNotPresent
+    tag: "13-SNAPSHOT"
+    command:
+      - "python"
+      - "/tmp/interpolate_env_vars.py"
+      - "/etc/gateway/raw-config.yaml"
+      - "/etc/gateway/config.yaml"
+
 imagePullSecrets: []
 
-# Provide configuration for the Trino Gateway dataStore in dataStoreSecret. This node can
-# be left undefined if dataStore is defined under the config node. For production deployments
-# sensitive values should be stored in a Secret
+# Provide a list of secrets and configmaps to mount into the init container as environment variables.
+# These environment variables may be interpolated into the configuration file by using
+# ${ENV:VAR_NAME} in place of a raw value. Example:
+#  kubectl create secret generic test-secret --from-literal=USER='me' --from-literal=PASSWORD='39528$vdg7Jb'
+#
+#envFrom:
+#  - secretRef:
+#      name: test-secret
+#
+#  dataStore:
+#    jdbcUrl: jdbc:postgresql://localhost:5432/gateway
+#    user: ${ENV:USER}
+#    password: ${ENV:PASSWORD}
+#    driver: org.postgresql.Driver
+envFrom: []
+
+# Provide configuration for the Trino Gateway dataStore, backendState and authentication as
+# secrets. These secrets should contain the entire yaml snippet, starting with the root node.
+# For example, if you have a file containing the following snippet in a file named my-data-store.yaml,
+# you should
+# kubectl create secret generic data-store-secret --from-file my-data-store.yaml
+# and set:
+#dataStoreSecret:
+#    name: "data-store-secret"
+#    key: "my-data-store.yaml"
+#
+# File contents:
+#dataStore:
+#  jdbcUrl: jdbc:postgresql://localhost:5432/gateway
+#  user: postgres
+#  password: mysecretpassword
+#  driver: org.postgresql.Driver
+#
+# Secrets are appended to the configuration defined in the config.yaml node. If multiple secrets are
+# used, make sure each ends in a newline!
 dataStoreSecret:
     name: ""
     key: ""
 
-# Provide configuration for the Trino Gateway backendState in backendStateSecret. This should
-# be used with health check configurations that require backend credentials. This node can
-# be left undefined if dataStore is defined under the config node.
 backendStateSecret:
     name: ""
     key: ""
 
-# Provide configuration for the Trino Gateway authentication configuration in authenticationSecret.
-# This node can be left undefined if dataStore is defined under the config node.
 authenticationSecret:
     name: ""
     key: ""


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Support interpolation of environment variables from secrets in Helm configuration. Remove usage of Helm lookup function in generating configuration.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
The existing Helm chart uses Helm's [lookup](https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-lookup-function) to combine Kubernetes secrets with non-sensitive configuration. This caused incompatibilities with some frameworks such as ArgoCD.

The lookup function is replaced with an initContainer which merges secrets with the configuration provided directly in the chart. Adding an initContainer also allows providing sensitive values through environment variables using the `envFrom` feature. 


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:
Support environment variable references in configuration and improve compatibility with ArgoCD
