### PR TITLE
Show RoutingGroup info in query history

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/ProxyUtils.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/ProxyUtils.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.HttpMethod;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -118,8 +119,8 @@ public final class ProxyUtils
         return Optional.empty();
     }
 
-    public static String buildUriWithNewBackend(String backendHost, HttpServletRequest request)
+    public static URI buildUriWithNewCluster(String backendHost, HttpServletRequest request)
     {
-        return backendHost + request.getRequestURI() + (request.getQueryString() != null ? "?" + request.getQueryString() : "");
+        return URI.create(backendHost + request.getRequestURI() + (request.getQueryString() != null ? "?" + request.getQueryString() : ""));
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingDestination.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingDestination.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.handler;
+
+import java.net.URI;
+
+public record RoutingDestination(String routingGroup, String clusterHost, URI clusterUri) {}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/QueryHistory.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/QueryHistory.java
@@ -24,7 +24,8 @@ public record QueryHistory(
         @ColumnName("backend_url") String backendUrl,
         @ColumnName("user_name") @Nullable String userName,
         @ColumnName("source") @Nullable String source,
-        @ColumnName("created") long created)
+        @ColumnName("created") long created,
+        @ColumnName("routing_group") String routingGroup)
 {
     public QueryHistory
     {

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/QueryHistoryDao.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/QueryHistoryDao.java
@@ -78,6 +78,12 @@ public interface QueryHistoryDao
     String findBackendUrlByQueryId(String queryId);
 
     @SqlQuery("""
+            SELECT routing_group FROM query_history
+            WHERE query_id = :queryId
+            """)
+    String findRoutingGroupByQueryId(String queryId);
+
+    @SqlQuery("""
             SELECT * FROM query_history
             WHERE 1 = 1 <condition>
             ORDER BY created DESC
@@ -104,10 +110,10 @@ public interface QueryHistoryDao
     List<Map<String, Object>> findDistribution(long created);
 
     @SqlUpdate("""
-            INSERT INTO query_history (query_id, query_text, backend_url, user_name, source, created)
-            VALUES (:queryId, :queryText, :backendUrl, :userName, :source, :created)
+            INSERT INTO query_history (query_id, query_text, backend_url, user_name, source, created, routing_group)
+            VALUES (:queryId, :queryText, :backendUrl, :userName, :source, :created, :routingGroup)
             """)
-    void insertHistory(String queryId, String queryText, String backendUrl, String userName, String source, long created);
+    void insertHistory(String queryId, String queryText, String backendUrl, String userName, String source, long created, String routingGroup);
 
     @SqlUpdate("""
             DELETE FROM query_history

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/ExternalRoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/ExternalRoutingGroupSelector.java
@@ -78,7 +78,7 @@ public class ExternalRoutingGroupSelector
     }
 
     @Override
-    public String findRoutingGroup(HttpServletRequest servletRequest)
+    public Optional<String> findRoutingGroup(HttpServletRequest servletRequest)
     {
         try {
             RoutingGroupExternalBody requestBody = createRequestBody(servletRequest);
@@ -100,13 +100,13 @@ public class ExternalRoutingGroupSelector
             else if (response.errors() != null && !response.errors().isEmpty()) {
                 throw new RuntimeException("Response with error: " + String.join(", ", response.errors()));
             }
-            return response.routingGroup();
+            return Optional.ofNullable(response.routingGroup());
         }
         catch (Exception e) {
             log.error(e, "Error occurred while retrieving routing group "
                     + "from external routing rules processing at " + uri);
         }
-        return servletRequest.getHeader(ROUTING_GROUP_HEADER);
+        return Optional.ofNullable(servletRequest.getHeader(ROUTING_GROUP_HEADER));
     }
 
     private RoutingGroupExternalBody createRequestBody(HttpServletRequest request)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/FileBasedRoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/FileBasedRoutingGroupSelector.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.Suppliers.memoizeWithExpiration;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -60,7 +61,7 @@ public class FileBasedRoutingGroupSelector
     }
 
     @Override
-    public String findRoutingGroup(HttpServletRequest request)
+    public Optional<String> findRoutingGroup(HttpServletRequest request)
     {
         Map<String, String> result = new HashMap<>();
         Map<String, Object> state = new HashMap<>();
@@ -84,7 +85,7 @@ public class FileBasedRoutingGroupSelector
                 rule.evaluateAction(result, data, state);
             }
         });
