### PR TITLE
Update h2 test database version

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -325,7 +325,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.192</version>
+            <version>2.2.220</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
## Description

The H2 Database Engine, a popular open-source relational database management system written in Java, has identified vulnerabilities that could be exploited by malicious actors. Below is a brief description and impact of these vulnerabilities:

Vulnerabilities:
CVE-2022-23221:

Impact: High - Can lead to complete control of the affected system. 
CVE-2021-42392:

Impact: High - Can result in complete system compromise.

Context in Trino Gateway and applicability details from @mosabua:

"The H2 database is only used in testing and NOT included in the shipped binaries. There is therefore zero impact from these reported vulnerabilities and we could safely use the old version. However for code quality and cleanness reasons we will update the version."

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<img width="1156" alt="Screenshot 2025-03-13 at 5 00 52 PM" src="https://github.com/user-attachments/assets/0d862c45-9a83-4ac3-985f-c551a277e4bc" />

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
