### PR TITLE
Store routing rules in database

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -492,6 +492,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>-Djol.skipHotspotSAAttach=true</argLine>
                     <!-- This is needed because we call main() in test setups. Otherwise Guice singleton won't work. -->
                     <reuseForks>false</reuseForks>
                 </configuration>

--- a/gateway-ha/src/main/java/io/trino/gateway/baseapp/BaseApp.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/baseapp/BaseApp.java
@@ -35,7 +35,7 @@ import io.trino.gateway.ha.resource.LoginResource;
 import io.trino.gateway.ha.resource.PublicResource;
 import io.trino.gateway.ha.resource.TrinoResource;
 import io.trino.gateway.ha.router.ForRouter;
-import io.trino.gateway.ha.router.RoutingRulesManager;
+import io.trino.gateway.ha.router.ForwardingRoutingRulesManager;
 import io.trino.gateway.ha.security.AuthorizedExceptionMapper;
 import io.trino.gateway.proxyserver.ForProxy;
 import io.trino.gateway.proxyserver.ProxyRequestHandler;
@@ -145,7 +145,7 @@ public class BaseApp
         jaxrsBinder(binder).bind(AuthorizedExceptionMapper.class);
         binder.bind(ProxyHandlerStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(ProxyHandlerStats.class).withGeneratedName();
-        binder.bind(RoutingRulesManager.class);
+        binder.bind(ForwardingRoutingRulesManager.class);
     }
 
     private static void addManagedApps(HaGatewayConfiguration configuration, Binder binder)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/RulesType.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/RulesType.java
@@ -37,4 +37,9 @@ public enum RulesType
      * The service URL can implement dynamic rule changes.
      */
     EXTERNAL,