-        return result.get(RESULTS_ROUTING_GROUP_KEY);
+        return Optional.ofNullable(result.get(RESULTS_ROUTING_GROUP_KEY));
     }
 
     public List<RoutingRule> readRulesFromPath(Path rulesPath)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
@@ -60,7 +60,8 @@ public class HaQueryHistoryManager
                 queryDetail.getBackendUrl(),
                 queryDetail.getUser(),
                 queryDetail.getSource(),
-                queryDetail.getCaptureTime());
+                queryDetail.getCaptureTime(),
+                queryDetail.getRoutingGroup());
     }
 
     @Override
@@ -87,6 +88,7 @@ public class HaQueryHistoryManager
             queryDetail.setBackendUrl(dao.backendUrl());
             queryDetail.setUser(dao.userName());
             queryDetail.setSource(dao.source());
+            queryDetail.setRoutingGroup(dao.routingGroup());
             queryDetails.add(queryDetail);
         }
         return queryDetails;
@@ -96,6 +98,12 @@ public class HaQueryHistoryManager
     public String getBackendForQueryId(String queryId)
     {
         return dao.findBackendUrlByQueryId(queryId);
+    }
+
+    @Override
+    public String getRoutingGroupForQueryId(String queryId)
+    {
+        return dao.findRoutingGroupByQueryId(queryId);
     }
 
     @Override

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/QueryCountBasedRouter.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/QueryCountBasedRouter.java
@@ -222,16 +222,16 @@ public class QueryCountBasedRouter
     }
 
     @Override
-    public String provideAdhocBackend(String user)
+    public String provideAdhocCluster(String user)
     {
         return getBackendForRoutingGroup("adhoc", user).orElseThrow(() -> new RouterException("did not find any cluster for the adhoc routing group"));
     }
 
     @Override
-    public String provideBackendForRoutingGroup(String routingGroup, String user)
+    public String provideClusterForRoutingGroup(String routingGroup, String user)
     {
         return getBackendForRoutingGroup(routingGroup, user)
-                .orElseGet(() -> provideAdhocBackend(user));
+                .orElse(provideAdhocCluster(user));
     }
 
     @Override

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/QueryHistoryManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/QueryHistoryManager.java
@@ -32,6 +32,8 @@ public interface QueryHistoryManager
 
     String getBackendForQueryId(String queryId);
 
+    String getRoutingGroupForQueryId(String queryId);
+
     TableData<QueryDetail> findQueryHistory(QueryHistoryRequest query);
 
     List<DistributionResponse.LineChart> findDistribution(Long ts);
@@ -45,6 +47,7 @@ public interface QueryHistoryManager
         private String source;
         private String backendUrl;
         private long captureTime;
+        private String routingGroup;
 
         public QueryDetail() {}
 
@@ -125,6 +128,17 @@ public interface QueryHistoryManager
             this.captureTime = captureTime;
         }
 
+        @JsonProperty
+        public String getRoutingGroup()
+        {
+            return this.routingGroup;
+        }
+
+        public void setRoutingGroup(String routingGroup)
+        {
+            this.routingGroup = routingGroup;
+        }
+
         @Override
         public boolean equals(Object o)
         {
@@ -140,13 +154,14 @@ public interface QueryHistoryManager
                     Objects.equals(queryText, that.queryText) &&
                     Objects.equals(user, that.user) &&
                     Objects.equals(source, that.source) &&
-                    Objects.equals(backendUrl, that.backendUrl);
+                    Objects.equals(backendUrl, that.backendUrl) &&
+                    Objects.equals(routingGroup, that.routingGroup);
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(queryId, queryText, user, source, backendUrl, captureTime);
+            return Objects.hash(queryId, queryText, user, source, backendUrl, captureTime, routingGroup);
         }
 
         @Override
@@ -159,6 +174,7 @@ public interface QueryHistoryManager
                     .add("source", source)
                     .add("backendUrl", backendUrl)
                     .add("captureTime", captureTime)
+                    .add("routingGroup", routingGroup)
                     .toString();
         }
     }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingGroupSelector.java
