### PR TITLE
Add release automation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking changes 🛠
+      labels:
+        - breaking
+    - title: Bug fixes 🐛
+      labels:
+        - bug
+    - title: Improvements 🎉
+      labels:
+        - improvement
+        - cleanup
+    - title: Dependency updates 📦
+      labels:
+        - dependency
+    - title: Security fixes 🔒
+      labels:
+        - security
+    - title: Others
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+name: Release new version
+
+on:
+  workflow_dispatch:
+    inputs:
+      push:
+        description: 'Push artifacts to Central and commits to the repository'
+        required: true
+        default: true
+        type: 'boolean'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    env:
+      STAGED_REPOSITORY: target/checkout/target/staging-deploy
+
+    steps:
+      - name: Check if release is running from main
+        run: |
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "Release is only allowed from main branch"
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '23'
+          distribution: 'temurin'
+          gpg-private-key: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          cache: 'maven'
+
+      - name: Configure git
+        run: |
+          git config user.name "Trino Release"
+          git config user.email "trino-bot@trino.io"
+
+      - name: Lock branch before release
+        uses: github/lock@v2
+        id: release-lock
+        with:
+          mode: 'lock'
+
+      - name: Run mvn release:prepare
+        env:
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+        run: |
+          ./mvnw -B release:prepare -Poss-release,oss-stage
+
+      - name: Determine release version
+        run: |
+          export VERSION=$(grep 'scm.tag=' release.properties | cut -d'=' -f2)
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "Releasing version: ${VERSION}"
+
+      - name: Run mvn release:perform to local staging
+        env:
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+        run: |
+          ./mvnw -B release:perform -Poss-release,oss-stage
+
+      - name: Display git status and history
+        run: |
+          git status
+          git log --oneline -n 2
+
+      - name: List locally staged artifacts
+        run: |
+          find ${{ env.STAGED_REPOSITORY }} -type f
+
+      - name: Run JReleaser
+        uses: jreleaser/release-action@v2
+        env:
+          JRELEASER_PROJECT_VERSION: ${{ env.VERSION }}
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ vars.JRELEASER_GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+          JRELEASER_NEXUS2_MAVEN_CENTRAL_USERNAME: ${{ secrets.JRELEASER_NEXUS2_MAVEN_CENTRAL_USERNAME }}
+          JRELEASER_NEXUS2_MAVEN_CENTRAL_TOKEN: ${{ secrets.JRELEASER_NEXUS2_MAVEN_CENTRAL_TOKEN }}
+          JRELEASER_NEXUS2_END_STAGE: ${{ inputs.push && 'RELEASE' || 'CLOSE' }}
+          JRELEASER_SKIP_RELEASE: ${{ inputs.push && 'false' || 'true' }}
+        with:
+          setup-java: false
+
+      - name: Push git changes
+        if: ${{ inputs.push }}
+        run: |
+          git status
+          git push origin main
+
+      - name: Unlock branch after a release
+        uses: github/lock@v2
+        id: release-unlock
+        with:
+          mode: 'unlock'
+
+      - name: Upload JReleaser logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jreleaser-logs
+          path: |
+            out/jreleaser/trace.log
+            out/jreleaser/output.properties

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,0 +1,77 @@
+# Hooks that will run on the CI to generate the summary of the steps
+hooks:
+  condition: '"{{ Env.CI }}" == true'
+  script:
+    before:
+      - filter:
+          includes: ['session']
+        run: |
+          echo "### {{command}}" >> $GITHUB_STEP_SUMMARY
+          echo "| Step | Outcome |" >> $GITHUB_STEP_SUMMARY
+          echo "| ---- | ------- |" >> $GITHUB_STEP_SUMMARY
+    success:
+      - filter:
+          excludes: ['session']
+        run: 'echo "| {{event.name}} | :white_check_mark: |" >> $GITHUB_STEP_SUMMARY'
+      - filter:
+          includes: ['session']
+        run: echo "" >> $GITHUB_STEP_SUMMARY
+    failure:
+      - filter:
+          excludes: ['session']
+        run: 'echo "| {{event.name}} | :x: |" >> $GITHUB_STEP_SUMMARY'
+      - filter:
+          includes: ['session']
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Failure" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "{{event.stacktrace}}\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+# Project configuration
+project:
+  name: trino-gateway
+  description: A load balancer, proxy server, and configurable routing gateway
+    for multiple Trino clusters.
+  license: Apache-2
+  java:
+    groupId: io.trino
+    multiProject: true
+
+# Ordered as defined in the https://jreleaser.org/guide/latest/concepts/workflow.html#_full_release
+signing:
+  active: ALWAYS
+  armored: true
+
+# Deploy to OSSRH
+deploy:
+  maven:
+    pomchecker:
+      failOnWarning: false # We don't want to fail the build on warnings
+      failOnError: false # We don't want to fail the build on errors
+    nexus2:
+      maven-central:
+        active: ALWAYS
+        url: https://oss.sonatype.org/service/local
+        snapshotUrl: https://oss.sonatype.org/content/repositories/snapshots/
+        javadocJar: false # Not every module has javadoc (packaging)
+        closeRepository: true
+        releaseRepository: true
+        stagingRepositories:
+          - target/checkout/target/staging-deploy
+
+# Release to Github
+release:
+  github:
+    owner: trinodb
+    overwrite: true # if tag already exists, overwrite it
+    skipTag: true # created by the release plugin
+    branch: main
+    uploadAssets: NEVER
+    tagName: '{{projectVersion}}'
+    files: false
+    draft: false
+    releaseNotes:
+      enabled: true
+      configurationFile: .github/release.yml


### PR DESCRIPTION
## Description

Lifted and adapted from airlift. Doesnt do anything about the docker container and helm chart yet but that could also be separate steps anyway.

I think we probably have to provision various secrets and also the trino-bot email maybe.

And I have no idea how we would test this.

Do we need a CHANGES file?

## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
