### PR TITLE
Add Header Modification Support to External Routing Service

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
@@ -93,8 +93,10 @@ public class RoutingTargetHandler
     {
         RoutingSelectorResponse routingDestination = routingGroupSelector.findRoutingDestination(request);
         String user = request.getHeader(USER_HEADER);
-        // This falls back on adhoc routing group if there is no cluster found for the routing group.
-        String routingGroup = routingDestination.routingGroup() != null ? routingDestination.routingGroup() : "adhoc";
+        // This falls back on adhoc routing group if there is no cluster found (or value is empty) for the routing group.
+        String routingGroup = (routingDestination.routingGroup() != null && !routingDestination.routingGroup().isEmpty())
+                ? routingDestination.routingGroup()
+                : "adhoc";
         String clusterHost = routingManager.provideClusterForRoutingGroup(routingGroup, user);
         // Apply headers from RoutingDestination if there are any
         HttpServletRequest modifiedRequest = request;

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -83,12 +84,12 @@ public class RoutingTargetHandler
             return new RoutingTargetResponse(
                     new RoutingDestination(routingGroup, cluster, buildUriWithNewCluster(cluster, request)),
                     request);
-        }).orElse(getClusterFromRoutingGroup(request));
+        }).orElse(getRoutingTargetResponse(request));
         logRewrite(routingTargetResponse.routingDestination().clusterHost(), request);
         return routingTargetResponse;
     }
 
-    private RoutingTargetResponse getClusterFromRoutingGroup(HttpServletRequest request)
+    private RoutingTargetResponse getRoutingTargetResponse(HttpServletRequest request)
     {
         RoutingSelectorResponse routingDestination = routingGroupSelector.findRoutingDestination(request);
         String user = request.getHeader(USER_HEADER);
@@ -152,13 +153,10 @@ public class RoutingTargetHandler
         @Override
         public Enumeration<String> getHeaderNames()
         {
-            List<String> names = Collections.list(super.getHeaderNames());
-            for (String name : customHeaders.keySet()) {
-                if (!names.contains(name)) {
-                    names.add(name);
-                }
-            }
-            return Collections.enumeration(names);
+            return Collections.enumeration(
+                    Stream.concat(Collections.list(super.getHeaderNames()).stream(), customHeaders.keySet().stream())
+                            .distinct()
+                            .toList());
         }
     }
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/schema/RoutingDestination.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/schema/RoutingDestination.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.gateway.ha.handler;
+package io.trino.gateway.ha.handler.schema;
 
 import java.net.URI;
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/schema/RoutingTargetResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/schema/RoutingTargetResponse.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.handler.schema;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Contains the complete result of the routing process including:
+ * - routingDestination: Contains the routing group, cluster host, and target URI to route the request to
+ * - modifiedRequest: The request with any headers set by the external routing service
+ * or other routing selectors. The modifiedRequest might be a wrapper around the original
+ * request with custom header handling.
+ */
+public record RoutingTargetResponse(
+        RoutingDestination routingDestination,
+        HttpServletRequest modifiedRequest) {}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/FileBasedRoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/FileBasedRoutingGroupSelector.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import io.trino.gateway.ha.config.RequestAnalyzerConfig;
+import io.trino.gateway.ha.router.schema.RoutingSelectorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.io.IOException;
@@ -30,7 +31,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static com.google.common.base.Suppliers.memoizeWithExpiration;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -61,7 +61,7 @@ public class FileBasedRoutingGroupSelector
     }
 
     @Override
-    public Optional<String> findRoutingGroup(HttpServletRequest request)
+    public RoutingSelectorResponse findRoutingDestination(HttpServletRequest request)
     {
         Map<String, String> result = new HashMap<>();
         Map<String, Object> state = new HashMap<>();
@@ -85,7 +85,7 @@ public class FileBasedRoutingGroupSelector
                 rule.evaluateAction(result, data, state);
             }
         });
-        return Optional.ofNullable(result.get(RESULTS_ROUTING_GROUP_KEY));
+        return new RoutingSelectorResponse(result.get(RESULTS_ROUTING_GROUP_KEY));
     }
 
     public List<RoutingRule> readRulesFromPath(Path rulesPath)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingGroupSelector.java