@@ -19,6 +19,8 @@ import io.trino.gateway.ha.config.RequestAnalyzerConfig;
 import io.trino.gateway.ha.config.RulesExternalConfiguration;
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.Optional;
+
 /**
  * RoutingGroupSelector provides a way to match an HTTP request to a Gateway routing group.
  */
@@ -32,7 +34,7 @@ public interface RoutingGroupSelector
      */
     static RoutingGroupSelector byRoutingGroupHeader()
     {
-        return request -> request.getHeader(ROUTING_GROUP_HEADER);
+        return request -> Optional.ofNullable(request.getHeader(ROUTING_GROUP_HEADER));
     }
 
     /**
@@ -60,5 +62,5 @@ public interface RoutingGroupSelector
      * Given an HTTP request find a routing group to direct the request to. If a routing group cannot
      * be determined return null.
      */
-    String findRoutingGroup(HttpServletRequest request);
+    Optional<String> findRoutingGroup(HttpServletRequest request);
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/StochasticRoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/StochasticRoutingManager.java
@@ -20,12 +20,12 @@ public class StochasticRoutingManager
         extends RoutingManager
 {
     private static final Logger log = Logger.get(StochasticRoutingManager.class);
-    QueryHistoryManager queryHistoryManager;
+    private final QueryHistoryManager queryHistoryManager;
 
     public StochasticRoutingManager(
             GatewayBackendManager gatewayBackendManager, QueryHistoryManager queryHistoryManager)
     {
-        super(gatewayBackendManager);
+        super(gatewayBackendManager, queryHistoryManager);
         this.queryHistoryManager = queryHistoryManager;
     }
 

--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/RouteToBackendResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/RouteToBackendResource.java
@@ -15,6 +15,7 @@ package io.trino.gateway.proxyserver;
 
 import com.google.inject.Inject;
 import io.trino.gateway.ha.handler.ProxyHandlerStats;
+import io.trino.gateway.ha.handler.RoutingDestination;
 import io.trino.gateway.ha.handler.RoutingTargetHandler;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.DELETE;
@@ -25,8 +26,6 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.Context;
-
-import java.net.URI;
 
 import static io.trino.gateway.ha.handler.HttpUtils.V1_STATEMENT_PATH;
 import static io.trino.gateway.proxyserver.RouterPreMatchContainerRequestFilter.ROUTE_TO_BACKEND;
@@ -65,8 +64,8 @@ public class RouteToBackendResource
         if (multiReadHttpServletRequest.getRequestURI().startsWith(V1_STATEMENT_PATH)) {
             proxyHandlerStats.recordRequest();
         }
-        String remoteUri = routingTargetHandler.getRoutingDestination(multiReadHttpServletRequest);
-        proxyRequestHandler.postRequest(body, multiReadHttpServletRequest, asyncResponse, URI.create(remoteUri));
+        RoutingDestination routingDestination = routingTargetHandler.getRoutingDestination(multiReadHttpServletRequest);
+        proxyRequestHandler.postRequest(body, multiReadHttpServletRequest, asyncResponse, routingDestination);
     }
 
     @GET
@@ -74,8 +73,8 @@ public class RouteToBackendResource
             @Context HttpServletRequest servletRequest,
             @Suspended AsyncResponse asyncResponse)
     {
-        String remoteUri = routingTargetHandler.getRoutingDestination(servletRequest);
-        proxyRequestHandler.getRequest(servletRequest, asyncResponse, URI.create(remoteUri));
+        RoutingDestination routingDestination = routingTargetHandler.getRoutingDestination(servletRequest);
+        proxyRequestHandler.getRequest(servletRequest, asyncResponse, routingDestination);
     }
 
     @DELETE
@@ -83,8 +82,8 @@ public class RouteToBackendResource
             @Context HttpServletRequest servletRequest,
             @Suspended AsyncResponse asyncResponse)
     {
-        String remoteUri = routingTargetHandler.getRoutingDestination(servletRequest);
-        proxyRequestHandler.deleteRequest(servletRequest, asyncResponse, URI.create(remoteUri));
+        RoutingDestination routingDestination = routingTargetHandler.getRoutingDestination(servletRequest);
+        proxyRequestHandler.deleteRequest(servletRequest, asyncResponse, routingDestination);
     }
 
     @PUT
