### PR TITLE
Ignore version output file for git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/**
 /**/var/
 gateway-ha/**/static/**
 .cache
+trino-gateway-version.txt


### PR DESCRIPTION
## Description

The docker build creates that file and we should ignore it so accidental commit of it can be avoided.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

na

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
