### PR TITLE
Add Trino Gateway 15 release notes

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,7 +22,7 @@ It  copies the following, necessary files to current directory:
 ```shell
 #!/usr/bin/env sh
 
-VERSION=14
+VERSION=15
 BASE_URL="https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha"
 POSTGRES_SQL="gateway-ha-persistence-postgres.sql"
 JAR_FILE="gateway-ha-$VERSION-jar-with-dependencies.jar"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,36 @@
 
 ## 2025
 
+### Trino Gateway 15 (12 Mar 2025) { id="15" }
+
+Artifacts:
+
+* [JAR file gateway-ha-15-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/15/gateway-ha-15-jar-with-dependencies.jar)
+* Container image `trinodb/trino-gateway:15`
+* Source code as
+  [tar.gz](https://github.com/trinodb/trino-gateway/archive/refs/tags/15.tar.gz)
+  or [zip](https://github.com/trinodb/trino-gateway/archive/refs/tags/15.zip)
+* [Trino Helm chart](https://trinodb.github.io/charts/) `trino/trino-gateway` version `1.15.0`
+
+Changes:
+
+* Add pop up messages for operations in the user interface.
+  ([#617](https://github.com/trinodb/trino-gateway/pull/617))
+* Add support for configuring custom OpenMetrics from the Trino clusters for the
+  metrics monitor health check.
+  ([#621](https://github.com/trinodb/trino-gateway/pull/621))
+* [:warning: Breaking change:](#breaking) Change paths and file names in the
+  Docker image. Configuration file name is `/opt/trino-gateway/config.yaml` and 
+  folder names use `trino-gateway` consistently.  
+  ([#623](https://github.com/trinodb/trino-gateway/pull/623)) and 
+  ([#628](https://github.com/trinodb/trino-gateway/pull/628))
+* Prevent proxy failures resulting from backend URL configuration containing a 
+  trailing slash.
+  ([#564](https://github.com/trinodb/trino-gateway/issues/564))
+* Fix query errors when adhoc routing group has no healthy backends.
+  ([#630](https://github.com/trinodb/trino-gateway/pull/630)) and
+  ([#641](https://github.com/trinodb/trino-gateway/issues/641))
+
 ### Trino Gateway 14 (14 Feb 2025) { id="14" }
 
 Artifacts:


### PR DESCRIPTION
## Description

Assemble the release notes for Trino Gateway 15 release and adjust rest of docs to version 15.

Release date is set to the planned date following our monthly release cadence.

## Additional context and related issues

* https://github.com/trinodb/charts/pull/315
* https://github.com/trinodb/charts/pull/310

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Verification for each pull request

Format: PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

Any dates missing in the list just had no merged PRs.

## 19 Feb 2024

* #622 ✅ rn ✅ docs
* #623 ✅ rn ✅ docs

## 26 Feb 2024

* #632 ✅ rn ✅ docs
* #628 ✅ rn ✅ docs
* #617 ✅ rn ✅ docs
* #614 ✅ rn ✅ docs

## 4 Mar 2024

* #570 ✅ rn ✅ docs

## 5 Mar 2024

* #530 ✅ rn ✅ docs

## 6 Mar 2024

* #630 ✅ rn ✅ docs

## 7 Mar 2024

* #621 ✅ rn ✅ docs
* #626 ✅ rn ✅ docs

## 11 Mar 2024

* #640 ✅ rn ✅ docs

## 12 Mar 2024

* #642 ✅ rn ✅ docs