### PR TITLE
Clean webapp output folders with Maven build

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -400,6 +400,24 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>../${frontend.project.name}/dist</directory>
+                        </fileset>
+                        <fileset>
+                            <directory>../${frontend.project.name}/node</directory>
+                        </fileset>
+                        <fileset>
+                            <directory>../${frontend.project.name}/node_modules</directory>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <doclint>none</doclint>


### PR DESCRIPTION
## Description

Currently the three folders are never cleaned up and depending on your setup and build with switching branches and more this can lead to the wrong impression that things are working or not work as expected. 

This is a preliminary clean up to actually move the maven build parts for webapp into the webapp folder and will help for now .. 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

#556 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
