### PR TITLE
Improve logging for backend cluster (de)activation

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayResource.java
@@ -86,7 +86,7 @@ public class GatewayResource
             this.gatewayBackendManager.activateBackend(name);
         }
         catch (Exception e) {
-            log.error(e);
+            log.error(e, e.getMessage());
             return throwError(e);
         }
         return Response.ok().build();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
As apart of efforts to improve telemetry as described in Issue https://github.com/trinodb/trino-gateway/issues/649, this PR adds logging for whenever a backend cluster is activated/deactivated. 

## Testing
- built and ran locally
- confirmed logs appeared when calling de(activate) via curl call or changing deactivation status via the UI, e.g.:
```
2025-04-03T17:09:03.588-0700	INFO	http-worker-87	io.trino.gateway.ha.router.HaGatewayManager	Backend cluster trino-3 activation status changed to active=false (previous status: active=true).
```
- confirm error thrown if try to activate/deactivate non-existent backend
```
java.lang.IllegalStateException: No backend found with name: trino-4, could not activate
```

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
