### PR TITLE
Add health check API endpoints

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -347,7 +347,7 @@ Standard Helm options such as `replicaCount`, `image`, `imagePullSecrets`,
 More detail about the chart are available in the [values 
 reference documentation](https://github.com/trinodb/charts/blob/main/charts/gateway/README.md)
 
-### Health Checks on Trino Clusters
+### Health checks on Trino clusters
 
 The Trino Gateway periodically performs health checks and maintains
 an in-memory TrinoStatus for each backend. If a backend fails a health check,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -347,7 +347,7 @@ Standard Helm options such as `replicaCount`, `image`, `imagePullSecrets`,
 More detail about the chart are available in the [values 
 reference documentation](https://github.com/trinodb/charts/blob/main/charts/gateway/README.md)
 
-### Health Checks
+### Health Checks on Trino Clusters
 
 The Trino Gateway periodically performs health checks and maintains
 an in-memory TrinoStatus for each backend. If a backend fails a health check,

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -72,7 +72,7 @@ scrape_configs:
 Trino Gateway provides two API endpoints to indicate the current status of the server:
 
 * `/trino-gateway/livez` always returns status code 200, indicating the server is
-alive. However, it might not respond if the gateway is too busy, stuck, or
+alive. However, it might not respond if the Trino Gateway is too busy, stuck, or
 taking a long time for garbage collection.
 * `/trino-gateway/readyz` returns status code 200, indicating the server has
 completed initialization and is ready to serve requests. This means the initial

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -72,5 +72,6 @@ scrape_configs:
 Trino Gateway provides two API endpoints to indicate the current status of the server:
 * `/trino-gateway/livez` returns status code 200, indicating the server is alive.
 * `/trino-gateway/readyz` returns status code 200, indicating the server has
-completed initialization and is ready to serve requests. Otherwise, status code
-503 is returned.
+completed initialization and is ready to serve requests. This means the initial
+connection to database and the first round of health check on Trino clusters
+were completed. Otherwise, status code 503 is returned.

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -77,4 +77,4 @@ taking a long time for garbage collection.
 * `/trino-gateway/readyz` returns status code 200, indicating the server has
 completed initialization and is ready to serve requests. This means the initial
 connection to the database and the first round of health check on Trino clusters
-were completed. Otherwise, status code 503 is returned.
+are completed. Otherwise, status code 503 is returned.

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -70,6 +70,7 @@ scrape_configs:
 ## Trino Gateway health endpoints
 
 Trino Gateway provides two API endpoints to indicate the current status of the server:
+
 * `/trino-gateway/livez` always returns status code 200, indicating the server is
 alive. However, it might not respond if the gateway is too busy, stuck, or
 taking a long time for garbage collection.

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -36,6 +36,7 @@ documentation](https://trino.io/docs/current/admin/graceful-shutdown.html) for
 more details.
 
 ## Query routing options
+
 - The default router selects the backend randomly to route the queries. 
 - If you want to route the queries to the least loaded backend for a user
 i.e. backend with the least number of queries running or queued from a particular user,
@@ -65,3 +66,11 @@ scrape_configs:
     - targets:
         - gateway1.example.com:8080
 ```
+
+## API health endpoints
+
+Trino Gateway provides two API endpoints to indicate the current status of the server.
+`/trino-gateway/livez` returns status code 200, indicating the server is alive.
+`/trino-gateway/readyz` returns status code 200, indicating the server has
+completed initialization and is ready to serve requests. Otherwise, status code
+503 will be returned.

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -70,7 +70,9 @@ scrape_configs:
 ## Trino Gateway health endpoints
 
 Trino Gateway provides two API endpoints to indicate the current status of the server:
-* `/trino-gateway/livez` returns status code 200, indicating the server is alive.
+* `/trino-gateway/livez` always returns status code 200, indicating the server is
+alive. However, it might not respond if the gateway is too busy, stuck, or
+taking a long time for garbage collection.
 * `/trino-gateway/readyz` returns status code 200, indicating the server has
 completed initialization and is ready to serve requests. This means the initial
 connection to database and the first round of health check on Trino clusters

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -67,10 +67,10 @@ scrape_configs:
         - gateway1.example.com:8080
 ```
 
-## API health endpoints
+## Trino Gateway health endpoints
 
-Trino Gateway provides two API endpoints to indicate the current status of the server.
-`/trino-gateway/livez` returns status code 200, indicating the server is alive.
-`/trino-gateway/readyz` returns status code 200, indicating the server has
+Trino Gateway provides two API endpoints to indicate the current status of the server:
+* `/trino-gateway/livez` returns status code 200, indicating the server is alive.
+* `/trino-gateway/readyz` returns status code 200, indicating the server has
 completed initialization and is ready to serve requests. Otherwise, status code
-503 will be returned.
+503 is returned.

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -76,5 +76,5 @@ alive. However, it might not respond if the Trino Gateway is too busy, stuck, or
 taking a long time for garbage collection.
 * `/trino-gateway/readyz` returns status code 200, indicating the server has
 completed initialization and is ready to serve requests. This means the initial
-connection to database and the first round of health check on Trino clusters
+connection to the database and the first round of health check on Trino clusters
 were completed. Otherwise, status code 503 is returned.

--- a/gateway-ha/src/main/java/io/trino/gateway/baseapp/BaseApp.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/baseapp/BaseApp.java
@@ -26,6 +26,7 @@ import io.trino.gateway.ha.handler.RoutingTargetHandler;
 import io.trino.gateway.ha.module.RouterBaseModule;
 import io.trino.gateway.ha.module.StochasticRoutingManagerProvider;
 import io.trino.gateway.ha.resource.EntityEditorResource;
+import io.trino.gateway.ha.resource.GatewayHealthCheckResource;
 import io.trino.gateway.ha.resource.GatewayResource;
 import io.trino.gateway.ha.resource.GatewayViewResource;
 import io.trino.gateway.ha.resource.GatewayWebAppResource;
@@ -179,6 +180,7 @@ public class BaseApp
         jaxrsBinder(binder).bind(PublicResource.class);
         jaxrsBinder(binder).bind(TrinoResource.class);
         jaxrsBinder(binder).bind(WebUIStaticResource.class);
+        jaxrsBinder(binder).bind(GatewayHealthCheckResource.class);
     }
 
     private static void registerAuthFilters(Binder binder)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ActiveClusterMonitor.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ActiveClusterMonitor.java
@@ -37,6 +37,7 @@ public class ActiveClusterMonitor
     public static final int DEFAULT_THREAD_POOL_SIZE = 20;
     private static final Logger log = Logger.get(ActiveClusterMonitor.class);
 
+    private volatile boolean isInitialized;
     private final List<TrinoClusterStatsObserver> clusterStatsObservers;
     private final GatewayBackendManager gatewayBackendManager;
 
@@ -83,6 +84,7 @@ public class ActiveClusterMonitor
                         observer.observe(stats);
                     }
                 }