@@ -17,9 +17,8 @@ import io.airlift.http.client.HttpClient;
 import io.airlift.units.Duration;
 import io.trino.gateway.ha.config.RequestAnalyzerConfig;
 import io.trino.gateway.ha.config.RulesExternalConfiguration;
+import io.trino.gateway.ha.router.schema.RoutingSelectorResponse;
 import jakarta.servlet.http.HttpServletRequest;
-
-import java.util.Optional;
 
 /**
  * RoutingGroupSelector provides a way to match an HTTP request to a Gateway routing group.
@@ -34,7 +33,7 @@ public interface RoutingGroupSelector
      */
     static RoutingGroupSelector byRoutingGroupHeader()
     {
-        return request -> Optional.ofNullable(request.getHeader(ROUTING_GROUP_HEADER));
+        return request -> new RoutingSelectorResponse(request.getHeader(ROUTING_GROUP_HEADER));
     }
 
     /**
@@ -62,5 +61,5 @@ public interface RoutingGroupSelector
      * Given an HTTP request find a routing group to direct the request to. If a routing group cannot
      * be determined return null.
      */
-    Optional<String> findRoutingGroup(HttpServletRequest request);
+    RoutingSelectorResponse findRoutingDestination(HttpServletRequest request);
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/ExternalRouterResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/ExternalRouterResponse.java
@@ -13,6 +13,7 @@
  */
 package io.trino.gateway.ha.router.schema;
 
+import com.google.common.collect.ImmutableMap;
 import jakarta.annotation.Nullable;
 
 import java.util.List;
@@ -28,4 +29,9 @@ public record ExternalRouterResponse(
         @Nullable String routingGroup,
         List<String> errors,
         Map<String, String> externalHeaders)