@@ -94,7 +93,7 @@ public class RouteToBackendResource
             @Suspended AsyncResponse asyncResponse)
     {
         MultiReadHttpServletRequest multiReadHttpServletRequest = new MultiReadHttpServletRequest(servletRequest, body);
-        String remoteUri = routingTargetHandler.getRoutingDestination(multiReadHttpServletRequest);
-        proxyRequestHandler.putRequest(body, multiReadHttpServletRequest, asyncResponse, URI.create(remoteUri));
+        RoutingDestination routingDestination = routingTargetHandler.getRoutingDestination(multiReadHttpServletRequest);
+        proxyRequestHandler.putRequest(body, multiReadHttpServletRequest, asyncResponse, routingDestination);
     }
 }

--- a/gateway-ha/src/main/resources/mysql/V2__add_routingGroup_to_query_history.sql
+++ b/gateway-ha/src/main/resources/mysql/V2__add_routingGroup_to_query_history.sql
@@ -1,0 +1,2 @@
+ALTER TABLE query_history
+    ADD routing_group VARCHAR(255);

--- a/gateway-ha/src/main/resources/oracle/V2__add_routingGroup_to_query_history.sql
+++ b/gateway-ha/src/main/resources/oracle/V2__add_routingGroup_to_query_history.sql
@@ -1,0 +1,2 @@
+ALTER TABLE query_history
+    ADD routing_group VARCHAR(255);

--- a/gateway-ha/src/main/resources/postgresql/V2__add_routingGroup_to_query_history.sql
+++ b/gateway-ha/src/main/resources/postgresql/V2__add_routingGroup_to_query_history.sql
@@ -1,0 +1,2 @@
+ALTER TABLE query_history
+    ADD routing_group VARCHAR(255);

--- a/gateway-ha/src/test/java/io/trino/gateway/TrinoGatewayRunner.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/TrinoGatewayRunner.java
@@ -36,9 +36,11 @@ public final class TrinoGatewayRunner
 
         TrinoContainer trino1 = new TrinoContainer("trinodb/trino:466");
         trino1.setPortBindings(List.of("8081:8080"));
+        trino1.withCopyFileToContainer(forClasspathResource("trino-config.properties"), "/etc/trino/config.properties");
         trino1.start();
         TrinoContainer trino2 = new TrinoContainer("trinodb/trino:466");
         trino2.setPortBindings(List.of("8082:8080"));
