### PR TITLE
Remove "Optional[]" from getResourceGroupQueryType string

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/TrinoQueryProperties.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/TrinoQueryProperties.java
@@ -206,7 +206,7 @@ public class TrinoQueryProperties
             }
 
             queryType = statement.getClass().getSimpleName();
-            resourceGroupQueryType = StatementUtils.getQueryType(statement).toString();
+            resourceGroupQueryType = StatementUtils.getResourceGroupQueryType(statement);
             ImmutableSet.Builder<QualifiedName> tableBuilder = ImmutableSet.builder();
             ImmutableSet.Builder<String> catalogBuilder = ImmutableSet.builder();
             ImmutableSet.Builder<String> schemaBuilder = ImmutableSet.builder();

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelector.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelector.java
@@ -179,6 +179,18 @@ final class TestRoutingGroupSelector
     }
 
     @Test
+    void testTrinoQueryPropertiesResourceGroupQueryType()
+            throws IOException
+    {
+        RoutingGroupSelector routingGroupSelector =
+                RoutingGroupSelector.byRoutingRulesEngine("src/test/resources/rules/routing_rules_trino_query_properties.yml", requestAnalyzerConfig);
+        HttpServletRequest mockRequest = prepareMockRequest();
+        when(mockRequest.getReader()).thenReturn(new BufferedReader(new StringReader("CREATE TABLE cat.schem.foo (c1 int)")));
+
+        assertThat(routingGroupSelector.findRoutingGroup(mockRequest)).isEqualTo("resource-group-type-group");
+    }
+
+    @Test
     void testTrinoQueryPropertiesAlternateStatementFormat()
             throws IOException
     {

--- a/gateway-ha/src/test/resources/rules/routing_rules_trino_query_properties.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_trino_query_properties.yml
@@ -32,6 +32,13 @@ condition: |
 actions:
   - "result.put(\"routingGroup\", \"type-group\")"
 ---
+name: "resource-group-query-type"
+description: "test table type"
+condition: |
+  trinoQueryProperties.getResourceGroupQueryType().equals("DATA_DEFINITION")
+actions:
+  - "result.put(\"routingGroup\", \"resource-group-type-group\")"
+---
 name: "prepared-statement-header"
 description: "test execute with multiple prepared statements"
 condition: |


### PR DESCRIPTION
TrinoQueryProperties.getResourceGroupQueryType() called `toString` on an `Optional`. This unintended behavior produced output such as `"Optional[DATA_DEFINITION]"`, complicating rule writing for end users.

<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Fix TrinoQueryProperties.getResourceGroupQueryType()
```