+                isInitialized = true;
             }
             catch (Exception e) {
                 log.error(e, "Error performing backend monitor tasks");
@@ -95,5 +97,10 @@ public class ActiveClusterMonitor
     {
         executorService.shutdownNow();
         scheduledExecutor.shutdownNow();
+    }
+
+    public boolean isInitialized()
+    {
+        return isInitialized;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayHealthCheckResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayHealthCheckResource.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.resource;
+
+import com.google.inject.Inject;
+import io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import static java.util.Objects.requireNonNull;
+
+@Path("/trino-gateway")
+public class GatewayHealthCheckResource
+{
+    private final ActiveClusterMonitor activeClusterMonitor;
+
+    @Inject
+    public GatewayHealthCheckResource(ActiveClusterMonitor activeClusterMonitor)
+    {
+        this.activeClusterMonitor = requireNonNull(activeClusterMonitor, "activeClusterMonitor is null");
+    }
+
+    @GET
+    @Path("/livez")
+    public Response liveness()
+    {
+        return Response.ok("ok").build();
+    }
+
+    @GET
+    @Path("/readyz")
+    public Response readiness()
+    {
+        if (!activeClusterMonitor.isInitialized()) {
+            return Response
+                    .status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity("Trino Gateway is still initializing")
+                    .build();
+        }
+        return Response.ok("ok").build();
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Add two new health check API endpoints: `/trino-gateway/livez` and `/trino-gateway/readyz`.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
`/trino-gateway/livez` always returns 200.
`/trino-gateway/readyz` returns 200 after the initial fetch from database and the first round of Trino cluster health check is completed. Otherwise, 503 will be returned.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes
(x) Release notes are required, with the following suggested text:

```markdown
* Added API health endpoints `/trino-gateway/livez` and `/trino-gateway/readyz` for monitoring liveness and readiness. ({issue}`issuenumber`)
```