+        trino2.withCopyFileToContainer(forClasspathResource("trino-config.properties"), "/etc/trino/config.properties");
         trino2.start();
 
         PostgreSQLContainer<?> postgres = new PostgreSQLContainer("postgres:16");

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryCountBasedRouter.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryCountBasedRouter.java
@@ -164,7 +164,7 @@ final class TestQueryCountBasedRouter
     {
         // The user u1 has same number of queries queued on each cluster
         // The query needs to be routed to cluster with least number of queries running
-        String proxyTo = queryCountBasedRouter.provideBackendForRoutingGroup("etl", "u1");
+        String proxyTo = queryCountBasedRouter.provideClusterForRoutingGroup("etl", "u1");
 
         assertThat(proxyTo).isEqualTo(BACKEND_URL_3);
         assertThat(proxyTo).isNotEqualTo(BACKEND_URL_UNHEALTHY);
@@ -179,7 +179,7 @@ final class TestQueryCountBasedRouter
         assertThat(c3Stats.userQueuedCount().getOrDefault("u1", 0))
                 .isEqualTo(6);
 
-        proxyTo = queryCountBasedRouter.provideBackendForRoutingGroup("etl", "u1");
+        proxyTo = queryCountBasedRouter.provideClusterForRoutingGroup("etl", "u1");
 
         assertThat(proxyTo).isEqualTo(BACKEND_URL_1);
         assertThat(proxyTo).isNotEqualTo(BACKEND_URL_UNHEALTHY);
@@ -190,7 +190,7 @@ final class TestQueryCountBasedRouter
     {
         // The user u2 has different number of queries queued on each cluster
         // The query needs to be routed to cluster with least number of queued for that user
-        String proxyTo = queryCountBasedRouter.provideAdhocBackend("u2");
+        String proxyTo = queryCountBasedRouter.provideAdhocCluster("u2");
         assertThat(BACKEND_URL_2).isEqualTo(proxyTo);
         assertThat(BACKEND_URL_UNHEALTHY).isNotEqualTo(proxyTo);
     }
@@ -198,7 +198,7 @@ final class TestQueryCountBasedRouter
     @Test
     void testUserWithDifferentQueueLengthUser2()
     {
-        String proxyTo = queryCountBasedRouter.provideAdhocBackend("u3");
+        String proxyTo = queryCountBasedRouter.provideAdhocCluster("u3");
         assertThat(BACKEND_URL_1).isEqualTo(proxyTo);
         assertThat(BACKEND_URL_UNHEALTHY).isNotEqualTo(proxyTo);
     }
@@ -206,7 +206,7 @@ final class TestQueryCountBasedRouter
     @Test
     void testUserWithNoQueuedQueries()
     {
-        String proxyTo = queryCountBasedRouter.provideAdhocBackend("u101");
+        String proxyTo = queryCountBasedRouter.provideAdhocCluster("u101");
         assertThat(BACKEND_URL_3).isEqualTo(proxyTo);
     }
 
@@ -214,7 +214,7 @@ final class TestQueryCountBasedRouter
     void testAdhocRoutingGroupFailOver()
     {
         // The ETL routing group doesn't exist
-        String proxyTo = queryCountBasedRouter.provideBackendForRoutingGroup("NonExisting", "u1");
+        String proxyTo = queryCountBasedRouter.provideClusterForRoutingGroup("NonExisting", "u1");
         assertThat(BACKEND_URL_3).isEqualTo(proxyTo);
         assertThat(BACKEND_URL_UNHEALTHY).isNotEqualTo(proxyTo);
     }
@@ -229,7 +229,7 @@ final class TestQueryCountBasedRouter
                 .build();
         queryCountBasedRouter.updateBackEndStats(clusters);
 
-        String proxyTo = queryCountBasedRouter.provideBackendForRoutingGroup("NonExisting", "u1");
+        String proxyTo = queryCountBasedRouter.provideClusterForRoutingGroup("NonExisting", "u1");
         assertThat(BACKEND_URL_4).isEqualTo(proxyTo);
         assertThat(BACKEND_URL_UNHEALTHY).isNotEqualTo(proxyTo);
     }
@@ -246,7 +246,7 @@ final class TestQueryCountBasedRouter
 
         queryCountBasedRouter.updateBackEndStats(clusters);
 
-        String proxyTo = queryCountBasedRouter.provideBackendForRoutingGroup("NonExisting", "u1");
+        String proxyTo = queryCountBasedRouter.provideClusterForRoutingGroup("NonExisting", "u1");
         assertThat(BACKEND_URL_5).isEqualTo(proxyTo);
         assertThat(BACKEND_URL_UNHEALTHY).isNotEqualTo(proxyTo);
     }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelector.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelector.java
@@ -85,11 +85,11 @@ final class TestRoutingGroupSelector
         // If the header is present the routing group is the value of that header.
         when(mockRequest.getHeader(ROUTING_GROUP_HEADER)).thenReturn("batch_backend");
         assertThat(RoutingGroupSelector.byRoutingGroupHeader().findRoutingGroup(mockRequest))
-                .isEqualTo("batch_backend");
+                .contains("batch_backend");
 
         // If the header is not present just return null.
         when(mockRequest.getHeader(ROUTING_GROUP_HEADER)).thenReturn(null);
-        assertThat(RoutingGroupSelector.byRoutingGroupHeader().findRoutingGroup(mockRequest)).isNull();
+        assertThat(RoutingGroupSelector.byRoutingGroupHeader().findRoutingGroup(mockRequest)).isEmpty();
     }
 
     @ParameterizedTest
@@ -103,7 +103,7 @@ final class TestRoutingGroupSelector
 
         when(mockRequest.getHeader(TRINO_SOURCE_HEADER)).thenReturn("airflow");
         assertThat(routingGroupSelector.findRoutingGroup(mockRequest))
-                .isEqualTo("etl");
+                .contains("etl");
     }
 
     @Test
