### PR TITLE
Conditionally skip Oracle tests

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -30,6 +30,10 @@ compilation and testing are specified in `.mvn/jvm.config`.
 Edit the configuration file `gateway-ha-config.yml` in the `gateway-ha` folder
 and update the mysql db information.
 
+Note that tests using Oracle are disabled by default on non-x86_64 CPU architectures.
+To enable them, set the environment variable `TG_RUN_ORACLE_TESTS=true`. These tests
+will always be run in GitHub CI.
+
 ```shell
 cd gateway-ha/target/
 java -jar gateway-ha-{{VERSION}}-jar-with-dependencies.jar ../gateway-ha-config.yml

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/HaGatewayTestUtils.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/HaGatewayTestUtils.java
@@ -27,6 +27,7 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
+import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import java.io.BufferedWriter;
@@ -47,6 +48,7 @@ import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class HaGatewayTestUtils
 {
@@ -145,6 +147,15 @@ public class HaGatewayTestUtils
         Response response = httpClient.newCall(request).execute();
         assertThat(response.isSuccessful()).isTrue();
         verifyTrinoStatus(routerPort, name);
+    }
+
+    public static OracleContainer getOracleContainer()
+    {
+        // reference for GITHUB_ACTIONS: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
+        assumeTrue("true".equals(System.getenv("GITHUB_ACTIONS"))
+                || "x86_64".equalsIgnoreCase(System.getProperty("os.arch"))
+                || "true".equals(System.getenv("TG_RUN_ORACLE_TESTS")));
+        return new OracleContainer("gvenzl/oracle-xe:18.4.0-slim");
     }
 
     private static void verifyTrinoStatus(int port, String name)

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/HaGatewayTestUtils.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/HaGatewayTestUtils.java
@@ -151,7 +151,12 @@ public class HaGatewayTestUtils
 
     public static OracleContainer getOracleContainer()
     {
-        // reference for GITHUB_ACTIONS: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
+        // gvenzl/oracle-xe:18.4.0-slim is x86 only, and tests using this image will most likely timeout if
+        // run on other CPU architectures. This test should run in three circumstances:
+        // * in CI, defined by the presence of GitHub environment variables
+        // * if the CPU architecture is x86_64
+        // * if they are explicitly enabled by setting TG_RUN_ORACLE_TESTS=true in the test environment
+        // reference: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
         assumeTrue("true".equals(System.getenv("GITHUB_ACTIONS"))
                 || "x86_64".equalsIgnoreCase(System.getProperty("os.arch"))
                 || "true".equals(System.getenv("TG_RUN_ORACLE_TESTS")));

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestDatabaseMigrationsOracle.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestDatabaseMigrationsOracle.java
@@ -15,10 +15,10 @@ package io.trino.gateway.ha.persistence;
 
 import com.google.common.collect.ImmutableList;
 import org.jdbi.v3.core.Handle;
-import org.testcontainers.containers.OracleContainer;
 
 import java.util.List;
 
+import static io.trino.gateway.ha.HaGatewayTestUtils.getOracleContainer;
 import static java.lang.String.format;
 
 final class TestDatabaseMigrationsOracle
@@ -26,7 +26,7 @@ final class TestDatabaseMigrationsOracle
 {
     public TestDatabaseMigrationsOracle()
     {
-        super(new OracleContainer("gvenzl/oracle-xe:18.4.0-slim"), "TEST");
+        super(getOracleContainer(), "TEST");
     }
 
     @Override

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryHistoryManagerOracle.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryHistoryManagerOracle.java
@@ -14,7 +14,8 @@
 package io.trino.gateway.ha.router;
 
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.OracleContainer;
+
+import static io.trino.gateway.ha.HaGatewayTestUtils.getOracleContainer;
 
 public class TestQueryHistoryManagerOracle
         extends BaseTestQueryHistoryManager
@@ -22,7 +23,7 @@ public class TestQueryHistoryManagerOracle
     @Override
     protected final JdbcDatabaseContainer<?> startContainer()
     {
-        JdbcDatabaseContainer<?> container = new OracleContainer("gvenzl/oracle-xe:18.4.0-slim");
+        JdbcDatabaseContainer<?> container = getOracleContainer();
         container.start();
         return container;
     }


### PR DESCRIPTION
The Oracle test container runs very slowly on non x86 architectures, which causes tests to fail. These tests will be skipped unless they are running in Github Actions, on an x86_64, or explicitly enabled by setting the env var TG_RUN_ORACLE_TESTS=true.

<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
