### PR TITLE
Display cluster health status on cluster page

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterStats.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterStats.java
@@ -41,7 +41,7 @@ public record ClusterStats(
         private int runningQueryCount;
         private int queuedQueryCount;
         private int numWorkerNodes;
-        private TrinoStatus trinoStatus;
+        private TrinoStatus trinoStatus = TrinoStatus.UNKNOWN;
         private String proxyTo;
         private String externalUrl;
         private String routingGroup;

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/TrinoStatus.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/TrinoStatus.java
@@ -18,7 +18,7 @@ package io.trino.gateway.ha.clustermonitor;
  * We should use PENDING when Trino clusters are still spinning up
  * HEALTHY is when health checks report clusters as up
  * UNHEALTHY is when health checks report clusters as down
- * UNKNOWN is when the health checks are not able to determine the status
+ * UNKNOWN is the initial default state and also used when the health checks are not able to determine the status
  */
 public enum TrinoStatus
 {

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/TrinoStatus.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/TrinoStatus.java
@@ -18,10 +18,12 @@ package io.trino.gateway.ha.clustermonitor;
  * We should use PENDING when Trino clusters are still spinning up
  * HEALTHY is when health checks report clusters as up
  * UNHEALTHY is when health checks report clusters as down
+ * UNKNOWN is when the health checks are not able to determine the status
  */
 public enum TrinoStatus
 {
     PENDING,
     HEALTHY,
-    UNHEALTHY
+    UNHEALTHY,
+    UNKNOWN
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/response/BackendResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/response/BackendResponse.java
@@ -21,6 +21,7 @@ public class BackendResponse
 {
     private Integer queued;
     private Integer running;
+    private String status;
 
     @JsonProperty
     public Integer getQueued()
@@ -42,5 +43,16 @@ public class BackendResponse
     public void setRunning(Integer running)
     {
         this.running = running;
+    }
+
+    @JsonProperty
+    public String getStatus()
+    {
+        return status;
+    }
+
+    public void setStatus(String status)
+    {
+        this.status = status;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
@@ -99,7 +99,7 @@ public class GatewayWebAppResource
             backendResponse.setProxyTo(b.getProxyTo());
             backendResponse.setActive(b.isActive());
             if (Objects.isNull(backendState.trinoStatus())) {
-                backendResponse.setStatus(TrinoStatus.PENDING.toString());
+                backendResponse.setStatus(TrinoStatus.UNKNOWN.toString());
             }
             else {
                 backendResponse.setStatus(backendState.trinoStatus().toString());

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
@@ -16,7 +16,6 @@ package io.trino.gateway.ha.resource;
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import io.trino.gateway.ha.clustermonitor.ClusterStats;
-import io.trino.gateway.ha.clustermonitor.TrinoStatus;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 import io.trino.gateway.ha.domain.Result;
 import io.trino.gateway.ha.domain.TableData;
@@ -98,12 +97,7 @@ public class GatewayWebAppResource
             backendResponse.setName(b.getName());
             backendResponse.setProxyTo(b.getProxyTo());
             backendResponse.setActive(b.isActive());
-            if (Objects.isNull(backendState.trinoStatus())) {
-                backendResponse.setStatus(TrinoStatus.UNKNOWN.toString());
-            }
-            else {
-                backendResponse.setStatus(backendState.trinoStatus().toString());
-            }
+            backendResponse.setStatus(backendState.trinoStatus().toString());
             backendResponse.setRoutingGroup(b.getRoutingGroup());
             backendResponse.setExternalUrl(b.getExternalUrl());
             return backendResponse;

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
@@ -16,6 +16,7 @@ package io.trino.gateway.ha.resource;
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import io.trino.gateway.ha.clustermonitor.ClusterStats;
+import io.trino.gateway.ha.clustermonitor.TrinoStatus;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 import io.trino.gateway.ha.domain.Result;
 import io.trino.gateway.ha.domain.TableData;
@@ -97,6 +98,12 @@ public class GatewayWebAppResource
             backendResponse.setName(b.getName());
             backendResponse.setProxyTo(b.getProxyTo());
             backendResponse.setActive(b.isActive());
+            if (Objects.isNull(backendState.trinoStatus())) {
+                backendResponse.setStatus(TrinoStatus.PENDING.toString());
+            }
+            else {
+                backendResponse.setStatus(backendState.trinoStatus().toString());
+            }
             backendResponse.setRoutingGroup(b.getRoutingGroup());
             backendResponse.setExternalUrl(b.getExternalUrl());
             return backendResponse;

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestObjectSerializable.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestObjectSerializable.java
@@ -191,8 +191,9 @@ final class TestObjectSerializable
         backendResponse.setActive(false);
         backendResponse.setRoutingGroup("batch-1");
         backendResponse.setExternalUrl("example.com");
+        backendResponse.setStatus("HEALTHY");
         assertThat(objectMapper.writeValueAsString(backendResponse))
-                .contains(ImmutableList.of("queued", "running", "active", "routingGroup", "externalUrl", "name", "proxyTo"));
+                .contains(ImmutableList.of("queued", "running", "active", "routingGroup", "externalUrl", "name", "proxyTo", "status"));
     }
 
     @Test

--- a/webapp/src/components/cluster.tsx
+++ b/webapp/src/components/cluster.tsx
@@ -2,11 +2,12 @@ import { useEffect, useState } from "react";
 import styles from './cluster.module.scss';
 import Locale from "../locales";
 import { backendDeleteApi, backendSaveApi, backendUpdateApi, backendsApi } from "../api/webapp/cluster";
-import { Button, ButtonGroup, Card, Form, Modal, Popconfirm, Switch, Table, Typography } from "@douyinfe/semi-ui";
+import { Button, ButtonGroup, Card, Form, Modal, Popconfirm, Switch, Table, Tag, Typography } from "@douyinfe/semi-ui";
 import Column from "@douyinfe/semi-ui/lib/es/table/Column";
 import { FormApi } from "@douyinfe/semi-ui/lib/es/form";
 import { Role, useAccessStore } from "../store";
 import { BackendData } from "../types/cluster";
+import { TagColor } from "@douyinfe/semi-ui/lib/es/tag";
 
 export function Cluster() {
   const { Text } = Typography;
@@ -63,6 +64,24 @@ export function Cluster() {
     );
   }
 
+  const statusRender = (text: string) => {
+      let statusColor: TagColor;
+      switch (text) {
+          case 'HEALTHY':
+              statusColor = 'green';
+              break;
+          case 'UNHEALTHY':
+              statusColor = 'red';
+              break;
+          case 'PENDING':
+              statusColor = 'yellow';
+              break;
+          default:
+              statusColor = 'white';
+        }
+        return <Tag color={statusColor}>{text}</Tag>;
+    };
+
   return (
     <>
       <Card bordered={false} className={styles.card} bodyStyle={{ padding: '10px' }}>
@@ -85,6 +104,7 @@ export function Cluster() {
           <Column title="Queued" dataIndex="queued" key="queued" />
           <Column title="Running" dataIndex="running" key="running" />
           <Column title="Active" dataIndex="active" key="active" render={switchRender} />
+          <Column title="Status" dataIndex="status" key="status" render={statusRender}/>
           {access.hasRole(Role.ADMIN) && (
             <Column title={<>
               <ButtonGroup size={'default'}>

--- a/webapp/src/components/cluster.tsx
+++ b/webapp/src/components/cluster.tsx
@@ -76,8 +76,13 @@ export function Cluster() {
           case 'PENDING':
               statusColor = 'yellow';
               break;
-          default:
+          case 'UNKNOWN':
               statusColor = 'white';
+              break;
+          default:
+              //This should never happen, but just in case defaulting to UNKNOWN state setup as a safety net
+              statusColor = 'white';
+              break;
         }
         return <Tag color={statusColor}>{text}</Tag>;
     };

--- a/webapp/src/types/cluster.d.ts
+++ b/webapp/src/types/cluster.d.ts
@@ -6,4 +6,5 @@ export interface BackendData {
   externalUrl: string;
   queued: number;
   running: number;
+  status: string;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Display cluster health status on the cluster page

<img width="1173" alt="Screenshot 2025-01-28 at 12 27 56 AM" src="https://github.com/user-attachments/assets/be83aa10-8e86-4930-9aa4-b4082d4babee" />

<img width="1170" alt="Screenshot 2025-01-28 at 8 35 39 AM" src="https://github.com/user-attachments/assets/7046003b-ecad-4b66-a3b2-0f5bfb2e6c9e" />

<img width="1174" alt="Screenshot 2025-01-29 at 9 30 16 AM" src="https://github.com/user-attachments/assets/b4926e69-a428-4278-badb-df82afb478b8" />

<img width="1175" alt="Screenshot 2025-01-29 at 9 31 48 AM" src="https://github.com/user-attachments/assets/be65adb9-eccc-421d-9ead-f2f3a99a4ac6" />


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