@@ -120,7 +120,7 @@ final class TestRoutingGroupSelector
         when(mockRequest.getHeader("Authorization")).thenReturn("Basic " + encodedUsernamePassword);
 
         assertThat(routingGroupSelector.findRoutingGroup(mockRequest))
-                .isEqualTo("will-group");
+                .contains("will-group");
     }
 
     @Test
@@ -140,7 +140,7 @@ final class TestRoutingGroupSelector
         when(mockRequest.getHeader(TrinoQueryProperties.TRINO_CATALOG_HEADER_NAME)).thenReturn("cat_default");
         when(mockRequest.getHeader(TrinoQueryProperties.TRINO_SCHEMA_HEADER_NAME)).thenReturn("schem_\\\"default");
 
-        assertThat(routingGroupSelector.findRoutingGroup(mockRequest)).isEqualTo("tbl-group");
+        assertThat(routingGroupSelector.findRoutingGroup(mockRequest)).contains("tbl-group");
     }
 
     @Test
@@ -160,7 +160,7 @@ final class TestRoutingGroupSelector
         when(mockRequest.getHeader(TrinoQueryProperties.TRINO_CATALOG_HEADER_NAME)).thenReturn("catx");
         when(mockRequest.getHeader(TrinoQueryProperties.TRINO_SCHEMA_HEADER_NAME)).thenReturn("default");
 
-        assertThat(routingGroupSelector.findRoutingGroup(mockRequest)).isEqualTo("catalog-schema-group");
+        assertThat(routingGroupSelector.findRoutingGroup(mockRequest)).contains("catalog-schema-group");
     }
 
     @Test
@@ -176,7 +176,7 @@ final class TestRoutingGroupSelector
         when(mockRequest.getHeader(TrinoQueryProperties.TRINO_CATALOG_HEADER_NAME)).thenReturn("other_catalog");
         when(mockRequest.getHeader(TrinoQueryProperties.TRINO_SCHEMA_HEADER_NAME)).thenReturn("other_schema");
 
-        assertThat(routingGroupSelector.findRoutingGroup(mockRequest)).isEqualTo("defaults-group");
+        assertThat(routingGroupSelector.findRoutingGroup(mockRequest)).contains("defaults-group");
     }
 
     @Test
@@ -194,7 +194,7 @@ final class TestRoutingGroupSelector
         HttpServletRequest mockRequest = prepareMockRequest();
         when(mockRequest.getReader()).thenReturn(bufferedReader);
 
-        assertThat(routingGroupSelector.findRoutingGroup(mockRequest)).isEqualTo("type-group");
+        assertThat(routingGroupSelector.findRoutingGroup(mockRequest)).contains("type-group");
     }
 
     @Test
@@ -209,7 +209,7 @@ final class TestRoutingGroupSelector
         HttpServletRequest mockRequest = prepareMockRequest();
         when(mockRequest.getReader()).thenReturn(new BufferedReader(new StringReader("CREATE TABLE cat.schem.foo (c1 int)")));
 
-        assertThat(routingGroupSelector.findRoutingGroup(mockRequest)).isEqualTo("resource-group-type-group");
+        assertThat(routingGroupSelector.findRoutingGroup(mockRequest)).contains("resource-group-type-group");
     }
 
     @Test
@@ -228,7 +228,7 @@ final class TestRoutingGroupSelector
         HttpServletRequest mockRequest = prepareMockRequest();
         when(mockRequest.getReader()).thenReturn(bufferedReader);
 
-        assertThat(routingGroupSelector.findRoutingGroup(mockRequest)).isEqualTo("type-group");
+        assertThat(routingGroupSelector.findRoutingGroup(mockRequest)).contains("type-group");
     }
 
     @Test
@@ -252,7 +252,7 @@ final class TestRoutingGroupSelector
         when(mockRequest.getHeader(TrinoQueryProperties.TRINO_CATALOG_HEADER_NAME)).thenReturn("cat");
         when(mockRequest.getHeader(TrinoQueryProperties.TRINO_SCHEMA_HEADER_NAME)).thenReturn("schem");
 
-        assertThat(routingGroupSelector.findRoutingGroup(mockRequest)).isEqualTo("statement-header-group");
+        assertThat(routingGroupSelector.findRoutingGroup(mockRequest)).contains("statement-header-group");
     }
 
     @ParameterizedTest
