### PR TITLE
Add Trino Gateway 13 release notes

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,7 +22,7 @@ It  copies the following, necessary files to current directory:
 ```shell
 #!/usr/bin/env sh
 
-VERSION=12
+VERSION=13
 
 # Copy necessary files to current directory
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,25 @@
 # Release notes
 
+## Trino Gateway 13 (?? Dec 2024) { id="13" }
+
+Artifacts:
+
+* [JAR file gateway-ha-13-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/13/gateway-ha-13-jar-with-dependencies.jar)
+* Container image `trinodb/trino-gateway:13`
+* Source code as
+  [tar.gz](https://github.com/trinodb/trino-gateway/archive/refs/tags/13.tar.gz)
+  or [zip](https://github.com/trinodb/trino-gateway/archive/refs/tags/13.zip)
+* Helm chart `1.13.0` in `helm/trino-gateway` of the tagged source code
+
+Changes:
+
+* Allow proxying of HTTP PUT requests to Trino clusters.
+  ([#543](https://github.com/trinodb/trino-gateway/pull/543))
+* Add a filter for `source` to the **History** page in the UI.
+  ([#551](https://github.com/trinodb/trino-gateway/pull/551))
+* Log out inactive users from the UI automatically.
+  ([#544](https://github.com/trinodb/trino-gateway/pull/544))
+
 ## Trino Gateway 12 (7 Nov 2024) { id="12" }
 
 Artifacts:


### PR DESCRIPTION
## Description

Assemble the release notes for Trino Gateway 13 release and adjust rest of docs to version 13.

## Additional context and related issues

As a follow up we need to merge https://github.com/trinodb/charts/pull/270 for the Helm chart after this release is done.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Verification for each pull request

Format: PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

Any dates missing in the list just had no merged PRs.

## 11 Nov 2024

* #547 ✅ rn ✅ docs
* #550 ✅ rn ✅ docs
* #549 ✅ rn ✅ docs
* #551 ✅ rn ✅ docs

## 15 Nov 2024

* #543 ✅ rn ✅ docs

## 27 Nov 2024

* #544 ✅ rn ✅ docs

## 28 Nov 2024

* #536 ✅ rn ✅ docs

## 2 Dec 2024

* #558 ✅ rn ✅ docs
* #561 ✅ rn ✅ docs
