### PR TITLE
Update METRICS monitor to configure custom metrics for running and qu…

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -394,6 +394,24 @@ It retrieves the number of running and queued queries for use with
 the `QueryCountBasedRouter` (either `METRICS` or `JDBC` must be enabled if
 `QueryCountBasedRouter` is used).
 
+By default, it uses the `trino_execution_name_QueryManager_RunningQueries` and
+`trino_execution_name_QueryManager_QueuedQueries` to track the number of running
+and queued queries respectively, however these metrics can be configured as follows:
+
+```yaml
+monitor:
+    runningQueriesMetricName: io_starburst_galaxy_name_GalaxyMetrics_RunningQueries
+    queuedQueriesMetricName: io_starburst_galaxy_name_GalaxyMetrics_QueuedQueries
+```
+
+Similarly, by default the monitor pulls the metrics using the `/metrics` endpoint, but it
+can be updated to use another one:
+
+```yaml
+monitor:
+    metricsEndpoint: /v1/metrics
+```
+
 This monitor allows customizing health definitions by comparing metrics to fixed
 values. This is configured through two maps: `metricMinimumValues` and 
 `metricMaximumValues`. The keys of these maps are the metric names, and the values
@@ -401,7 +419,7 @@ are the minimum or maximum values (inclusive) that are considered healthy. By de
 the only metric populated is:
 
 ```yaml
-monitorConfiguration:
+monitor:
     metricMinimumValues:
         trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount: 1
 ```
@@ -412,7 +430,7 @@ worker count to 10 and disqualify clusters that have been experiencing frequent 
 Collections, set
 
 ```yaml
-monitorConfiguration:
+monitor:
     metricMinimumValues:
         trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount: 10
     metricMaximumValues:
@@ -428,19 +446,21 @@ method of backend clusters. Configure a username and password by adding
 `backendState` to your configuration. The username and password must be valid 
 across all backends.
 
-Trino Gateway uses `explicitPrepare=false` by default. This property was introduced
-in Trino 431, and uses a single query for prepared statements, instead of a 
-`PREPARE/EXECUTE` pair. If you are using the JDBC health check option with older 
-versions of Trino, set
-```yaml
-monitorConfiguration:
-   explicitPrepare: false
-```
-
 ```yaml
 backendState:
   username: "user"
   password: "password"