@@ -268,7 +268,7 @@ final class TestRoutingGroupSelector
         when(mockRequest.getHeader(TRINO_CLIENT_TAGS_HEADER)).thenReturn(
                 "email=test@example.com,label=special");
         assertThat(routingGroupSelector.findRoutingGroup(mockRequest))
-                .isEqualTo("etl-special");
+                .contains("etl-special");
     }
 
     @ParameterizedTest
@@ -283,7 +283,7 @@ final class TestRoutingGroupSelector
         // should return no match
         when(mockRequest.getHeader(TRINO_CLIENT_TAGS_HEADER)).thenReturn(
                 "email=test@example.com,label=special");
-        assertThat(routingGroupSelector.findRoutingGroup(mockRequest)).isNull();
+        assertThat(routingGroupSelector.findRoutingGroup(mockRequest)).isEmpty();
     }
 
     @Test
@@ -310,7 +310,7 @@ final class TestRoutingGroupSelector
 
         when(mockRequest.getHeader(TRINO_SOURCE_HEADER)).thenReturn("airflow");
         assertThat(routingGroupSelector.findRoutingGroup(mockRequest))
-                .isEqualTo("etl");
+                .contains("etl");
 
         try (BufferedWriter writer = Files.newBufferedWriter(file.toPath(), UTF_8)) {
             writer.write(
@@ -325,7 +325,7 @@ final class TestRoutingGroupSelector
 
         when(mockRequest.getHeader(TRINO_SOURCE_HEADER)).thenReturn("airflow");
         assertThat(routingGroupSelector.findRoutingGroup(mockRequest))
-                .isEqualTo("etl2");
+                .contains("etl2");
         file.deleteOnExit();
     }
 

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelectorExternal.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelectorExternal.java
@@ -152,7 +152,7 @@ final class TestRoutingGroupSelectorExternal
 
         // Verify the response
         assertThat(routingGroupSelector.findRoutingGroup(mockRequest))
-                .isEqualTo("default-group-api-failure");
+                .contains("default-group-api-failure");
     }
 
     @Test

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
@@ -67,7 +67,7 @@ final class TestStochasticRoutingManager
             haRoutingManager.updateBackEndHealth(backend, TrinoStatus.UNHEALTHY);
         }
 
-        assertThat(haRoutingManager.provideBackendForRoutingGroup(groupName, ""))
+        assertThat(haRoutingManager.provideClusterForRoutingGroup(groupName, ""))
                 .isEqualTo("test_group0.trino.example.com");
     }
 }

--- a/webapp/src/components/history.tsx
+++ b/webapp/src/components/history.tsx
@@ -81,6 +81,12 @@ export function History() {
     );
   }
 
+  const routingGroupRender = (_: string, record: HistoryDetail) => {
+    return (
+        <Text>{record.routingGroup}</Text>
+    )
+  }
+
   return (
     <>
       <Card bordered={false} className={styles.card} bodyStyle={{ padding: '10px' }}>
@@ -115,6 +121,7 @@ export function History() {
           onPageChange: list,
         }}>
           <Column title="QueryId" dataIndex="queryId" key="queryId" render={linkQueryRender} />
+          <Column title="RoutingGroup" dataIndex="routingGroup" key="routingGroup" render={routingGroupRender} />
           <Column title="RoutedTo" dataIndex="backendUrl" key="backendUrlName" render={(text: string) => <Text>{backendMapping[text]}</Text>} />
           <Column title="RoutedTo" dataIndex="backendUrl" key="backendUrl" render={linkRender} />
           <Column title="User" dataIndex="user" key="user" />

--- a/webapp/src/types/history.d.ts
+++ b/webapp/src/types/history.d.ts
@@ -5,6 +5,7 @@ export interface HistoryDetail {
   source: string;
   backendUrl: string;
   captureTime: number;
+  routingGroup: string;
 }
 
 export interface HistoryData {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

It is useful to show what routing group a request is being routed to because if two routing groups have the same `routedTo` url, it will show the wrong information on the history page

Old:
![image](https://github.com/user-attachments/assets/c6da73fb-271c-40f1-aa84-4caeab4368b1)


New:
![image](https://github.com/user-attachments/assets/e118fd6a-5ff2-4f65-b8ac-3cca1f57e359)



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
