### PR TITLE
Allow USER role to get UI Configuration

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
@@ -463,7 +463,7 @@ public class GatewayWebAppResource
     }
 
     @GET
-    @RolesAllowed("ADMIN")
+    @RolesAllowed("USER")
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/getUIConfiguration")
     public Response getUIConfiguration()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Trino Gateway supports disabling pages from the UI using uiConfiguration config https://trinodb.github.io/trino-gateway/gateway-api/#disable-routing-rules-ui

The webapp makes the call to get the list of disabled pages using the /webapp/getUIConfiguration endpoint.

This is called irrespective of whether an Admin has logged in or User because the pages disabled in the uiConfiguration are globally disabled.

However, currently only the ADMIN role is allowed to call /webapp/getUIConfiguration endpoint which results in "Login has expired, please login again" error messages whenever anyone with USER role logs in through the webapp.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Only the Admin is allowed to get the uiConfiguration based on https://github.com/trinodb/trino-gateway/blob/main/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java#L466

webapp makes the getUIConfiguration call at https://github.com/trinodb/trino-gateway/blob/main/webapp/src/components/layout.tsx#L25


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Allow USER role to get UI configuration
```
