### PR TITLE
Update to oryd/hydra:v1.11.10 for OAuth2 testing

### DIFF
--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestOIDC.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestOIDC.java
@@ -59,7 +59,7 @@ final class TestOIDC
     private static final int TTL_ACCESS_TOKEN_IN_SECONDS = 5;
     private static final int TTL_REFRESH_TOKEN_IN_SECONDS = 15;
 
-    private static final String HYDRA_IMAGE = "oryd/hydra:v1.10.6";
+    private static final String HYDRA_IMAGE = "oryd/hydra:v1.11.10";
     private static final String DSN = "postgres://hydra:mysecretpassword@hydra-db:5432/hydra?sslmode=disable";
     private static final int ROUTER_PORT = 21001 + (int) (Math.random() * 1000);
 


### PR DESCRIPTION
## Description

This fixes build failures with some newer OS versions, but avoids any updates necessary for adopting v2.x. Testing with 2.x with the current setup fails to start the container.

## Additional context and related issues

Also ported change to Trino.  

https://github.com/trinodb/trino/pull/24500

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