-        implements RoutingGroupResponse {}
+        implements RoutingGroupResponse
+{
+    public ExternalRouterResponse {
+        externalHeaders = ImmutableMap.copyOf(externalHeaders);
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/ExternalRouterResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/ExternalRouterResponse.java
@@ -15,19 +15,17 @@ package io.trino.gateway.ha.router.schema;
 
 import jakarta.annotation.Nullable;
 
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
- * Response from the routing service that includes:
- * - routingGroup: The target routing group for the request (Optional)
- * - externalHeaders: Headers that can be set in the request (Currently can only be set in ExternalRoutingGroupSelector)
+ * Response from the external routing service that includes:
+ * - routingGroup: The target routing group for the request (optional)
+ * - errors: Any errors that occurred during routing
+ * - externalHeaders: Headers that can be set in the request
  */
-public record RoutingSelectorResponse(@Nullable String routingGroup, Map<String, String> externalHeaders)
-        implements RoutingGroupResponse
-{
-    public RoutingSelectorResponse(String routingGroup)
-    {
-        this(routingGroup, Collections.emptyMap());
-    }
-}
+public record ExternalRouterResponse(
+        @Nullable String routingGroup,
+        List<String> errors,
+        Map<String, String> externalHeaders)
+        implements RoutingGroupResponse {}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingGroupResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingGroupResponse.java
@@ -15,16 +15,20 @@ package io.trino.gateway.ha.router.schema;
 
 import jakarta.annotation.Nullable;
 
-import java.util.List;
 import java.util.Map;
 
 /**
- * Response from the external routing service that includes:
- * - routingGroup: The target routing group for the request (optional)
- * - errors: Any errors that occurred during routing
- * - externalHeaders: Headers that can be set in the request
+ Interface representing the response from a routing group selector.
+ This interface defines the contract for responses that determine how requests should be routed within
+    the Trino Gateway system.
+
+ Implementations of this interface are used to:
+    * Specify the target routing group for a request
+    * Provide additional headers that should be added to the request
  */
-public record RoutingGroupExternalResponse(
-        @Nullable String routingGroup,
-        List<String> errors,
-        Map<String, Object> externalHeaders){}
+public interface RoutingGroupResponse
+{
+    @Nullable String routingGroup();
+
+    Map<String, String> externalHeaders();
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingSelectorResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingSelectorResponse.java
@@ -15,16 +15,20 @@ package io.trino.gateway.ha.router.schema;
 
 import jakarta.annotation.Nullable;
 
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 
 /**
- * Response from the external routing service that includes:
- * - routingGroup: The target routing group for the request (optional)
- * - errors: Any errors that occurred during routing
- * - externalHeaders: Headers that can be set in the request
+ * Response from the routing service that includes:
+ * - routingGroup: The target routing group for the request (Optional)
+ * - externalHeaders: Headers that can be set in the request (Currently can only be set in ExternalRoutingGroupSelector)
  */
-public record RoutingGroupExternalResponse(
+public record RoutingSelectorResponse(
         @Nullable String routingGroup,
-        List<String> errors,
-        Map<String, Object> externalHeaders){}
+        Map<String, String> externalHeaders)
+{
+    public RoutingSelectorResponse(String routingGroup)
+    {
+        this(routingGroup, Collections.emptyMap());
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingSelectorResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingSelectorResponse.java
@@ -13,9 +13,9 @@
  */
 package io.trino.gateway.ha.router.schema;
 
+import com.google.common.collect.ImmutableMap;
 import jakarta.annotation.Nullable;
 
-import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -26,8 +26,12 @@ import java.util.Map;
 public record RoutingSelectorResponse(@Nullable String routingGroup, Map<String, String> externalHeaders)
         implements RoutingGroupResponse
 {
+    public RoutingSelectorResponse {
+        externalHeaders = ImmutableMap.copyOf(externalHeaders);
+    }
+
     public RoutingSelectorResponse(String routingGroup)
     {
-        this(routingGroup, Collections.emptyMap());
+        this(routingGroup, ImmutableMap.of());
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
@@ -26,7 +26,7 @@ import io.airlift.units.Duration;
 import io.trino.gateway.ha.config.GatewayCookieConfigurationPropertiesProvider;
 import io.trino.gateway.ha.config.HaGatewayConfiguration;
 import io.trino.gateway.ha.config.ProxyResponseConfiguration;
-import io.trino.gateway.ha.handler.RoutingDestination;
+import io.trino.gateway.ha.handler.schema.RoutingDestination;
 import io.trino.gateway.ha.router.GatewayCookie;
 import io.trino.gateway.ha.router.OAuth2GatewayCookie;
 import io.trino.gateway.ha.router.QueryHistoryManager;

--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/RouteToBackendResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/RouteToBackendResource.java
@@ -15,8 +15,8 @@ package io.trino.gateway.proxyserver;
 
 import com.google.inject.Inject;
 import io.trino.gateway.ha.handler.ProxyHandlerStats;
-import io.trino.gateway.ha.handler.RoutingDestination;
 import io.trino.gateway.ha.handler.RoutingTargetHandler;
+import io.trino.gateway.ha.handler.schema.RoutingTargetResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
@@ -64,8 +64,8 @@ public class RouteToBackendResource
         if (multiReadHttpServletRequest.getRequestURI().startsWith(V1_STATEMENT_PATH)) {
             proxyHandlerStats.recordRequest();
         }
-        RoutingDestination routingDestination = routingTargetHandler.getRoutingDestination(multiReadHttpServletRequest);
-        proxyRequestHandler.postRequest(body, multiReadHttpServletRequest, asyncResponse, routingDestination);
+        RoutingTargetResponse result = routingTargetHandler.resolveRouting(multiReadHttpServletRequest);
+        proxyRequestHandler.postRequest(body, result.modifiedRequest(), asyncResponse, result.routingDestination());
     }
 
     @GET
@@ -73,8 +73,8 @@ public class RouteToBackendResource
             @Context HttpServletRequest servletRequest,
             @Suspended AsyncResponse asyncResponse)
     {
-        RoutingDestination routingDestination = routingTargetHandler.getRoutingDestination(servletRequest);
-        proxyRequestHandler.getRequest(servletRequest, asyncResponse, routingDestination);
+        RoutingTargetResponse result = routingTargetHandler.resolveRouting(servletRequest);
+        proxyRequestHandler.getRequest(result.modifiedRequest(), asyncResponse, result.routingDestination());
     }
 
     @DELETE
@@ -82,8 +82,8 @@ public class RouteToBackendResource
             @Context HttpServletRequest servletRequest,
             @Suspended AsyncResponse asyncResponse)
     {
-        RoutingDestination routingDestination = routingTargetHandler.getRoutingDestination(servletRequest);
-        proxyRequestHandler.deleteRequest(servletRequest, asyncResponse, routingDestination);
+        RoutingTargetResponse result = routingTargetHandler.resolveRouting(servletRequest);
+        proxyRequestHandler.deleteRequest(result.modifiedRequest(), asyncResponse, result.routingDestination());
     }
 
     @PUT
@@ -93,7 +93,7 @@ public class RouteToBackendResource
             @Suspended AsyncResponse asyncResponse)
     {
         MultiReadHttpServletRequest multiReadHttpServletRequest = new MultiReadHttpServletRequest(servletRequest, body);
-        RoutingDestination routingDestination = routingTargetHandler.getRoutingDestination(multiReadHttpServletRequest);
-        proxyRequestHandler.putRequest(body, multiReadHttpServletRequest, asyncResponse, routingDestination);
+        RoutingTargetResponse result = routingTargetHandler.resolveRouting(multiReadHttpServletRequest);
+        proxyRequestHandler.putRequest(body, result.modifiedRequest(), asyncResponse, result.routingDestination());
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandler.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandler.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.handler;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.http.client.HttpClient;
+import io.trino.gateway.ha.config.GatewayCookieConfiguration;
+import io.trino.gateway.ha.config.GatewayCookieConfigurationPropertiesProvider;
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.config.RequestAnalyzerConfig;
+import io.trino.gateway.ha.config.RulesExternalConfiguration;
+import io.trino.gateway.ha.handler.schema.RoutingTargetResponse;
+import io.trino.gateway.ha.router.RoutingGroupSelector;
+import io.trino.gateway.ha.router.RoutingManager;
+import io.trino.gateway.ha.router.schema.ExternalRouterResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.HttpMethod;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.gateway.ha.handler.HttpUtils.USER_HEADER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestRoutingTargetHandler
+{
+    private RoutingManager routingManager;
+    private HttpClient httpClient;
+    private HttpServletRequest request;
+
+    private RoutingTargetHandler handler;
+    private HaGatewayConfiguration config;
+
+    static HaGatewayConfiguration provideGatewayConfiguration()
+    {
+        HaGatewayConfiguration config = new HaGatewayConfiguration();
+        config.setRequestAnalyzerConfig(new RequestAnalyzerConfig());
+
+        // Configure excluded headers
+        RulesExternalConfiguration rulesExternalConfig = new RulesExternalConfiguration();
+        rulesExternalConfig.setExcludeHeaders(List.of("Authorization", "Cookie"));
+        rulesExternalConfig.setUrlPath("http://localhost:8080/api/routing");
+        config.getRoutingRules().setRulesExternalConfiguration(rulesExternalConfig);
+
+        // Initialize cookie configuration
+        GatewayCookieConfiguration cookieConfig = new GatewayCookieConfiguration();
+        cookieConfig.setEnabled(false); // Disable cookies for testing
+        GatewayCookieConfigurationPropertiesProvider.getInstance().initialize(cookieConfig);
+
+        return config;
+    }
+
+    private HttpServletRequest prepareMockRequest()
+    {
+        HttpServletRequest mockRequest = Mockito.mock(HttpServletRequest.class);
+        when(mockRequest.getMethod()).thenReturn(HttpMethod.GET);
+        when(mockRequest.getHeader(USER_HEADER)).thenReturn("test-user");
+
+        // Set up header names enumeration
+        List<String> headerNames = List.of(
+            USER_HEADER,
+            "Authorization",
+            "Cookie"
+        );
+        when(mockRequest.getHeaderNames()).thenReturn(Collections.enumeration(headerNames));
+
+        // Set up individual header values
+        when(mockRequest.getHeader("Authorization")).thenReturn("secret-token");
+        when(mockRequest.getHeader("Cookie")).thenReturn("session-id");
+
+        // Set up header values enumeration for each header
+        when(mockRequest.getHeaders(USER_HEADER)).thenReturn(Collections.enumeration(List.of("test-user")));
+        when(mockRequest.getHeaders("Authorization")).thenReturn(Collections.enumeration(List.of("secret-token")));
+        when(mockRequest.getHeaders("Cookie")).thenReturn(Collections.enumeration(List.of("session-id")));
+
+        return mockRequest;
+    }
+
+    @BeforeAll
+    void setUp()
+    {
+        config = provideGatewayConfiguration();
+        httpClient = Mockito.mock(HttpClient.class);
+        routingManager = Mockito.mock(RoutingManager.class);
+        request = prepareMockRequest();
+
+        // Initialize the handler with the configuration
+        handler = new RoutingTargetHandler(routingManager, RoutingGroupSelector.byRoutingExternal(httpClient, config.getRoutingRules().getRulesExternalConfiguration(), config.getRequestAnalyzerConfig()), config);
+    }
+
+    @Test
+    void testBasicHeaderModification()
+            throws Exception
+    {
+        // Setup routing group selector response
+        Map<String, String> modifiedHeaders = ImmutableMap.of(
+                "X-Original-Header", "new-value",
+                "X-New-Header", "new-value");
+        ExternalRouterResponse mockResponse = new ExternalRouterResponse(
+                "test-group",
+                Collections.emptyList(),
+                modifiedHeaders);
+        when(httpClient.execute(any(), any())).thenReturn(mockResponse);
+
+        // Execute
+        RoutingTargetResponse response = handler.resolveRouting(request);
+
+        // Verify
+        assertThat(response.modifiedRequest().getHeader("X-Original-Header"))
+                .isEqualTo("new-value");
+        assertThat(response.modifiedRequest().getHeader("X-New-Header"))
+                .isEqualTo("new-value");
+    }
+
+    @Test
+    void testExcludedHeaders()
+            throws Exception
+    {
+        // Setup routing group selector response
+        Map<String, String> modifiedHeaders = ImmutableMap.of(
+                "Authorization", "new-token",
+                "Cookie", "new-session");
+        ExternalRouterResponse mockResponse = new ExternalRouterResponse(
+                "test-group",
+                Collections.emptyList(),
+                modifiedHeaders);
+        when(httpClient.execute(any(), any())).thenReturn(mockResponse);
+
+        // Execute
+        RoutingTargetResponse response = handler.resolveRouting(request);
+
+        // Verify sensitive headers are not modified
+        assertThat(response.modifiedRequest().getHeader("Authorization"))
+                .isEqualTo("secret-token");
+        assertThat(response.modifiedRequest().getHeader("Cookie"))
+                .isEqualTo("session-id");
+    }
+
+    @Test
+    void testNoHeaderModification()
+            throws Exception
+    {
+        // Setup routing group selector response with no header modifications
+        ExternalRouterResponse mockResponse = new ExternalRouterResponse(
+                "test-group",
+                Collections.emptyList(),
+                ImmutableMap.of());
+        when(httpClient.execute(any(), any())).thenReturn(mockResponse);
+
+        // Execute
+        RoutingTargetResponse response = handler.resolveRouting(request);
+
+        // Verify original headers are preserved
+        assertThat(response.modifiedRequest().getHeader("X-Original-Header"))
+                .isNull();
+    }
+
+    @Test
+    void testEmptyHeader()
+            throws Exception
+    {
+        // Setup routing group selector response
+        Map<String, String> modifiedHeaders = ImmutableMap.of(
+                "X-Empty-Header", "",
+                "X-New-Header", "new-value");
+        ExternalRouterResponse mockResponse = new ExternalRouterResponse(
+                "test-group",
+                Collections.emptyList(),
+                modifiedHeaders);
+        when(httpClient.execute(any(), any())).thenReturn(mockResponse);
+
+        // Execute
+        RoutingTargetResponse response = handler.resolveRouting(request);
+
+        // Verify
+        assertThat(response.modifiedRequest().getHeader("X-Empty-Header"))
+                .isEmpty();
+        assertThat(response.modifiedRequest().getHeader("X-New-Header"))
+                .isEqualTo("new-value");
+    }
+
+    @Test
+    void testEmptyRoutingGroup()
+            throws Exception
+    {
+        // Setup routing group selector response with empty routing group
+        Map<String, String> modifiedHeaders = ImmutableMap.of(
+                "X-Empty-Group-Header", "should-be-set");
+        ExternalRouterResponse mockResponse = new ExternalRouterResponse(
+                "",
+                Collections.emptyList(),
+                modifiedHeaders);
+        when(httpClient.execute(any(), any())).thenReturn(mockResponse);
+
+        // Execute
+        RoutingTargetResponse response = handler.resolveRouting(request);
+
+        // Verify that when no routing group header is set, we default to "adhoc"
+        assertThat(response.routingDestination().routingGroup()).isEqualTo("adhoc");
+        assertThat(response.modifiedRequest().getHeader("X-Empty-Group-Header"))
+                .isEqualTo("should-be-set");
+    }
+
+    @Test
+    void testErrorsGiven()
+            throws Exception
+    {
+        // Setup routing group selector response with errors
+        Map<String, String> modifiedHeaders = ImmutableMap.of(
+                "X-New-Header", "new-value");
+        List<String> someErrors = Arrays.asList("ErrorA", "ErrorB");
+        ExternalRouterResponse mockResponse = new ExternalRouterResponse(
+                "test-group",  // This value should be ignored due to errors
+                someErrors,
+                modifiedHeaders);
+        when(httpClient.execute(any(), any())).thenReturn(mockResponse);
+
+        // Execute
+        RoutingTargetResponse response = handler.resolveRouting(request);
+
+        // Verify that when errors are present, we default to "adhoc" group
+        assertThat(response.routingDestination().routingGroup()).isEqualTo("adhoc");
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandler.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandler.java
@@ -81,10 +81,9 @@ class TestRoutingTargetHandler
 
         // Set up header names enumeration
         List<String> headerNames = List.of(
-            USER_HEADER,
-            "Authorization",
-            "Cookie"
-        );
+                USER_HEADER,
+                "Authorization",
+                "Cookie");
         when(mockRequest.getHeaderNames()).thenReturn(Collections.enumeration(headerNames));
 
         // Set up individual header values

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelectorExternal.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelectorExternal.java
@@ -304,7 +304,7 @@ final class TestRoutingGroupSelectorExternal
         RoutingSelectorResponse routingSelectorResponse = selector.findRoutingDestination(mockRequest);
 
         // Verify
-        assertThat(routingSelectorResponse.routingGroup()).isEqualTo("");
+        assertThat(routingSelectorResponse.routingGroup()).isEmpty();
         assertThat(routingSelectorResponse.externalHeaders().get(header_key)).isNotNull().isEqualTo(header_value);
     }
 

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelectorExternal.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelectorExternal.java
@@ -22,8 +22,8 @@ import io.airlift.http.client.Request;
 import io.airlift.json.JsonCodec;
 import io.trino.gateway.ha.config.RequestAnalyzerConfig;
 import io.trino.gateway.ha.config.RulesExternalConfiguration;
+import io.trino.gateway.ha.router.schema.ExternalRouterResponse;
 import io.trino.gateway.ha.router.schema.RoutingGroupExternalBody;
-import io.trino.gateway.ha.router.schema.RoutingGroupExternalResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.HttpMethod;
 import org.junit.jupiter.api.BeforeAll;
@@ -65,8 +65,8 @@ final class TestRoutingGroupSelectorExternal
 {
     RequestAnalyzerConfig requestAnalyzerConfig = new RequestAnalyzerConfig();
     private HttpClient httpClient;
-    private static final JsonResponseHandler<RoutingGroupExternalResponse> ROUTING_GROUP_REST_API_JSON_RESPONSE_HANDLER =
-            createJsonResponseHandler(jsonCodec(RoutingGroupExternalResponse.class));
+    private static final JsonResponseHandler<ExternalRouterResponse> ROUTING_GROUP_REST_API_JSON_RESPONSE_HANDLER =
+            createJsonResponseHandler(jsonCodec(ExternalRouterResponse.class));
 
     @BeforeAll
     void initialize()
@@ -92,12 +92,12 @@ final class TestRoutingGroupSelectorExternal
         HttpServletRequest mockRequest = prepareMockRequest();
 
         // Create a mock response
-        RoutingGroupExternalResponse mockResponse = new RoutingGroupExternalResponse("test-group", null, ImmutableMap.of());
+        ExternalRouterResponse mockResponse = new ExternalRouterResponse("test-group", null, ImmutableMap.of());
 
         // Create ArgumentCaptor
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
         @SuppressWarnings("unchecked")
-        ArgumentCaptor<JsonResponseHandler<RoutingGroupExternalResponse>> handlerCaptor = ArgumentCaptor.forClass(JsonResponseHandler.class);
+        ArgumentCaptor<JsonResponseHandler<ExternalRouterResponse>> handlerCaptor = ArgumentCaptor.forClass(JsonResponseHandler.class);
 
         // Mock the behavior of httpClient.execute
         when(httpClient.execute(requestCaptor.capture(), handlerCaptor.capture())).thenReturn(mockResponse);
@@ -114,7 +114,7 @@ final class TestRoutingGroupSelectorExternal
                 .build();
 
         // Execute the request
-        RoutingGroupExternalResponse response = httpClient.execute(request, ROUTING_GROUP_REST_API_JSON_RESPONSE_HANDLER);
+        ExternalRouterResponse response = httpClient.execute(request, ROUTING_GROUP_REST_API_JSON_RESPONSE_HANDLER);
 
         // Verify the response
         assertThat(response.routingGroup())
@@ -140,12 +140,12 @@ final class TestRoutingGroupSelectorExternal
         // Set a mock header for ROUTING_GROUP_HEADER
         when(mockRequest.getHeader(ROUTING_GROUP_HEADER)).thenReturn("default-group-api-failure");
         // Create a mock response that returns error in List<String>
-        RoutingGroupExternalResponse mockResponse = new RoutingGroupExternalResponse("fail-group", List.of("test-api-failure", "400 error"), ImmutableMap.of());
+        ExternalRouterResponse mockResponse = new ExternalRouterResponse("fail-group", List.of("test-api-failure", "400 error"), ImmutableMap.of());
 
         // Create ArgumentCaptor
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
         @SuppressWarnings("unchecked")
-        ArgumentCaptor<JsonResponseHandler<RoutingGroupExternalResponse>> handlerCaptor = ArgumentCaptor.forClass(JsonResponseHandler.class);
+        ArgumentCaptor<JsonResponseHandler<ExternalRouterResponse>> handlerCaptor = ArgumentCaptor.forClass(JsonResponseHandler.class);
 
         // Mock the behavior of httpClient.execute
         when(httpClient.execute(requestCaptor.capture(), handlerCaptor.capture())).thenReturn(mockResponse);


### PR DESCRIPTION
# Add Header Modification Support to External Routing Service

## Description
This PR
Enhances the external routing service to support header modifications in requests. It allows the external routing service to set custom headers that will be applied to the original request before it's forwarded to the target backend.

closes #646 

## Changes
- Added `setHeaders` field to `RoutingGroupExternalResponse` record to support header modifications
- Updated `ExternalRoutingGroupSelector` to handle header modifications from the external service
- Modified `RoutingTargetHandler` to apply the modified headers to the request
- Added comprehensive test coverage for header modification scenarios

## Example Usage
The external routing service can now return headers that should be set in the request:

```json
{
    "routingGroup": "test-group",
    "errors": [],
    "setHeaders": {
        "x-trino-client-tags": ["etl"],
        "x-trino-session": "query_max_memory=50GB,optimize_metadata_queries=false"
    }
}
```

## Testing
Added test cases to verify:
- Header exclusion functionality
- Different types of header values
- Multiple header values
- Error handling with headers
- Edge cases like empty routing groups


## Notes
- Headers are set as request attributes and then applied by the `RoutingTargetHandler`
- The external service can modify any headers except those in the exclude list
- Null header values are ignored

() This is not user-visible or is docs only, and no release notes are required.
( X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