+
+    /**
+     *  Routing rules stored in the database.
+     */
+    DB
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
@@ -201,10 +201,7 @@ public class HaGatewayProviderModule
         if (routingRulesConfig.isRulesEngineEnabled()) {
             try {
                 return switch (routingRulesConfig.getRulesType()) {
-                    case FILE -> RoutingGroupSelector.byRoutingRulesEngine(
-                            routingRulesConfig.getRulesConfigPath(),
-                            routingRulesConfig.getRulesRefreshPeriod(),
-                            configuration.getRequestAnalyzerConfig());
+                    case DB, FILE -> RoutingGroupSelector.byRoutingRulesEngine(configuration);
                     case EXTERNAL -> {
                         RulesExternalConfiguration rulesExternalConfiguration = routingRulesConfig.getRulesExternalConfiguration();
                         yield RoutingGroupSelector.byRoutingExternal(httpClient, rulesExternalConfiguration, configuration.getRequestAnalyzerConfig());

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/module/RouterBaseModule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/module/RouterBaseModule.java
@@ -36,10 +36,11 @@ public class RouterBaseModule
     public RouterBaseModule(HaGatewayConfiguration configuration)
     {
         Jdbi jdbi = Jdbi.create(configuration.getDataStore().getJdbcUrl(), configuration.getDataStore().getUser(), configuration.getDataStore().getPassword());
+        boolean isOracleBackend = configuration.getDataStore().getJdbcUrl().startsWith("jdbc:oracle");
         connectionManager = new JdbcConnectionManager(jdbi, configuration.getDataStore());
         resourceGroupsManager = new HaResourceGroupsManager(connectionManager);
-        gatewayBackendManager = new HaGatewayManager(jdbi);
-        queryHistoryManager = new HaQueryHistoryManager(jdbi, configuration.getDataStore().getJdbcUrl().startsWith("jdbc:oracle"));
+        gatewayBackendManager = new HaGatewayManager(jdbi, isOracleBackend);
+        queryHistoryManager = new HaQueryHistoryManager(jdbi, isOracleBackend);
     }
 
     @Provides

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/GatewayBackendDao.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/GatewayBackendDao.java
@@ -13,46 +13,124 @@
  */
 package io.trino.gateway.ha.persistence.dao;
 
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.statement.UseRowMapper;
 
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.util.List;
+
+import static java.util.Locale.ENGLISH;
 
 public interface GatewayBackendDao
 {
+    @UseRowMapper(GatewayBackendIntToBooleanMapper.class)
     @SqlQuery("SELECT * FROM gateway_backend")
     List<GatewayBackend> findAll();
 
+    @UseRowMapper(GatewayBackendIntToBooleanMapper.class)
     @SqlQuery("""
             SELECT * FROM gateway_backend
             WHERE active = true
             """)
     List<GatewayBackend> findActiveBackend();
 
+    @UseRowMapper(GatewayBackendIntToBooleanMapper.class)
+    @SqlQuery("""
+            SELECT * FROM gateway_backend
+            WHERE active = 1
+            """)
+    List<GatewayBackend> findActiveBackendNoBoolean();
+
+    default List<GatewayBackend> findActiveBackend(boolean isSupportsBooleanColumn)
+    {
+        if (isSupportsBooleanColumn) {
+            return findActiveBackend();
+        }
+
+        return findActiveBackendNoBoolean();
+    }
+
+    @UseRowMapper(GatewayBackendIntToBooleanMapper.class)
     @SqlQuery("""
             SELECT * FROM gateway_backend
             WHERE active = true AND routing_group = 'adhoc'
             """)
     List<GatewayBackend> findActiveAdhocBackend();
 
+    @UseRowMapper(GatewayBackendIntToBooleanMapper.class)
+    @SqlQuery("""
+            SELECT * FROM gateway_backend
+            WHERE active = 1 AND routing_group = 'adhoc'
+            """)
+    List<GatewayBackend> findActiveAdhocBackendNoBoolean();
+
+    default List<GatewayBackend> findActiveAdhocBackend(boolean isSupportsBooleanColumn)
+    {
+        if (isSupportsBooleanColumn) {
+            return findActiveAdhocBackend();
+        }
+
+        return findActiveAdhocBackendNoBoolean();
+    }
+
+    @UseRowMapper(GatewayBackendIntToBooleanMapper.class)
     @SqlQuery("""
             SELECT * FROM gateway_backend
             WHERE active = true AND routing_group = :routingGroup
             """)
     List<GatewayBackend> findActiveBackendByRoutingGroup(String routingGroup);
 
+    @UseRowMapper(GatewayBackendIntToBooleanMapper.class)
+    @SqlQuery("""
+            SELECT * FROM gateway_backend
+            WHERE active = 1 AND routing_group = :routingGroup
+            """)
+    List<GatewayBackend> findActiveBackendByRoutingGroupNoBoolean(String routingGroup);
+
+    default List<GatewayBackend> findActiveBackendByRoutingGroup(String routingGroup, boolean isSupportsBooleanColumn)
+    {
+        if (isSupportsBooleanColumn) {
+            return findActiveBackendByRoutingGroup(routingGroup);
+        }
+
+        return findActiveBackendByRoutingGroupNoBoolean(routingGroup);
+    }
+
+    @UseRowMapper(GatewayBackendIntToBooleanMapper.class)
     @SqlQuery("""
             SELECT * FROM gateway_backend
             WHERE name = :name
             """)
     List<GatewayBackend> findByName(String name);
 
+    @UseRowMapper(GatewayBackendIntToBooleanMapper.class)
     @SqlQuery("""
             SELECT * FROM gateway_backend
             WHERE name = :name
             LIMIT 1
             """)
     GatewayBackend findFirstByName(String name);
+
+    @UseRowMapper(GatewayBackendIntToBooleanMapper.class)
+    @SqlQuery("""
+            SELECT * FROM gateway_backend
+            WHERE name = :name
+            FETCH FIRST 1 ROWS ONLY
+            """)
+    GatewayBackend findFirstByNameWithFetch(String name);
+
+    default GatewayBackend findFirstByName(String name, boolean isLimitUnsupported){
+        if (isLimitUnsupported) {
+            return findFirstByNameWithFetch(name);
+        }
+
+        return findFirstByName(name);
+    }
 
     @SqlUpdate("""
             INSERT INTO gateway_backend (name, routing_group, backend_url, external_url, active)
@@ -61,11 +139,42 @@ public interface GatewayBackendDao
     void create(String name, String routingGroup, String backendUrl, String externalUrl, boolean active);
 
     @SqlUpdate("""
+            INSERT INTO gateway_backend (name, routing_group, backend_url, external_url, active)
+            VALUES (:name, :routingGroup, :backendUrl, :externalUrl, :active)
+            """)
+    void createNoBoolean(String name, String routingGroup, String backendUrl, String externalUrl, int active);
+
+    default void create(String name, String routingGroup, String backendUrl, String externalUrl, boolean active, boolean isSupportsBooleanColumn)
+    {
+        if (isSupportsBooleanColumn) {
+            create(name, routingGroup, backendUrl, externalUrl, active);
+            return;
+        }
+        createNoBoolean(name, routingGroup, backendUrl, externalUrl, active ? 1 : 0);
+    }
+
+    @SqlUpdate("""
             UPDATE gateway_backend
             SET routing_group = :routingGroup, backend_url = :backendUrl, external_url = :externalUrl, active = :active
             WHERE name = :name
             """)
     void update(String name, String routingGroup, String backendUrl, String externalUrl, boolean active);
+
+    @SqlUpdate("""
+            UPDATE gateway_backend
+            SET routing_group = :routingGroup, backend_url = :backendUrl, external_url = :externalUrl, active = :active
+            WHERE name = :name
+            """)
+    void updateNoBoolean(String name, String routingGroup, String backendUrl, String externalUrl, int active);
+
+    default void update(String name, String routingGroup, String backendUrl, String externalUrl, boolean active, boolean isSupportsBooleanColumn)
+    {
+        if (isSupportsBooleanColumn) {
+            update(name, routingGroup, backendUrl, externalUrl, active);
+            return;
+        }
+        updateNoBoolean(name, routingGroup, backendUrl, externalUrl, active ? 1 : 0);
+    }
 
     @SqlUpdate("""
             UPDATE gateway_backend
@@ -86,4 +195,28 @@ public interface GatewayBackendDao
             WHERE name = :name
             """)
     void deleteByName(String name);
+
+    class GatewayBackendIntToBooleanMapper
+            implements RowMapper<GatewayBackend>
+    {
+        @Override
+        public GatewayBackend map(ResultSet resultSet, StatementContext ctx)
+                throws SQLException
+        {
+            boolean active;
+            ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+            if (resultSetMetaData.getColumnClassName(5).toLowerCase(ENGLISH).startsWith("int")) {
+                active = resultSet.getInt(5) != 0;
+            }
+            else {
+                active = resultSet.getBoolean(5);
+            }
+            return new GatewayBackend(
+                    resultSet.getString("name"),
+                    resultSet.getString("routing_group"),
+                    resultSet.getString("backend_url"),
+                    resultSet.getString("external_url"),
+                    active);
+        }
+    }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/RoutingRule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/RoutingRule.java
@@ -11,14 +11,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.gateway.ha.domain;
+package io.trino.gateway.ha.persistence.dao;
 
-import com.google.common.collect.ImmutableList;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
 
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.Objects.requireNonNullElse;
 
 /**
  * RoutingRules
@@ -28,19 +28,22 @@ import static java.util.Objects.requireNonNullElse;
  * @param priority priority of the routing rule. Higher number represents higher priority. If two rules have same priority then order of execution is not guaranteed.
  * @param actions actions of the routing rule
  * @param condition condition of the routing rule
+ * @param routingRuleEngine the engine used for rule evaluation
  */
+
 public record RoutingRule(
-        String name,
-        String description,
-        Integer priority,
-        List<String> actions,
-        String condition)
+        @JsonProperty("name") @ColumnName("name") String name,
+        @JsonProperty("description") @ColumnName("description") String description,
+        @JsonProperty("priority") @ColumnName("priority") Integer priority,
+        // "conditionExpression" is used as a column name because "condition" is a reserved word in MySQL
+        @JsonProperty("condition") @ColumnName("conditionExpression") String condition,
+        @JsonProperty("actions") @ColumnName("actions") List<String> actions,
+        @JsonProperty("routingRuleEngine") @ColumnName("routingRuleEngine") RoutingRuleEngine routingRuleEngine)
 {
-    public RoutingRule {
-        requireNonNull(name, "name is null");
-        description = requireNonNullElse(description, "");
-        priority = requireNonNullElse(priority, 0);
-        actions = ImmutableList.copyOf(actions);
-        requireNonNull(condition, "condition is null");
+    public RoutingRule
+    {
+        requireNonNull(name);
+        requireNonNull(condition);
+        requireNonNull(actions);
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/RoutingRuleEngine.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/RoutingRuleEngine.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.persistence.dao;
+
+public enum RoutingRuleEngine
+{
+    MVEL
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/RoutingRulesDao.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/RoutingRulesDao.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.persistence.dao;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.statement.UseRowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+
+public interface RoutingRulesDao
+{
+    @SqlQuery("SELECT * FROM routing_rules")
+    List<RoutingRule> getAll();
+
+    // "conditionExpression" is used as a column name because "condition" is a reserved word in MySQL
+    @SqlUpdate("""
+            INSERT INTO routing_rules (name, description, priority, conditionExpression, actions, routingRuleEngine)
+            VALUES (:name, :description, :priority, :condition, :actions, :routingRuleEngine)
+            """)
+    void create(String name, String description, Integer priority, String condition, List<String> actions, RoutingRuleEngine routingRuleEngine);
+
+    @SqlUpdate("""
+            UPDATE routing_rules
+            SET description = :description, priority = :priority, conditionExpression = :condition, actions = :actions, routingRuleEngine = :routingRuleEngine
+            WHERE name = :name
+            """)
+    void update(String name, String description, Integer priority, String condition, List<String> actions, RoutingRuleEngine routingRuleEngine);
+
+    @SqlQuery("SELECT * FROM routing_rules")
+    @UseRowMapper(RoutingRulesStringToListMapper.class)
+    List<RoutingRule> getAllNoListSupport();
+
+    @SqlUpdate("""
+            INSERT INTO routing_rules (name, description, priority, conditionExpression, actions, routingRuleEngine)
+            VALUES (:name, :description, :priority, :condition, :actions, :routingRuleEngine)
+            """)
+    void createNoListSupport(String name, String description, Integer priority, String condition, String actions, RoutingRuleEngine routingRuleEngine);
+
+    @SqlUpdate("""
+            UPDATE routing_rules
+            SET description = :description, priority = :priority, conditionExpression = :condition, actions = :actions, routingRuleEngine = :routingRuleEngine
+            WHERE name = :name
+            """)
+    void updateNoListSupport(String name, String description, Integer priority, String condition, String actions, RoutingRuleEngine routingRuleEngine);
+
+    @SqlUpdate("""
+            DELETE FROM routing_rules
+            WHERE name = :name
+            """
+    )
+    void delete(String name);
+
+    class RoutingRulesStringToListMapper
+            implements RowMapper<RoutingRule>
+    {
+        ObjectMapper objectMapper = new ObjectMapper();
+        TypeReference<List<String>> actionsTypeReference = new TypeReference<List<String>>() {};
+
+        @Override
+        public RoutingRule map(ResultSet rs, StatementContext ctx)
+                throws SQLException
+        {
+            try {
+                return new RoutingRule(
+                        rs.getString("name"),
+                        rs.getString("description"),
+                        rs.getInt("priority"),
+                        rs.getString("conditionExpression"),
+                        objectMapper.readValue(rs.getString("actions"), actionsTypeReference),
+                        RoutingRuleEngine.valueOf(Optional.ofNullable(rs.getString("routingRuleEngine")).orElse("MVEL")));
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/DbRoutingRulesManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/DbRoutingRulesManager.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.trino.gateway.ha.persistence.dao.RoutingRule;
+import io.trino.gateway.ha.persistence.dao.RoutingRulesDao;
+
+import java.util.List;
+
+public class DbRoutingRulesManager
+        implements IRoutingRulesManager
+{
+    private final RoutingRulesDao routingRulesDao;
+    private final boolean dbSupportsArray;
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    public DbRoutingRulesManager(RoutingRulesDao routingRulesDao, boolean dbSupportsArray)
+    {
+        this.routingRulesDao = routingRulesDao;
+        this.dbSupportsArray = dbSupportsArray;
+    }
+
+    @Override
+    public List<RoutingRule> getRoutingRules()
+    {
+        if (dbSupportsArray) {
+            return routingRulesDao.getAll();
+        }
+        return routingRulesDao.getAllNoListSupport();
+    }
+
+    @Override
+    public List<RoutingRule> updateRoutingRule(RoutingRule routingRule)
+    {
+        if (dbSupportsArray) {
+            routingRulesDao.update(
+                    routingRule.name(),
+                    routingRule.description(),
+                    routingRule.priority(),
+                    routingRule.condition(),
+                    routingRule.actions(),
+                    routingRule.routingRuleEngine());
+            return routingRulesDao.getAll();
+        }
+        else {
+            routingRulesDao.updateNoListSupport(routingRule.name(),
+                    routingRule.description(),
+                    routingRule.priority(),
+                    routingRule.condition(),
+                    toJson(routingRule.actions()),
+                    routingRule.routingRuleEngine());
+            return routingRulesDao.getAllNoListSupport();
+        }
+    }
+
+    @Override
+    public void deleteRoutingRule(String name)
+    {
+        routingRulesDao.delete(name);
+    }
+
+    @Override
+    public void createRoutingRule(RoutingRule routingRule)
+    {
+        if (dbSupportsArray) {
+            routingRulesDao.create(
+                    routingRule.name(),
+                    routingRule.description(),
+                    routingRule.priority(),
+                    routingRule.condition(),
+                    routingRule.actions(),
+                    routingRule.routingRuleEngine());
+        }
+        else {
+            routingRulesDao.createNoListSupport(routingRule.name(),
+                    routingRule.description(),
+                    routingRule.priority(),
+                    routingRule.condition(),
+                    toJson(routingRule.actions()),
+                    routingRule.routingRuleEngine());
+        }
+    }
+
+    private String toJson(Object object)
+    {
+        try {
+            return objectMapper.writeValueAsString(object);
+        }
+        catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed serializing routing rules to JSON", e);
+        }
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/ForwardingRoutingRulesManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/ForwardingRoutingRulesManager.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import com.google.inject.Inject;
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.config.RoutingRulesConfiguration;
+import io.trino.gateway.ha.persistence.RecordAndAnnotatedConstructorMapper;
+import io.trino.gateway.ha.persistence.dao.RoutingRule;
+import io.trino.gateway.ha.persistence.dao.RoutingRulesDao;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+
+import java.util.List;
+
+public class ForwardingRoutingRulesManager
+        implements IRoutingRulesManager
+{
+    IRoutingRulesManager delegate;
+
+    @Inject
+    ForwardingRoutingRulesManager(HaGatewayConfiguration haGatewayConfiguration)
+    {
+        RoutingRulesConfiguration routingRulesConfig = haGatewayConfiguration.getRoutingRules();
+        delegate = switch (routingRulesConfig.getRulesType()) {
+            case FILE -> new FileBasedRoutingRulesManager(haGatewayConfiguration);
+            case DB -> {
+                String jdbcUrl = haGatewayConfiguration.getDataStore().getJdbcUrl();
+                Jdbi jdbi = Jdbi.create(
+                                jdbcUrl,
+                                haGatewayConfiguration.getDataStore().getUser(),
+                                haGatewayConfiguration.getDataStore().getPassword())
+                        .installPlugin(new SqlObjectPlugin())
+                        .registerRowMapper(new RecordAndAnnotatedConstructorMapper());
+
+                yield new DbRoutingRulesManager(jdbi.onDemand(RoutingRulesDao.class), jdbcUrl.startsWith("jdbc:postgresql"));
+            }
+            default -> throw new RuntimeException("No routing manager for " + routingRulesConfig.getRulesType());
+        };
+    }
+
+    @Override
+    public List<RoutingRule> getRoutingRules()
+    {
+        return delegate.getRoutingRules();
+    }
+
+    @Override
+    public List<RoutingRule> updateRoutingRule(RoutingRule routingRule)
+    {
+        return delegate.updateRoutingRule(routingRule);
+    }
+
+    @Override
+    public void deleteRoutingRule(String name)
+    {
+        delegate.deleteRoutingRule(name);
+    }
+
+    @Override
+    public void createRoutingRule(RoutingRule routingRule)
+    {
+        delegate.createRoutingRule(routingRule);
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/IRoutingRulesManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/IRoutingRulesManager.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import io.trino.gateway.ha.persistence.dao.RoutingRule;
+
+import java.util.List;
+
+public interface IRoutingRulesManager
+{
+    List<RoutingRule> getRoutingRules();
+
+    List<RoutingRule> updateRoutingRule(RoutingRule routingRule);
+
+    void deleteRoutingRule(String name);
+
+    void createRoutingRule(RoutingRule routingRule);
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/MVELRoutingRule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/MVELRoutingRule.java
@@ -59,6 +59,17 @@ public class MVELRoutingRule
         this.actions = actions.stream().map(this::compileExpressionIfNecessary).collect(toImmutableList());
     }
 
+    public MVELRoutingRule(String name, String description, Integer priority, String condition, List<String> actions)
+    {
+        initializeParserContext(parserContext);
+
+        this.name = requireNonNull(name, "name is null");
+        this.description = requireNonNullElse(description, "");
+        this.priority = requireNonNullElse(priority, 0);
+        this.condition = requireNonNull(compileExpression(condition, parserContext));
+        this.actions = actions.stream().map(a -> compileExpression(a, parserContext)).collect(toImmutableList());
+    }
+
     private Serializable compileExpressionIfNecessary(Serializable expression)
     {
         if (expression instanceof String stringExpression) {
@@ -87,7 +98,7 @@ public class MVELRoutingRule
         parserContext.addImport(String.class);
         parserContext.addImport(StringBuffer.class);
         parserContext.addImport(StringBuilder.class);
-        parserContext.addImport(FileBasedRoutingGroupSelector.class);
+        parserContext.addImport(RulesRoutingGroupSelector.class);
     }
 
     @Override

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingGroupSelector.java
@@ -14,8 +14,9 @@
 package io.trino.gateway.ha.router;
 
 import io.airlift.http.client.HttpClient;
-import io.airlift.units.Duration;
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
 import io.trino.gateway.ha.config.RequestAnalyzerConfig;
+import io.trino.gateway.ha.config.RoutingRulesConfiguration;
 import io.trino.gateway.ha.config.RulesExternalConfiguration;
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -39,9 +40,11 @@ public interface RoutingGroupSelector
      * Routing group selector that uses routing engine rules
      * to determine the right routing group.
      */
-    static RoutingGroupSelector byRoutingRulesEngine(String rulesConfigPath, Duration rulesRefreshPeriod, RequestAnalyzerConfig requestAnalyzerConfig)
+    static RoutingGroupSelector byRoutingRulesEngine(HaGatewayConfiguration configuration)
     {
-        return new FileBasedRoutingGroupSelector(rulesConfigPath, rulesRefreshPeriod, requestAnalyzerConfig);
+        IRoutingRulesManager routingRulesManager = new ForwardingRoutingRulesManager(configuration);
+        RoutingRulesConfiguration routingRulesConfig = configuration.getRoutingRules();
+        return new RulesRoutingGroupSelector(routingRulesManager, routingRulesConfig.getRulesRefreshPeriod(), configuration.getRequestAnalyzerConfig());
     }
 
     /**

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingRule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingRule.java
@@ -23,4 +23,13 @@ public interface RoutingRule
     void evaluateAction(Map<String, String> result, Map<String, Object> data, Map<String, Object> state);
 
     Integer getPriority();
+
+    static RoutingRule fromPersistedRoutingRule(io.trino.gateway.ha.persistence.dao.RoutingRule rule)
+    {
+        return switch (rule.routingRuleEngine()) {
+            case MVEL -> new MVELRoutingRule(rule.name(), rule.description(), rule.priority(), rule.condition(), rule.actions());
+            // type will not be defined in legacy file based rules, but they are all MVEL
+            case null -> new MVELRoutingRule(rule.name(), rule.description(), rule.priority(), rule.condition(), rule.actions());
+        };
+    }
 }

--- a/gateway-ha/src/main/resources/mysql/V2__add_routing_rules.sql
+++ b/gateway-ha/src/main/resources/mysql/V2__add_routing_rules.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS routing_rules (
+    name varchar(128) primary key,
+    description varchar(256),
+    priority INT,
+    conditionExpression varchar(512),
+    actions varchar(1024),
+    routingRuleEngine varchar(128)
+)
+
+

--- a/gateway-ha/src/main/resources/oracle/V2__add_routing_rules.sql
+++ b/gateway-ha/src/main/resources/oracle/V2__add_routing_rules.sql
@@ -1,0 +1,9 @@
+CREATE TABLE routing_rules (
+    name varchar(128),
+    description varchar(512),
+    priority int,
+    conditionExpression varchar(512),
+    actions varchar(1024),
+    routingRuleEngine varchar(128),
+    PRIMARY KEY (name)
+);

--- a/gateway-ha/src/main/resources/postgresql/V2__add_routing_rules.sql
+++ b/gateway-ha/src/main/resources/postgresql/V2__add_routing_rules.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS routing_rules (
+    name varchar primary key,
+    description varchar,
+    priority int,
+    conditionExpression varchar,
+    actions varchar[],
+    routingRuleEngine varchar
+);

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/BaseTestDbRoutingRulesMultipleBackend.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/BaseTestDbRoutingRulesMultipleBackend.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import io.trino.gateway.ha.config.ProxyBackendConfiguration;
+import io.trino.gateway.ha.persistence.dao.RoutingRule;
+import io.trino.gateway.ha.persistence.dao.RoutingRuleEngine;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.TrinoContainer;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.utility.MountableFile.forClasspathResource;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class BaseTestDbRoutingRulesMultipleBackend
+{
+    private static final MediaType MEDIA_TYPE = MediaType.parse("application/json; charset=utf-8");
+
+    private TrinoContainer adhocTrino;
+    private TrinoContainer systemTrino;
+    private final JdbcDatabaseContainer<?> database;
+    private int adhocTrinoMappedPort;
+    private int systemTrinoMappedPort;
+
+    final int routerPort = 20000 + (int) (Math.random() * 1000);
+
+    private final OkHttpClient httpClient = new OkHttpClient();
+
+    public BaseTestDbRoutingRulesMultipleBackend(JdbcDatabaseContainer<?> container)
+    {
+        this.database = requireNonNull(container, "container is null");
+        this.database.start();
+    }
+
+    @BeforeAll
+    void setup()
+            throws Exception
+    {
+        adhocTrino = new TrinoContainer("trinodb/trino");
+        adhocTrino.withCopyFileToContainer(forClasspathResource("trino-config.properties"), "/etc/trino/config.properties");
+        adhocTrino.start();
+        systemTrino = new TrinoContainer("trinodb/trino");
+        systemTrino.withCopyFileToContainer(forClasspathResource("trino-config.properties"), "/etc/trino/config.properties");
+        systemTrino.start();
+        database.start();
+
+        adhocTrinoMappedPort = adhocTrino.getMappedPort(8080);
+        systemTrinoMappedPort = systemTrino.getMappedPort(8080);
+
+        File testConfigFile =
+                HaGatewayTestUtils.buildGatewayConfig(database, routerPort, "test-config-with-db-routing-rules.yaml", database.getDriverClassName());
+
+        String[] args = {testConfigFile.getAbsolutePath()};
+        HaGatewayLauncher.main(args);
+
+        HaGatewayTestUtils.setUpBackend(
+                "trino1", "http://localhost:" + adhocTrinoMappedPort, "externalUrl", true, "adhoc", routerPort);
+        HaGatewayTestUtils.setUpBackend(
+                "trino2", "http://localhost:" + systemTrinoMappedPort, "externalUrl", true, "system", routerPort);
+
+        getRules().forEach(routingRule -> applyRule(routingRule, Operation.CREATE));
+        Thread.sleep(2000); //ensure rules are loaded
+    }
+
+    private List<RoutingRule> getRules()
+    {
+        return ImmutableList.of(new RoutingRule(
+                "system-group",
+                "capture queries to system catalog",
+                0,
+                "trinoQueryProperties.getCatalogs().contains(\"system\")",
+                ImmutableList.of("result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"system\")"),
+                RoutingRuleEngine.MVEL));
+    }
+
+    private void applyRule(RoutingRule routingRule, Operation operation)
+    {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            RequestBody requestBody = RequestBody.create(objectMapper.writeValueAsString(routingRule), MediaType.parse("application/json; charset=utf-8"));
+
+            String path = switch (operation) {
+                case CREATE -> "/webapp/createRoutingRule";
+                case UPDATE -> "/webapp/updateRoutingRules";
+                case DELETE -> "/webapp/deleteRoutingRules";
+            };
+
+            Request request = new Request.Builder()
+                    .url("http://localhost:" + routerPort + path)
+                    .addHeader("Content-Type", "application/json")
+                    .post(requestBody)
+                    .build();
+            Response response = httpClient.newCall(request).execute();
+            if (!response.isSuccessful()) {
+                throw new RuntimeException("Rule creation failed with response code " + response.code() + " and body " + response.body().string());
+            }
+        }
+        catch (JsonProcessingException e) {
+            throw new RuntimeException("Could not serialize rule as JSON", e);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void testQueryDeliveryToMultipleRoutingGroups()
+            throws Exception
+    {
+        // Default request should be routed to adhoc backend
+        submitQueryAndCheckDelivery("SELECT 1", adhocTrinoMappedPort);
+
+        submitQueryAndCheckDelivery("SELECT * from system.runtime.nodes", systemTrinoMappedPort);
+    }
+
+    @Test
+    void testRoutingWithUpdates()
+            throws Exception
+    {
+        submitQueryAndCheckDelivery("SELECT * from system.runtime.nodes", systemTrinoMappedPort);
+
+        //update rule to only capture system.jdbc queries
+        applyRule(new RoutingRule(
+                "system-group",
+                "capture queries to system catalog",
+                0,
+                "trinoQueryProperties.getCatalogSchemas().contains(\"system.jdbc\")",
+                ImmutableList.of("result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"system\")"),
+                RoutingRuleEngine.MVEL), Operation.UPDATE);
+        Thread.sleep(2000);
+
+        submitQueryAndCheckDelivery("SELECT * from system.runtime.nodes", adhocTrinoMappedPort);
+        submitQueryAndCheckDelivery("SELECT * from system.jdbc.tables", systemTrinoMappedPort);
+
+        Request deleteRequest = new Request.Builder()
+                .url("http://localhost:" + routerPort + "/webapp/deleteRoutingRule/system-group")
+                .delete()
+                .build();
+        Response response = httpClient.newCall(deleteRequest).execute();
+        assertThat(response.code()).isIn(200, 202, 204);
+        Thread.sleep(2000);
+        submitQueryAndCheckDelivery("SELECT * from system.jdbc.tables", adhocTrinoMappedPort);
+
+        getRules().forEach(routingRule -> applyRule(routingRule, Operation.CREATE)); // Reset for other tests
+        Thread.sleep(2000);
+        submitQueryAndCheckDelivery("SELECT * from system.runtime.nodes", systemTrinoMappedPort);
+    }
+
+    @Test
+    void testBackendConfiguration()
+            throws Exception
+    {
+        Request request = new Request.Builder()
+                .url("http://localhost:" + routerPort + "/entity/GATEWAY_BACKEND")
+                .method("GET", null)
+                .build();
+        Response response = httpClient.newCall(request).execute();
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        ProxyBackendConfiguration[] backendConfiguration =
+                objectMapper.readValue(response.body().string(), ProxyBackendConfiguration[].class);
+
+        assertThat(backendConfiguration).isNotNull();
+        assertThat(backendConfiguration).hasSize(2);
+        assertThat(backendConfiguration[0].isActive()).isTrue();
+        assertThat(backendConfiguration[1].isActive()).isTrue();
+        assertThat(backendConfiguration[0].getRoutingGroup()).isEqualTo("adhoc");
+        assertThat(backendConfiguration[1].getRoutingGroup()).isEqualTo("system");
+        assertThat(backendConfiguration[0].getExternalUrl()).isEqualTo("externalUrl");
+        assertThat(backendConfiguration[1].getExternalUrl()).isEqualTo("externalUrl");
+    }
+
+    private void submitQueryAndCheckDelivery(String queryText, int expectedBackendPort)
+            throws Exception
+    {
+        // Intended for use with addXForwardedHeaders: false, so that the backend host is used for nextUri
+        ObjectMapper objectMapper = new ObjectMapper();
+        RequestBody requestBody = RequestBody.create(queryText, MEDIA_TYPE);
+        Request request =
+                new Request.Builder()
+                        .url("http://localhost:" + routerPort + "/v1/statement")
+                        .addHeader("X-Trino-User", "test")
+                        .post(requestBody)
+                        .build();
+        Response response = httpClient.newCall(request).execute();
+        String responseBody = response.body().string();
+
+        HashMap<String, String> results = objectMapper.readValue(responseBody, HashMap.class);
+        URI nextUri = URI.create(results.get("nextUri"));
+        assertThat(nextUri.getPort()).isEqualTo(expectedBackendPort);
+    }
+
+    @AfterAll
+    void cleanup()
+    {
+        adhocTrino.stop();
+        systemTrino.stop();
+    }
+
+    enum Operation
+    {
+        CREATE,
+        UPDATE,
+        DELETE
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestDbRoutingRulesMultipleBackendMySql.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestDbRoutingRulesMultipleBackendMySql.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha;
+
+import org.testcontainers.containers.MySQLContainer;
+
+public class TestDbRoutingRulesMultipleBackendMySql
+        extends BaseTestDbRoutingRulesMultipleBackend
+{
+    public TestDbRoutingRulesMultipleBackendMySql()
+    {
+        super(new MySQLContainer<>("mysql:5.7"));
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestDbRoutingRulesMultipleBackendPostgreSql.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestDbRoutingRulesMultipleBackendPostgreSql.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha;
+
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public class TestDbRoutingRulesMultipleBackendPostgreSql
+        extends BaseTestDbRoutingRulesMultipleBackend
+{
+    public TestDbRoutingRulesMultipleBackendPostgreSql()
+    {
+        super(new PostgreSQLContainer<>("postgres:16"));
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaWithFileBasedRoutingRulesSingleBackend.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaWithFileBasedRoutingRulesSingleBackend.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-final class TestGatewayHaWithRoutingRulesSingleBackend
+final class TestGatewayHaWithFileBasedRoutingRulesSingleBackend
 {
     private final OkHttpClient httpClient = new OkHttpClient();
     private TrinoContainer trino;

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/BaseTestDatabaseMigrations.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/BaseTestDatabaseMigrations.java
@@ -13,6 +13,7 @@
  */
 package io.trino.gateway.ha.persistence;
 
+import io.airlift.log.Logger;
 import io.trino.gateway.ha.config.DataStoreConfiguration;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
@@ -41,6 +42,7 @@ public abstract class BaseTestDatabaseMigrations
     private final JdbcDatabaseContainer<?> container;
     protected final String schema;
     protected final Jdbi jdbi;
+    Logger log = Logger.get(BaseTestDatabaseMigrations.class);
 
     public BaseTestDatabaseMigrations(JdbcDatabaseContainer<?> container, String schema)
     {
@@ -107,6 +109,7 @@ public abstract class BaseTestDatabaseMigrations
         verifyResultSetCount("SELECT name FROM resource_groups", 0);
         verifyResultSetCount("SELECT user_regex FROM selectors", 0);
         verifyResultSetCount("SELECT environment FROM exact_match_source_selectors", 0);
+        verifyResultSetCount("SELECT name FROM routing_rules", 0);
     }
 
     protected void verifyResultSetCount(String sql, int expectedCount)
@@ -125,9 +128,10 @@ public abstract class BaseTestDatabaseMigrations
         String selectorsTable = "DROP TABLE IF EXISTS selectors";
         String exactMatchTable = "DROP TABLE IF EXISTS exact_match_source_selectors";
         String flywayHistoryTable = "DROP TABLE IF EXISTS flyway_schema_history";
+        String routingRulesTable = "DROP TABLE IF EXISTS routing_rules";
         Handle jdbiHandle = jdbi.open();
         String sql = format("SELECT 1 FROM information_schema.tables WHERE table_schema = '%s'", schema);
-        verifyResultSetCount(sql, 7);
+        verifyResultSetCount(sql, 8);
         jdbiHandle.execute(gatewayBackendTable);
         jdbiHandle.execute(queryHistoryTable);
         jdbiHandle.execute(propertiesTable);
@@ -135,6 +139,7 @@ public abstract class BaseTestDatabaseMigrations
         jdbiHandle.execute(resourceGroupsTable);
         jdbiHandle.execute(exactMatchTable);
         jdbiHandle.execute(flywayHistoryTable);
+        jdbiHandle.execute(routingRulesTable);
         verifyResultSetCount(sql, 0);
         jdbiHandle.close();
     }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestDatabaseMigrationsOracle.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestDatabaseMigrationsOracle.java
@@ -48,10 +48,17 @@ final class TestDatabaseMigrationsOracle
          * For this reason, if you remove the double quotes on flyway_schema_history,
          * you will get a table not found error.
          */
-        List<String> tables = ImmutableList.of("gateway_backend", "query_history", "resource_groups_global_properties", "selectors", "resource_groups", "exact_match_source_selectors", "\"flyway_schema_history\"");
+        List<String> tables = ImmutableList.of(
+                "gateway_backend",
+                "query_history",
+                "resource_groups_global_properties",
+                "selectors", "resource_groups",
+                "exact_match_source_selectors",
+                "routing_rules",
+                "\"flyway_schema_history\"");
         Handle jdbiHandle = jdbi.open();
         String sql = format("SELECT 1 FROM all_tables WHERE owner = '%s'", schema);
-        verifyResultSetCount(sql, 7);
+        verifyResultSetCount(sql, 8);
         tables.forEach(table -> jdbiHandle.execute("DROP TABLE " + table));
         verifyResultSetCount(sql, 0);
         jdbiHandle.close();

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestDatabaseMigrationsPostgreSql.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestDatabaseMigrationsPostgreSql.java
@@ -83,6 +83,17 @@ final class TestDatabaseMigrationsPostgreSql
                 "    PRIMARY KEY (environment, source, query_type),\n" +
                 "    UNIQUE (source, environment, query_type, resource_group_id)\n" +
                 ");";
+
+        String routingRulesTable = """
+                CREATE TABLE routing_rules (
+                name VARCHAR PRIMARY KEY,
+                description VARCHAR,
+                priority INT,
+                condition VARCHAR,
+                actions VARCHAR[],
+                routingRuleEngine VARCHAR)
+                """;
+
         Handle jdbiHandle = jdbi.open();
         jdbiHandle.execute(gatewayBackendTable);
         jdbiHandle.execute(queryHistoryTable);
@@ -90,6 +101,7 @@ final class TestDatabaseMigrationsPostgreSql
         jdbiHandle.execute(resourceGroupsTable);
         jdbiHandle.execute(selectorsTable);
         jdbiHandle.execute(exactMatchSourceSelectorsTable);
+        jdbiHandle.execute(routingRulesTable);
         jdbiHandle.close();
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestHaGatewayManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestHaGatewayManager.java
@@ -32,7 +32,7 @@ final class TestHaGatewayManager
     void setUp()
     {
         JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager();
-        haGatewayManager = new HaGatewayManager(connectionManager.getJdbi());
+        haGatewayManager = new HaGatewayManager(connectionManager.getJdbi(), false);
     }
 
     @Test

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
@@ -35,7 +35,7 @@ final class TestStochasticRoutingManager
     void setUp()
     {
         JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager();
-        backendManager = new HaGatewayManager(connectionManager.getJdbi());
+        backendManager = new HaGatewayManager(connectionManager.getJdbi(), false);
         historyManager = new HaQueryHistoryManager(connectionManager.getJdbi(), false);
         haRoutingManager = new StochasticRoutingManager(backendManager, historyManager);
     }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/util/TestDbRoutingRulesMultipleBackendsOracle.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/util/TestDbRoutingRulesMultipleBackendsOracle.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.util;
+
+import io.trino.gateway.ha.BaseTestDbRoutingRulesMultipleBackend;
+
+import static io.trino.gateway.ha.HaGatewayTestUtils.getOracleContainer;
+
+public class TestDbRoutingRulesMultipleBackendsOracle
+        extends BaseTestDbRoutingRulesMultipleBackend
+{
+    public TestDbRoutingRulesMultipleBackendsOracle()
+    {
+        super(getOracleContainer());
+    }
+}

--- a/gateway-ha/src/test/resources/rules/routing_rules_atomic.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_atomic.yml
@@ -3,10 +3,10 @@ name: "airflow"
 description: "if query from airflow, route to etl group"
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && (request.getHeader(\"X-Trino-Client-Tags\") == null || request.getHeader(\"X-Trino-Client-Tags\").isEmpty())"
 actions:
-  - "result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"etl\")"
+  - "result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"etl\")"
 ---
 name: "airflow special"
 description: "if query from airflow with special label, route to etl-special group"
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\") contains \"label=special\""
 actions:
-  - "result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"etl-special\")"
+  - "result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"etl-special\")"

--- a/gateway-ha/src/test/resources/rules/routing_rules_concurrent.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_concurrent.yml
@@ -2,6 +2,7 @@
 name: "airflow"
 description: "if query from airflow, route to adhoc group"
 priority: 0
+condition: "request.getHeader(\"X-Trino-Source\") == \"datagrip\""
 actions:
 - "result.put(\"routingGroup\", \"adhoc\")"
-condition: "request.getHeader(\"X-Trino-Source\") == \"datagrip\""
+routingRuleEngine: null

--- a/gateway-ha/src/test/resources/rules/routing_rules_if_statements.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_if_statements.yml
@@ -4,8 +4,8 @@ description: "if query from airflow, route to etl group"
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
 actions:
   - "if (request.getHeader(\"X-Trino-Client-Tags\") contains \"label=special\") {
-      result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"etl-special\")
+      result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"etl-special\")
     }
     else {
-      result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"etl\")
+      result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"etl\")
     }"

--- a/gateway-ha/src/test/resources/rules/routing_rules_priorities.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_priorities.yml
@@ -4,11 +4,11 @@ description: "if query from airflow, route to etl group"
 priority: 0
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
 actions:
-  - "result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"etl\")"
+  - "result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"etl\")"
 ---
 name: "airflow special"
 description: "if query from airflow with special label, route to etl-special group"
 priority: 1
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\") contains \"label=special\""
 actions:
-  - "result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"etl-special\")"
+  - "result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"etl-special\")"

--- a/gateway-ha/src/test/resources/rules/routing_rules_state.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_state.yml
@@ -17,7 +17,7 @@ condition: |
   request.getHeader("X-Trino-Source") == "airflow"
 actions:
   - |
-    result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, "etl")
+    result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, "etl")
   - |
     state.get("triggeredRules").add("airflow")
 ---
@@ -28,4 +28,4 @@ condition: |
   state.get("triggeredRules").contains("airflow") && request.getHeader("X-Trino-Client-Tags") contains "label=special"
 actions:
   - |
-    result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, "etl-special")
+    result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, "etl-special")

--- a/gateway-ha/src/test/resources/rules/routing_rules_trino_query_properties.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_trino_query_properties.yml
@@ -3,7 +3,7 @@ name: "user"
 description: "if user is will, route to will-group"
 condition: "trinoRequestUser.userExistsAndEquals(\"will\")"
 actions:
-  - "result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"will-group\")"
+  - "result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"will-group\")"
 ---
 name: "query"
 description: "test extraction of tables and schemas in conjunction with default catalog and schema"
@@ -14,7 +14,7 @@ condition: |
   && trinoQueryProperties.getSchemas().contains("schemy")
   && trinoQueryProperties.getCatalogs().contains("catx")
 actions:
-  - "result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"tbl-group\")"
+  - "result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"tbl-group\")"
 ---
 name: "catalog-schema"
 description: "test that catalogSchemas with default catalog and schema"
@@ -23,14 +23,14 @@ condition: |
   && trinoQueryProperties.getCatalogSchemas.contains("caty.default")
   && !trinoQueryProperties.getCatalogSchemas.contains("catx.default")
 actions:
-  - "result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"catalog-schema-group\")"
+  - "result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"catalog-schema-group\")"
 ---
 name: "query-type"
 description: "test table type"
 condition: |
   trinoQueryProperties.getQueryType().toLowerCase.equals("insert")
 actions:
-  - "result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"type-group\")"
+  - "result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"type-group\")"
 ---
 name: "resource-group-query-type"
 description: "test table type"
@@ -44,7 +44,7 @@ description: "test execute with multiple prepared statements"
 condition: |
   trinoQueryProperties.getQueryType().toLowerCase.equals("query") && trinoQueryProperties.tablesContains("cat.schem.foo")
 actions:
-  - "result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"statement-header-group\")"
+  - "result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"statement-header-group\")"
 ---
 name: "defaults-group"
 description: "test default schema and catalog"
@@ -53,14 +53,14 @@ condition: |
   && trinoQueryProperties.getDefaultSchema().equals(java.util.Optional.of("other_schema"))
 
 actions:
-  - "result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"defaults-group\")"
+  - "result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"defaults-group\")"
 ---
 name: "system-group"
 description: "capture queries to system catalog"
 condition: |
   trinoQueryProperties.getCatalogs().contains("system")
 actions:
-  - "result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"system\")"
+  - "result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"system\")"
 
 ---
 name: "nomatch"
@@ -68,4 +68,4 @@ priority: -1
 description: "default group to catch if no other rules fired"
 condition: "true"
 actions:
-  - "result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"no-match\")"
+  - "result.put(RulesRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"no-match\")"

--- a/gateway-ha/src/test/resources/rules/routing_rules_update.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_update.yml
@@ -2,14 +2,16 @@
 name: "airflow"
 description: "if query from airflow, route to etl group"
 priority: 0
+condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
 actions:
 - "result.put(\"routingGroup\", \"etl\")"
-condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
+routingRuleEngine: null
 ---
 name: "airflow special"
 description: "if query from airflow with special label, route to etl-special group"
 priority: 1
-actions:
-- "result.put(\"routingGroup\", \"etl-special\")"
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"\
   X-Trino-Client-Tags\") contains \"label=special\""
+actions:
+- "result.put(\"routingGroup\", \"etl-special\")"
+routingRuleEngine: null

--- a/gateway-ha/src/test/resources/test-config-with-db-routing-rules.yaml
+++ b/gateway-ha/src/test/resources/test-config-with-db-routing-rules.yaml
@@ -1,0 +1,38 @@
+serverConfig:
+    node.environment: test
+    http-server.http.port: REQUEST_ROUTER_PORT
+
+dataStore:
+    jdbcUrl: POSTGRESQL_JDBC_URL
+    user: POSTGRESQL_USER
+    password: POSTGRESQL_PASSWORD
+    driver: DRIVER_CLASS
+
+clusterStatsConfiguration:
+    monitorType: INFO_API
+
+monitor:
+    taskDelaySeconds: 1
+
+extraWhitelistPaths:
+    - '/v1/custom.*'
+    - '/custom/logout.*'
+
+gatewayCookieConfiguration:
+    enabled: true
+    cookieSigningSecret: "kjlhbfrewbyuo452cds3dc1234ancdsjh"
+
+oauth2GatewayCookieConfiguration:
+    deletePaths:
+        - "/custom/logout"
+
+requestAnalyzerConfig:
+    analyzeRequest: true
+
+routingRules:
+    rulesEngineEnabled: true
+    rulesType: "DB"
+    rulesRefreshPeriod: "1s"
+
+routing:
+    addXForwardedHeaders: false


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Store rules in the backend database. This simplifies running a cluster of gateways and CRUD operations on the rule set.

This also adds API methods for creating and deleting rules. UI support for create and delete is not included.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Store routing rules in the database. A rule is defined as a name, description, priority, condition and list of actions, with an additional field for identifying the rule evaluation engine. `MVEL` is currently the only supported engine,  however we anticipate supporting more in the future. The engine field is added at this time to avoid future database schema migrations. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x ) Release notes are required, with the following suggested text:

```markdown
* Store routing rules in the database
```