+```
+
+Trino Gateway allows to define the `explicitPrepare` property for the JDBC monitor.
+This property was introduced in Trino 431, and uses a single query for prepared
+statements when set to `false`, instead of a `PREPARE/EXECUTE` pair.
+If you are using Trino 431 or later, you can improve latency for prepared statements
+by setting:
+
+```yaml
+monitor:
+   explicitPrepare: false
 ```
 
 The query timeout can be set through

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterStatsMetricsMonitor.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterStatsMetricsMonitor.java
@@ -46,8 +46,6 @@ import static java.util.Objects.requireNonNull;
 public class ClusterStatsMetricsMonitor
         implements ClusterStatsMonitor
 {
-    public static final String RUNNING_QUERIES_METRIC = "trino_execution_name_QueryManager_RunningQueries";
-    public static final String QUEUED_QUERIES_METRIC = "trino_execution_name_QueryManager_QueuedQueries";
     private static final Logger log = Logger.get(ClusterStatsMetricsMonitor.class);
 
     private final HttpClient httpClient;
@@ -55,6 +53,8 @@ public class ClusterStatsMetricsMonitor
     private final MetricsResponseHandler metricsResponseHandler;
     private final Header identityHeader;
     private final String metricsEndpoint;
+    private final String runningQueriesMetricName;
+    private final String queuedQueriesMetricName;
     private final ImmutableSet<String> metricNames;
     private final Map<String, Float> metricMinimumValues;
     private final Map<String, Float> metricMaximumValues;
@@ -71,10 +71,12 @@ public class ClusterStatsMetricsMonitor
             identityHeader = new Header("X-Trino-User", backendStateConfiguration.getUsername());
         }
         metricsEndpoint = monitorConfiguration.getMetricsEndpoint();
+        runningQueriesMetricName = monitorConfiguration.getRunningQueriesMetricName();
+        queuedQueriesMetricName = monitorConfiguration.getQueuedQueriesMetricName();
         metricMinimumValues = ImmutableMap.copyOf(monitorConfiguration.getMetricMinimumValues());
         metricMaximumValues = ImmutableMap.copyOf(monitorConfiguration.getMetricMaximumValues());
         metricNames = ImmutableSet.<String>builder()
-                .add(RUNNING_QUERIES_METRIC, QUEUED_QUERIES_METRIC)
+                .add(runningQueriesMetricName, queuedQueriesMetricName)
                 .addAll(metricMinimumValues.keySet())
                 .addAll(metricMaximumValues.keySet())
                 .build();
@@ -117,8 +119,8 @@ public class ClusterStatsMetricsMonitor
         }
         return ClusterStats.builder(backend.getName())
                 .trinoStatus(TrinoStatus.HEALTHY)
-                .runningQueryCount((int) Float.parseFloat(metrics.get(RUNNING_QUERIES_METRIC)))
-                .queuedQueryCount((int) Float.parseFloat(metrics.get(QUEUED_QUERIES_METRIC)))
+                .runningQueryCount((int) Float.parseFloat(metrics.get(runningQueriesMetricName)))
+                .queuedQueryCount((int) Float.parseFloat(metrics.get(queuedQueriesMetricName)))
                 .proxyTo(backend.getProxyTo())
                 .externalUrl(backend.getExternalUrl())
                 .routingGroup(backend.getRoutingGroup())

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/MonitorConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/MonitorConfiguration.java
@@ -33,7 +33,10 @@ public class MonitorConfiguration
 
     private String metricsEndpoint = "/metrics";
 
-    // Require 1 node for health by default. This configuration only applies to the ClusterStatsMetricsMonitor
+    private String runningQueriesMetricName = "trino_execution_name_QueryManager_RunningQueries";
+
+    private String queuedQueriesMetricName = "trino_execution_name_QueryManager_QueuedQueries";
+
     private Map<String, Float> metricMinimumValues = ImmutableMap.of("trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount", 1f);
 
     private Map<String, Float> metricMaximumValues = ImmutableMap.of();
@@ -88,6 +91,20 @@ public class MonitorConfiguration
     public void setMetricsEndpoint(String metricsEndpoint)
     {
         this.metricsEndpoint = metricsEndpoint;
+    }
+
+    public String getRunningQueriesMetricName() {return runningQueriesMetricName; }
+
+    public void setRunningQueriesMetricName(String runningQueriesMetricName)
+    {
+        this.runningQueriesMetricName = runningQueriesMetricName;
+    }
+
+    public String getQueuedQueriesMetricName() {return queuedQueriesMetricName; }
+
+    public void setQueuedQueriesMetricName(String queuedQueriesMetricName)
+    {
+        this.queuedQueriesMetricName = queuedQueriesMetricName;
     }
 
     public Map<String, Float> getMetricMinimumValues()


### PR DESCRIPTION
## Description

This PR updates the `METRICS` monitor to allow to configure the metrics that Trino Gateway should rely on to keep track of the number of running and queued queries in a given cluster. Previously the values were configured to strictly track `trino_execution_name_QueryManager_RunningQueries` and `trino_execution_name_QueryManager_QueuedQueries`, but in some scenarios such as in the Starburst Galaxy metrics definition, those metrics don't exist with such naming. As such, while the former are still the default metric names, it is now possible to configure through the `monitor` spec in the YAML configuration.

In addition, all references to the `monitorConfiguration` config node in docs were updated to use `monitor`, as the former does not exist.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
