### PR TITLE
Update config file path in Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN \
     curl -#LfS "${JDK_DOWNLOAD_LINK}" | tar -zx --strip 1 -C "${JAVA_HOME}"
 
 FROM ${TRINO_GATEWAY_BASE_IMAGE}
-WORKDIR /opt/trino-gateway
+WORKDIR /usr/lib/trino-gateway
 
 ARG JDK_VERSION
 ENV JAVA_HOME="/usr/lib/jvm/jdk-${JDK_VERSION}"
@@ -40,14 +40,14 @@ RUN \
     microdnf install -y tar less shadow-utils && \
     groupadd trino --gid 1000 && \
     useradd trino --uid 1000 --gid 1000 --create-home && \
-    mkdir -p /usr/lib/trino-gateway && \
-    chown -R "trino:trino" /usr/lib/trino-gateway /opt/trino-gateway
+    mkdir -p /usr/lib/trino-gateway /etc/trino-gateway && \
+    chown -R "trino:trino" /usr/lib/trino-gateway /etc/trino-gateway
 
 COPY --chown=trino:trino gateway-ha /usr/lib/trino-gateway
 
 EXPOSE 8080
 USER trino:trino
-CMD java -jar /usr/lib/trino-gateway/gateway-ha-jar-with-dependencies.jar "/opt/trino-gateway/config.yaml"
+CMD java -jar /usr/lib/trino-gateway/gateway-ha-jar-with-dependencies.jar "/etc/trino-gateway/config.yaml"
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=10s \
   CMD /usr/lib/trino-gateway/bin/health-check

--- a/docker/bin/health-check
+++ b/docker/bin/health-check
@@ -6,7 +6,7 @@ function get_property() {
     grep "$1" "$2" | cut -d':' -f2 | tr -d '[:space:]' || true
 }
 
-config=/opt/trino-gateway/config.yaml
+config=/etc/trino-gateway/config.yaml
 scheme=http
 port=8080
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - target: /opt/trino-gateway/config.yaml
+      - target: /etc/trino-gateway/config.yaml
         source: ./config.yaml
         type: bind
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -152,7 +152,7 @@ details found in the `docker-compose.yml` file.
 ## Configuration
 
 The image uses the configuration file `docker/config.yaml` from the project
-checkout, and mounts it at `/opt/trino-gateway/config.yaml`.
+checkout, and mounts it at `/etc/trino-gateway/config.yaml`.
 
 ## Health check
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -299,7 +299,7 @@ configuration.
 By default, the Trino Gateway process is started with the following command:
 
 ```shell
-java -XX:MinRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -jar /usr/lib/trino/gateway-ha-jar-with-dependencies.jar config.yaml
+java -XX:MinRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0 -jar /usr/lib/trino-gateway/gateway-ha-jar-with-dependencies.jar /etc/trino-gateway/config.yaml
 ```
 
 You can customize details with the `command` node. It accepts a list, that must


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Refactor `/opt/trino-gateway/config.yaml` to `/etc/trino-gateway/config.yaml`.

I made a mistake in #623. 
We should use the same file path in the Docker image and the [chart](https://github.com/trinodb/charts/blob/c1bacab5b15a8ece6186a40ddd676f725b20a93b/charts/gateway/templates/deployment.yaml#L88) to avoid confusion.
This also consist with Trino's config path `/etc/trino`.




<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes
(x) Release notes are required, with the following suggested text:

```markdown
* [:warning: Breaking change:](#breaking) Change configuration file name in Docker image from 
  `/opt/trino/gateway-ha-config.yml` to `/etc/trino-gateway/config.yaml`.
```
