### PR TITLE
Add Oracle support for backend database

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,9 +38,9 @@ distribution is installed.
 
 ### Backend database
 
-Trino Gateway requires a MySQL or PostgreSQL database. Database initialization
-is performed automatically when the Trino Gateway process starts. Migrations
-are performed using `Flyway`.
+Trino Gateway requires a MySQL, PostgreSQL, or Oracle database. Database
+initialization is performed automatically when the Trino Gateway process
+starts. Migrations are performed using `Flyway`.
 
 The migration files can viewed in the `gateway-ha/src/main/resources/` folder.
 Each database type supported has its own sub-folder.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,7 +16,6 @@ under the project root folder, and run it at the temporary directory.
 It  copies the following, necessary files to current directory:
 
 - gateway-ha.jar
-- gateway-ha-persistence-postgres.sql
 - quickstart-config.yaml
 
 ```shell
@@ -41,26 +40,18 @@ else
     cp ../docs/quickstart-config.yaml ./quickstart-config.yaml
 fi
 
-# Check and get the postgres.sql
-if [[ -f "gateway-ha-persistence-postgres.sql" ]]; then
-    echo "Found gateway-ha-persistence-postgres.sql file in current directory."
-else
-    cp ../gateway-ha/src/main/resources/gateway-ha-persistence-postgres.sql ./gateway-ha-persistence-postgres.sql
-fi
-
 #Check if DB is running
 if docker ps --format '{{.Names}}' | grep -q '^local-postgres$'; then
     echo "PostgreSQL database container 'localhost-postgres' is already running. Only starting Trino Gateway."
 else
     echo "PostgreSQL database container 'localhost-postgres' is not running. Proceeding to initialize and run database server."
     export PGPASSWORD=mysecretpassword
-    docker run -v "$(pwd)"/gateway-ha-persistence-postgres.sql:/tmp/gateway-ha-persistence-postgres.sql --name local-postgres -p 5432:5432 -e POSTGRES_PASSWORD=$PGPASSWORD -d postgres:latest
+    docker run --name local-postgres -p 5432:5432 -e POSTGRES_PASSWORD=$PGPASSWORD -d postgres:latest
     #Make sure the DB has time to initialize
     sleep 5
 
     #Initialize the DB
     docker exec local-postgres psql -U postgres -h localhost -c 'CREATE DATABASE gateway'
-    docker exec local-postgres psql -U postgres -h localhost -d gateway -f /tmp/gateway-ha-persistence-postgres.sql
 fi
 
 

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -277,11 +277,26 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc11-production</artifactId>
+            <version>23.6.0.24.10</version>
+            <type>pom</type>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Required for ClusterStatsJdbcMonitor -->
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-jdbc</artifactId>
             <version>${dep.trino.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-oracle</artifactId>
+            <version>${dep.flyway.version}</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -382,6 +397,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>oracle-xe</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/module/RouterBaseModule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/module/RouterBaseModule.java
@@ -39,7 +39,7 @@ public class RouterBaseModule
         connectionManager = new JdbcConnectionManager(jdbi, configuration.getDataStore());
         resourceGroupsManager = new HaResourceGroupsManager(connectionManager);
         gatewayBackendManager = new HaGatewayManager(jdbi);
-        queryHistoryManager = new HaQueryHistoryManager(jdbi);
+        queryHistoryManager = new HaQueryHistoryManager(jdbi, configuration.getDataStore().getJdbcUrl().startsWith("jdbc:oracle"));
     }
 
     @Provides

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/FlywayMigration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/FlywayMigration.java
@@ -34,7 +34,10 @@ public class FlywayMigration
         if (configDbUrl.startsWith("jdbc:mysql")) {
             return "mysql";
         }
-        throw new IllegalArgumentException(format("Invalid JDBC URL: %s. Only PostgreSQL and MySQL are supported.", configDbUrl));
+        if (configDbUrl.startsWith("jdbc:oracle")) {
+            return "oracle";
+        }
+        throw new IllegalArgumentException(format("Invalid JDBC URL: %s. Only PostgreSQL, MySQL, and Oracle are supported.", configDbUrl));
     }
 
     public static void migrate(DataStoreConfiguration config)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
@@ -38,10 +38,12 @@ public class HaQueryHistoryManager
     private static final int FIRST_PAGE_NO = 1;
 
     private final QueryHistoryDao dao;
+    private final boolean isOracleBackend;
 
-    public HaQueryHistoryManager(Jdbi jdbi)
+    public HaQueryHistoryManager(Jdbi jdbi, boolean isOracleBackend)
     {
         dao = requireNonNull(jdbi, "jdbi is null").onDemand(QueryHistoryDao.class);
+        this.isOracleBackend = isOracleBackend;
     }
 
     @Override
@@ -66,10 +68,10 @@ public class HaQueryHistoryManager
     {
         List<QueryHistory> histories;
         if (user.isPresent()) {
-            histories = dao.findRecentQueriesByUserName(user.orElseThrow());
+            histories = dao.findRecentQueriesByUserName(user.orElseThrow(), isOracleBackend);
         }
         else {
-            histories = dao.findRecentQueries();
+            histories = dao.findRecentQueries(isOracleBackend);
         }
         return upcast(histories);
     }

--- a/gateway-ha/src/main/resources/oracle/V1__create_schema.sql
+++ b/gateway-ha/src/main/resources/oracle/V1__create_schema.sql
@@ -1,0 +1,69 @@
+CREATE TABLE gateway_backend (
+    name VARCHAR(256) PRIMARY KEY,
+    routing_group VARCHAR (256),
+    backend_url VARCHAR (256),
+    external_url VARCHAR (256),
+    active NUMBER(1)
+);
+
+CREATE TABLE query_history (
+    query_id VARCHAR(256) PRIMARY KEY,
+    query_text VARCHAR (256),
+    created NUMBER,
+    backend_url VARCHAR (256),
+    user_name VARCHAR(256),
+    source VARCHAR(256)
+);
+CREATE INDEX query_history_created_idx ON query_history(created);
+
+CREATE TABLE resource_groups (
+    resource_group_id NUMBER GENERATED ALWAYS as IDENTITY(START with 1 INCREMENT by 1),
+    name VARCHAR(250) NOT NULL,
+    -- OPTIONAL POLICY CONTROLS
+    parent NUMBER,
+    jmx_export CHAR(1),
+    scheduling_policy VARCHAR(128),
+    scheduling_weight NUMBER,
+    -- REQUIRED QUOTAS
+    soft_memory_limit VARCHAR(128) NOT NULL,
+    max_queued INT NOT NULL,
+    hard_concurrency_limit NUMBER NOT NULL,
+    -- OPTIONAL QUOTAS
+    soft_concurrency_limit NUMBER,
+    soft_cpu_limit VARCHAR(128),
+    hard_cpu_limit VARCHAR(128),
+    environment VARCHAR(128),
+    PRIMARY KEY(resource_group_id),
+    FOREIGN KEY (parent) REFERENCES resource_groups (resource_group_id) ON DELETE CASCADE
+);
+
+CREATE TABLE selectors (
+    resource_group_id NUMBER NOT NULL,
+    priority NUMBER NOT NULL,
+    -- Regex fields -- these will be used as a regular expression pattern to
+    --                 match against the field of the same name on queries
+    user_regex VARCHAR(512),
+    source_regex VARCHAR(512),
+    -- Selector fields -- these must match exactly.
+    query_type VARCHAR(512),
+    client_tags VARCHAR(512),
+    selector_resource_estimate VARCHAR(1024),
+    FOREIGN KEY (resource_group_id) REFERENCES resource_groups (resource_group_id) ON DELETE CASCADE
+);
+
+CREATE TABLE resource_groups_global_properties (
+    name VARCHAR(128) NOT NULL PRIMARY KEY,
+    value VARCHAR(512) NULL,
+    CHECK (name in ('cpu_quota_period'))
+);
+
+CREATE TABLE exact_match_source_selectors(
+    environment VARCHAR(256),
+    update_time TIMESTAMP NOT NULL,
+    -- Selector fields which must exactly match a query
+    source VARCHAR(512) NOT NULL,
+    query_type VARCHAR(512),
+    resource_group_id VARCHAR(256) NOT NULL,
+    PRIMARY KEY (environment, source, resource_group_id),
+    UNIQUE (source, environment, query_type, resource_group_id)
+);

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/HaGatewayTestUtils.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/HaGatewayTestUtils.java
@@ -76,16 +76,16 @@ public class HaGatewayTestUtils
         }
     }
 
-    public static TestConfig buildGatewayConfig(int routerPort, String configFile, PostgreSQLContainer postgresqlContainer)
+    public static File buildGatewayConfig(PostgreSQLContainer postgreSqlContainer, int routerPort, String configFile)
             throws Exception
     {
         URL resource = HaGatewayTestUtils.class.getClassLoader().getResource("auth/localhost.jks");
         String configStr =
                 getResourceFileContent(configFile)
                         .replace("REQUEST_ROUTER_PORT", String.valueOf(routerPort))
-                        .replace("POSTGRESQL_JDBC_URL", postgresqlContainer.getJdbcUrl())
-                        .replace("POSTGRESQL_USER", postgresqlContainer.getUsername())
-                        .replace("POSTGRESQL_PASSWORD", postgresqlContainer.getPassword())
+                        .replace("POSTGRESQL_JDBC_URL", postgreSqlContainer.getJdbcUrl())
+                        .replace("POSTGRESQL_USER", postgreSqlContainer.getUsername())
+                        .replace("POSTGRESQL_PASSWORD", postgreSqlContainer.getPassword())
                         .replace(
                                 "APPLICATION_CONNECTOR_PORT", String.valueOf(30000 + (int) (Math.random() * 1000)))
                         .replace("ADMIN_CONNECTOR_PORT", String.valueOf(31000 + (int) (Math.random() * 1000)))
@@ -99,7 +99,7 @@ public class HaGatewayTestUtils
         }
 
         log.info("Test Gateway Config \n[%s]", configStr);
-        return new TestConfig(target.getAbsolutePath());
+        return target;
     }
 
     public static String getResourceFileContent(String fileName)
@@ -168,13 +168,5 @@ public class HaGatewayTestUtils
             sleepUninterruptibly(1, TimeUnit.SECONDS);
         }
         throw new IllegalStateException("Trino cluster is not healthy");
-    }
-
-    public record TestConfig(String configFilePath)
-    {
-        public TestConfig
-        {
-            requireNonNull(configFilePath, "configFilePath is null");
-        }
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaSingleBackend.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaSingleBackend.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.TrinoContainer;
 
 import java.util.List;
@@ -39,6 +40,7 @@ import static org.testcontainers.utility.MountableFile.forClasspathResource;
 final class TestGatewayHaSingleBackend
 {
     private TrinoContainer trino;
+    private PostgreSQLContainer postgresql;
     int routerPort = 21001 + (int) (Math.random() * 1000);
 
     @BeforeAll
@@ -51,9 +53,11 @@ final class TestGatewayHaSingleBackend
 
         int backendPort = trino.getMappedPort(8080);
 
-        // seed database
+        // start postgres database
+        postgresql = new PostgreSQLContainer("postgres:16");
+        postgresql.start();
         HaGatewayTestUtils.TestConfig testConfig =
-                HaGatewayTestUtils.buildGatewayConfigAndSeedDb(routerPort, "test-config-template.yml");
+                HaGatewayTestUtils.buildGatewayConfig(routerPort, "test-config-template.yml", postgresql);
         // Start Gateway
         String[] args = {testConfig.configFilePath()};
         HaGatewayLauncher.main(args);

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestNoXForwarded.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestNoXForwarded.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.TrinoContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,6 +36,7 @@ final class TestNoXForwarded
 {
     private final OkHttpClient httpClient = new OkHttpClient();
     private TrinoContainer trino;
+    private PostgreSQLContainer postgresql;
     int routerPort = 21001 + (int) (Math.random() * 1000);
     int backendPort;
 
@@ -48,9 +50,11 @@ final class TestNoXForwarded
 
         backendPort = trino.getMappedPort(8080);
 
-        // seed database
+        postgresql = new PostgreSQLContainer("postgres:16");
+        postgresql.start();
+
         HaGatewayTestUtils.TestConfig testConfig =
-                HaGatewayTestUtils.buildGatewayConfigAndSeedDb(routerPort, "test-config-without-x-forwarded-template.yml");
+                HaGatewayTestUtils.buildGatewayConfig(routerPort, "test-config-without-x-forwarded-template.yml", postgresql);
         // Start Gateway
         String[] args = {testConfig.configFilePath()};
         HaGatewayLauncher.main(args);

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestingJdbcConnectionManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestingJdbcConnectionManager.java
@@ -29,7 +29,7 @@ public final class TestingJdbcConnectionManager
         File tempH2DbDir = Path.of(System.getProperty("java.io.tmpdir"), "h2db-" + System.currentTimeMillis()).toFile();
         tempH2DbDir.deleteOnExit();
         String jdbcUrl = "jdbc:h2:" + tempH2DbDir.getAbsolutePath();
-        HaGatewayTestUtils.seedRequiredData(new HaGatewayTestUtils.TestConfig("", tempH2DbDir.getAbsolutePath()));
+        HaGatewayTestUtils.seedRequiredData(tempH2DbDir.getAbsolutePath());
         DataStoreConfiguration db = new DataStoreConfiguration(jdbcUrl, "sa", "sa", "org.h2.Driver", 4, false);
         Jdbi jdbi = Jdbi.create(jdbcUrl, "sa", "sa");
         return new JdbcConnectionManager(jdbi, db);

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestingJdbcConnectionManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestingJdbcConnectionManager.java
@@ -16,6 +16,7 @@ package io.trino.gateway.ha;
 import io.trino.gateway.ha.config.DataStoreConfiguration;
 import io.trino.gateway.ha.persistence.JdbcConnectionManager;
 import org.jdbi.v3.core.Jdbi;
+import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -33,5 +34,11 @@ public final class TestingJdbcConnectionManager
         DataStoreConfiguration db = new DataStoreConfiguration(jdbcUrl, "sa", "sa", "org.h2.Driver", 4, false);
         Jdbi jdbi = Jdbi.create(jdbcUrl, "sa", "sa");
         return new JdbcConnectionManager(jdbi, db);
+    }
+
+    public static JdbcConnectionManager createTestingJdbcConnectionManager(JdbcDatabaseContainer<?> container, DataStoreConfiguration config)
+    {
+        Jdbi jdbi = Jdbi.create(container.getJdbcUrl(), container.getUsername(), container.getPassword());
+        return new JdbcConnectionManager(jdbi, config);
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/BaseTestDatabaseMigrations.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/BaseTestDatabaseMigrations.java
@@ -39,7 +39,7 @@ public abstract class BaseTestDatabaseMigrations
     protected abstract void createGatewaySchema();
 
     private final JdbcDatabaseContainer<?> container;
-    private final String schema;
+    protected final String schema;
     protected final Jdbi jdbi;
 
     public BaseTestDatabaseMigrations(JdbcDatabaseContainer<?> container, String schema)
@@ -109,7 +109,7 @@ public abstract class BaseTestDatabaseMigrations
         verifyResultSetCount("SELECT environment FROM exact_match_source_selectors", 0);
     }
 
-    private void verifyResultSetCount(String sql, int expectedCount)
+    protected void verifyResultSetCount(String sql, int expectedCount)
     {
         List<String> results = jdbi.withHandle(handle ->
                 handle.createQuery(sql).mapTo(String.class).list());

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestDatabaseMigrationsOracle.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestDatabaseMigrationsOracle.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.persistence;
+
+import com.google.common.collect.ImmutableList;
+import org.jdbi.v3.core.Handle;
+import org.testcontainers.containers.OracleContainer;
+
+import java.util.List;
+
+import static java.lang.String.format;
+
+final class TestDatabaseMigrationsOracle
+        extends BaseTestDatabaseMigrations
+{
+    public TestDatabaseMigrationsOracle()
+    {
+        super(new OracleContainer("gvenzl/oracle-xe:18.4.0-slim"), "TEST");
+    }
+
+    @Override
+    public void testMigrationWithExistingGatewaySchema()
+    {
+        /*
+         * We do not need to run this test with Oracle since Oracle
+         * backend DB support did not exist before so there
+         * can be no existing deployments of gateway using
+         * Oracle as the backend database.
+         */
+    }
+
+    @Override
+    protected void dropAllTables()
+    {
+        /*
+         * Flyway configuration items including table names are case-sensitive.
+         * For this reason, if you remove the double quotes on flyway_schema_history,
+         * you will get a table not found error.
+         */
+        List<String> tables = ImmutableList.of("gateway_backend", "query_history", "resource_groups_global_properties", "selectors", "resource_groups", "exact_match_source_selectors", "\"flyway_schema_history\"");
+        Handle jdbiHandle = jdbi.open();
+        String sql = format("SELECT 1 FROM all_tables WHERE owner = '%s'", schema);
+        verifyResultSetCount(sql, 7);
+        tables.forEach(table -> jdbiHandle.execute("DROP TABLE " + table));
+        verifyResultSetCount(sql, 0);
+        jdbiHandle.close();
+    }
+
+    @Override
+    protected void createGatewaySchema()
+    {
+        /*
+         * we do not create a schema because we are not running the testMigrationWithExistingGatewaySchema
+         * test against Oracle. This is the only test we need to create the gateway schema
+         * manually for.
+         */
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryHistoryManagerMySql.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryHistoryManagerMySql.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MySQLContainer;
+
+public class TestQueryHistoryManagerMySql
+        extends BaseTestQueryHistoryManager
+{
+    @Override
+    protected final JdbcDatabaseContainer<?> startContainer()
+    {
+        JdbcDatabaseContainer<?> container = new MySQLContainer<>("mysql:8.0.36");
+        container.start();
+        return container;
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryHistoryManagerOracle.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryHistoryManagerOracle.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.OracleContainer;
+
+public class TestQueryHistoryManagerOracle
+        extends BaseTestQueryHistoryManager
+{
+    @Override
+    protected final JdbcDatabaseContainer<?> startContainer()
+    {
+        JdbcDatabaseContainer<?> container = new OracleContainer("gvenzl/oracle-xe:18.4.0-slim");
+        container.start();
+        return container;
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryHistoryManagerPostgresql.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryHistoryManagerPostgresql.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public class TestQueryHistoryManagerPostgresql
+        extends BaseTestQueryHistoryManager
+{
+    @Override
+    protected final JdbcDatabaseContainer<?> startContainer()
+    {
+        JdbcDatabaseContainer<?> container = new PostgreSQLContainer<>("postgres:16");
+        container.start();
+        return container;
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestSpecificDbResourceGroupsManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestSpecificDbResourceGroupsManager.java
@@ -44,8 +44,7 @@ final class TestSpecificDbResourceGroupsManager
         File tempH2DbDir = Path.of(System.getProperty("java.io.tmpdir"), specificDb).toFile();
         tempH2DbDir.deleteOnExit();
         String jdbcUrl = "jdbc:h2:" + tempH2DbDir.getAbsolutePath();
-        HaGatewayTestUtils.seedRequiredData(
-                new HaGatewayTestUtils.TestConfig("", tempH2DbDir.getAbsolutePath()));
+        HaGatewayTestUtils.seedRequiredData(tempH2DbDir.getAbsolutePath());
         DataStoreConfiguration db = new DataStoreConfiguration(jdbcUrl, "sa",
                 "sa", "org.h2.Driver", 4, false);
         Jdbi jdbi = Jdbi.create(jdbcUrl, "sa", "sa");

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
@@ -36,7 +36,7 @@ final class TestStochasticRoutingManager
     {
         JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager();
         backendManager = new HaGatewayManager(connectionManager.getJdbi());
-        historyManager = new HaQueryHistoryManager(connectionManager.getJdbi());
+        historyManager = new HaQueryHistoryManager(connectionManager.getJdbi(), false);
         haRoutingManager = new StochasticRoutingManager(backendManager, historyManager);
     }
 

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestAuthorization.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestAuthorization.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.testcontainers.containers.PostgreSQLContainer;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -43,6 +44,7 @@ final class TestAuthorization
 {
     private static final OkHttpClient httpClient = new OkHttpClient();
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    private PostgreSQLContainer postgresql;
 
     int routerPort = 22000 + (int) (Math.random() * 1000);
 
@@ -50,7 +52,9 @@ final class TestAuthorization
     void setup()
             throws Exception
     {
-        HaGatewayTestUtils.TestConfig testConfig = HaGatewayTestUtils.buildGatewayConfigAndSeedDb(routerPort, "auth/auth-test-config.yml");
+        postgresql = new PostgreSQLContainer("postgres:16");
+        postgresql.start();
+        HaGatewayTestUtils.TestConfig testConfig = HaGatewayTestUtils.buildGatewayConfig(routerPort, "auth/auth-test-config.yml", postgresql);
         String[] args = {testConfig.configFilePath()};
         HaGatewayLauncher.main(args);
     }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestAuthorization.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestAuthorization.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.testcontainers.containers.PostgreSQLContainer;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -44,7 +45,7 @@ final class TestAuthorization
 {
     private static final OkHttpClient httpClient = new OkHttpClient();
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private PostgreSQLContainer postgresql;
+    private final PostgreSQLContainer postgresql = new PostgreSQLContainer("postgres:16");
 
     int routerPort = 22000 + (int) (Math.random() * 1000);
 
@@ -52,10 +53,9 @@ final class TestAuthorization
     void setup()
             throws Exception
     {
-        postgresql = new PostgreSQLContainer("postgres:16");
         postgresql.start();
-        HaGatewayTestUtils.TestConfig testConfig = HaGatewayTestUtils.buildGatewayConfig(routerPort, "auth/auth-test-config.yml", postgresql);
-        String[] args = {testConfig.configFilePath()};
+        File testConfigFile = HaGatewayTestUtils.buildGatewayConfig(postgresql, routerPort, "auth/auth-test-config.yml");
+        String[] args = {testConfigFile.getAbsolutePath()};
         HaGatewayLauncher.main(args);
     }
 

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestOIDC.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestOIDC.java
@@ -41,6 +41,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import java.io.File;
 import java.net.CookieManager;
 import java.net.CookiePolicy;
 import java.security.SecureRandom;
@@ -143,9 +144,9 @@ final class TestOIDC
         PostgreSQLContainer gatewayBackendDatabase = new PostgreSQLContainer("postgres:16");
         gatewayBackendDatabase.start();
 
-        HaGatewayTestUtils.TestConfig testConfig =
-                HaGatewayTestUtils.buildGatewayConfig(ROUTER_PORT, "auth/oauth-test-config.yml", gatewayBackendDatabase);
-        String[] args = {testConfig.configFilePath()};
+        File testConfigFile =
+                HaGatewayTestUtils.buildGatewayConfig(gatewayBackendDatabase, ROUTER_PORT, "auth/oauth-test-config.yml");
+        String[] args = {testConfigFile.getAbsolutePath()};
         System.out.println(ROUTER_PORT);
         HaGatewayLauncher.main(args);
     }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestOIDC.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestOIDC.java
@@ -140,8 +140,11 @@ final class TestOIDC
                         "--callbacks", callbackUrl);
         clientCreatingContainer.start();
 
+        PostgreSQLContainer gatewayBackendDatabase = new PostgreSQLContainer("postgres:16");
+        gatewayBackendDatabase.start();
+
         HaGatewayTestUtils.TestConfig testConfig =
-                HaGatewayTestUtils.buildGatewayConfigAndSeedDb(ROUTER_PORT, "auth/oauth-test-config.yml");
+                HaGatewayTestUtils.buildGatewayConfig(ROUTER_PORT, "auth/oauth-test-config.yml", gatewayBackendDatabase);
         String[] args = {testConfig.configFilePath()};
         System.out.println(ROUTER_PORT);
         HaGatewayLauncher.main(args);

--- a/gateway-ha/src/test/java/io/trino/gateway/proxyserver/TestProxyRequestHandler.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/proxyserver/TestProxyRequestHandler.java
@@ -28,10 +28,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.PostgreSQLContainer;
 
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.MediaType.JSON_UTF_8;
-import static io.trino.gateway.ha.HaGatewayTestUtils.buildGatewayConfigAndSeedDb;
+import static io.trino.gateway.ha.HaGatewayTestUtils.buildGatewayConfig;
 import static io.trino.gateway.ha.HaGatewayTestUtils.prepareMockBackend;
 import static io.trino.gateway.ha.HaGatewayTestUtils.setUpBackend;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,6 +43,7 @@ final class TestProxyRequestHandler
 {
     private final OkHttpClient httpClient = new OkHttpClient();
     private final MockWebServer mockTrinoServer = new MockWebServer();
+    private PostgreSQLContainer postgresql;
 
     private final int routerPort = 21001 + (int) (Math.random() * 1000);
     private final int customBackendPort = 21000 + (int) (Math.random() * 1000);
@@ -78,7 +80,10 @@ final class TestProxyRequestHandler
             }
         });
 
-        HaGatewayTestUtils.TestConfig testConfig = buildGatewayConfigAndSeedDb(routerPort, "test-config-template.yml");
+        postgresql = new PostgreSQLContainer("postgres:16");
+        postgresql.start();
+
+        HaGatewayTestUtils.TestConfig testConfig = buildGatewayConfig(routerPort, "test-config-template.yml", postgresql);
 
         String[] args = {testConfig.configFilePath()};
         HaGatewayLauncher.main(args);

--- a/gateway-ha/src/test/resources/auth/auth-test-config.yml
+++ b/gateway-ha/src/test/resources/auth/auth-test-config.yml
@@ -3,11 +3,10 @@ serverConfig:
   http-server.http.port: REQUEST_ROUTER_PORT
 
 dataStore:
-  jdbcUrl: jdbc:h2:DB_FILE_PATH
-  user: sa
-  password: sa
-  driver: org.h2.Driver
-  runMigrationsEnabled: false
+  jdbcUrl: POSTGRESQL_JDBC_URL
+  user: POSTGRESQL_USER
+  password: POSTGRESQL_PASSWORD
+  driver: org.postgresql.Driver
 
 extraWhitelistPaths:
   - '/v1/custom.*'

--- a/gateway-ha/src/test/resources/auth/oauth-test-config.yml
+++ b/gateway-ha/src/test/resources/auth/oauth-test-config.yml
@@ -7,11 +7,10 @@ serverConfig:
   http-server.https.keystore.key: 123456
 
 dataStore:
-  jdbcUrl: jdbc:h2:DB_FILE_PATH
-  user: sa
-  password: sa
-  driver: org.h2.Driver
-  runMigrationsEnabled: false
+  jdbcUrl: POSTGRESQL_JDBC_URL
+  user: POSTGRESQL_USER
+  password: POSTGRESQL_PASSWORD
+  driver: org.postgresql.Driver
 
 extraWhitelistPaths:
   - '/v1/custom.*'

--- a/gateway-ha/src/test/resources/test-config-template.yml
+++ b/gateway-ha/src/test/resources/test-config-template.yml
@@ -4,11 +4,10 @@ serverConfig:
 
 includeClusterHostInResponse: true
 dataStore:
-  jdbcUrl: jdbc:h2:DB_FILE_PATH
-  user: sa
-  password: sa
-  driver: org.h2.Driver
-  runMigrationsEnabled: false
+  jdbcUrl: POSTGRESQL_JDBC_URL
+  user: POSTGRESQL_USER
+  password: POSTGRESQL_PASSWORD
+  driver: org.postgresql.Driver
 
 clusterStatsConfiguration:
   monitorType: INFO_API

--- a/gateway-ha/src/test/resources/test-config-with-routing-template.yml
+++ b/gateway-ha/src/test/resources/test-config-with-routing-template.yml
@@ -3,11 +3,10 @@ serverConfig:
   http-server.http.port: REQUEST_ROUTER_PORT
 
 dataStore:
-  jdbcUrl: jdbc:h2:DB_FILE_PATH
-  user: sa
-  password: sa
-  driver: org.h2.Driver
-  runMigrationsEnabled: false
+  jdbcUrl: POSTGRESQL_JDBC_URL
+  user: POSTGRESQL_USER
+  password: POSTGRESQL_PASSWORD
+  driver: org.postgresql.Driver
 
 clusterStatsConfiguration:
   monitorType: INFO_API

--- a/gateway-ha/src/test/resources/test-config-without-x-forwarded-template.yml
+++ b/gateway-ha/src/test/resources/test-config-without-x-forwarded-template.yml
@@ -3,11 +3,10 @@ serverConfig:
   http-server.http.port: REQUEST_ROUTER_PORT
 
 dataStore:
-  jdbcUrl: jdbc:h2:DB_FILE_PATH
-  user: sa
-  password: sa
-  driver: org.h2.Driver
-  runMigrationsEnabled: false
+  jdbcUrl: POSTGRESQL_JDBC_URL
+  user: POSTGRESQL_USER
+  password: POSTGRESQL_PASSWORD
+  driver: org.postgresql.Driver
 
 clusterStatsConfiguration:
   monitorType: INFO_API


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This PR does 2 things:

1. update tests to use postgresql instead of h2 
2. adds Oracle as an option for the backend database. This required updates to the query history DAO since `LIMIT` is not supported in Oracle

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
