### PR TITLE
[Improvement] JDBC Connection Configuration with Flexible SSL and Property Injection

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -77,6 +77,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>9.2.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
             <version>10.0.2</version>
@@ -268,13 +274,6 @@
         <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
-            <version>9.2.0</version>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/DataStoreConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/DataStoreConfiguration.java
@@ -22,6 +22,10 @@ public class DataStoreConfiguration
     private Integer queryHistoryHoursRetention = 4;
     private boolean runMigrationsEnabled = true;
 
+    // TODO: Refactor to decouple DataStoreConfiguration from a specific
+    //  database implementation after adopting the Airlift configuration framework (https://github.com/trinodb/trino-gateway/issues/378)
+    private MysqlConfiguration mysqlConfiguration = new MysqlConfiguration();
+
     public DataStoreConfiguration(String jdbcUrl, String user, String password, String driver, Integer queryHistoryHoursRetention, boolean runMigrationsEnabled)
     {
         this.jdbcUrl = jdbcUrl;
@@ -92,5 +96,15 @@ public class DataStoreConfiguration
     public void setRunMigrationsEnabled(boolean runMigrationsEnabled)
     {
         this.runMigrationsEnabled = runMigrationsEnabled;
+    }
+
+    public MysqlConfiguration getMysqlConfiguration()
+    {
+        return mysqlConfiguration;
+    }
+
+    public void setMysqlConfiguration(MysqlConfiguration mysqlConfig)
+    {
+        this.mysqlConfiguration = mysqlConfig;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/HaGatewayConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/HaGatewayConfiguration.java
@@ -43,6 +43,7 @@ public class HaGatewayConfiguration
     private List<String> statementPaths = ImmutableList.of(V1_STATEMENT_PATH);
     private boolean includeClusterHostInResponse;
     private ProxyResponseConfiguration proxyResponseConfiguration = new ProxyResponseConfiguration();
+    private boolean oracleBackend;
 
     private RequestAnalyzerConfig requestAnalyzerConfig = new RequestAnalyzerConfig();
 
@@ -296,5 +297,15 @@ public class HaGatewayConfiguration
         {
             super(message);
         }
+    }
+
+    public boolean isOracleBackend()
+    {
+        return oracleBackend;
+    }
+
+    public void setOracleBackend(boolean oracleBackend)
+    {
+        this.oracleBackend = oracleBackend;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/MysqlConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/MysqlConfiguration.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.config;
+
+import com.mysql.cj.conf.PropertyDefinitions.SslMode;
+
+/**
+ * Configuration for MySQL SSL (client cert and truststore settings).
+ */
+public class MysqlConfiguration
+{
+    private SslMode sslMode = SslMode.DISABLED;
+    private String clientCertificateKeyStoreUrl;
+    private String clientCertificateKeyStorePassword;
+    private String clientCertificateKeyStoreType;
+    private String trustCertificateKeyStoreUrl;
+    private String trustCertificateKeyStorePassword;
+
+    public SslMode getSslMode()
+    {
+        return sslMode;
+    }
+
+    public MysqlConfiguration setSslMode(SslMode sslMode)
+    {
+        this.sslMode = sslMode;
+        return this;
+    }
+
+    public String getClientCertificateKeyStoreUrl()
+    {
+        return clientCertificateKeyStoreUrl;
+    }
+
+    public MysqlConfiguration setClientCertificateKeyStoreUrl(String url)
+    {
+        this.clientCertificateKeyStoreUrl = url;
+        return this;
+    }
+
+    public String getClientCertificateKeyStorePassword()
+    {
+        return clientCertificateKeyStorePassword;
+    }
+
+    public MysqlConfiguration setClientCertificateKeyStorePassword(String password)
+    {
+        this.clientCertificateKeyStorePassword = password;
+        return this;
+    }
+
+    public String getClientCertificateKeyStoreType()
+    {
+        return clientCertificateKeyStoreType;
+    }
+
+    public MysqlConfiguration setClientCertificateKeyStoreType(String type)
+    {
+        this.clientCertificateKeyStoreType = type;
+        return this;
+    }
+
+    public String getTrustCertificateKeyStoreUrl()
+    {
+        return trustCertificateKeyStoreUrl;
+    }
+
+    public MysqlConfiguration setTrustCertificateKeyStoreUrl(String url)
+    {
+        this.trustCertificateKeyStoreUrl = url;
+        return this;
+    }
+
+    public String getTrustCertificateKeyStorePassword()
+    {
+        return trustCertificateKeyStorePassword;
+    }
+
+    public MysqlConfiguration setTrustCertificateKeyStorePassword(String password)
+    {
+        this.trustCertificateKeyStorePassword = password;
+        return this;
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/module/QueryCountBasedRouterProvider.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/module/QueryCountBasedRouterProvider.java
@@ -14,24 +14,27 @@
 package io.trino.gateway.ha.module;
 
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.router.GatewayBackendManager;
 import io.trino.gateway.ha.router.QueryCountBasedRouter;
+import io.trino.gateway.ha.router.QueryHistoryManager;
 import io.trino.gateway.ha.router.RoutingManager;
 
 public class QueryCountBasedRouterProvider
           extends RouterBaseModule
 {
-    private final QueryCountBasedRouter routingManager;
-
     public QueryCountBasedRouterProvider(HaGatewayConfiguration configuration)
     {
         super(configuration);
-        routingManager = new QueryCountBasedRouter(gatewayBackendManager, queryHistoryManager);
     }
 
     @Provides
-    public RoutingManager getRoutingManager()
+    @Singleton
+    public RoutingManager provideRoutingManager(
+            GatewayBackendManager gatewayBackendManager,
+            QueryHistoryManager queryHistoryManager)
     {
-        return this.routingManager;
+        return new QueryCountBasedRouter(gatewayBackendManager, queryHistoryManager);
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/module/RouterBaseModule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/module/RouterBaseModule.java
@@ -15,8 +15,15 @@ package io.trino.gateway.ha.module;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.TypeLiteral;
+import io.trino.gateway.ha.config.DataStoreConfiguration;
 import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.persistence.BasicJdbcPropertiesProvider;
 import io.trino.gateway.ha.persistence.JdbcConnectionManager;
+import io.trino.gateway.ha.persistence.JdbcPropertiesProvider;
+import io.trino.gateway.ha.persistence.JdbcPropertiesProviderFactory;
+import io.trino.gateway.ha.persistence.MySqlJdbcPropertiesProvider;
 import io.trino.gateway.ha.router.GatewayBackendManager;
 import io.trino.gateway.ha.router.HaGatewayManager;
 import io.trino.gateway.ha.router.HaQueryHistoryManager;
@@ -24,45 +31,60 @@ import io.trino.gateway.ha.router.HaResourceGroupsManager;
 import io.trino.gateway.ha.router.QueryHistoryManager;
 import io.trino.gateway.ha.router.ResourceGroupsManager;
 import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+
+import java.util.List;
+import java.util.Properties;
 
 public class RouterBaseModule
         extends AbstractModule
 {
-    final ResourceGroupsManager resourceGroupsManager;
-    final GatewayBackendManager gatewayBackendManager;
-    final QueryHistoryManager queryHistoryManager;
-    final JdbcConnectionManager connectionManager;
+    private final HaGatewayConfiguration configuration;
 
     public RouterBaseModule(HaGatewayConfiguration configuration)
     {
-        Jdbi jdbi = Jdbi.create(configuration.getDataStore().getJdbcUrl(), configuration.getDataStore().getUser(), configuration.getDataStore().getPassword());
-        connectionManager = new JdbcConnectionManager(jdbi, configuration.getDataStore());
-        resourceGroupsManager = new HaResourceGroupsManager(connectionManager);
-        gatewayBackendManager = new HaGatewayManager(jdbi);
-        queryHistoryManager = new HaQueryHistoryManager(jdbi, configuration.getDataStore().getJdbcUrl().startsWith("jdbc:oracle"));
+        this.configuration = configuration;
+    }
+
+    @Override
+    protected void configure()
+    {
+        bind(HaGatewayConfiguration.class).toInstance(configuration);
+        bind(DataStoreConfiguration.class)
+                .toInstance(configuration.getDataStore());
+
+        bind(ResourceGroupsManager.class).to(HaResourceGroupsManager.class);
+        bind(GatewayBackendManager.class).to(HaGatewayManager.class);
+        bind(QueryHistoryManager.class).to(HaQueryHistoryManager.class);
+
+        bind(new TypeLiteral<List<JdbcPropertiesProvider>>() {}).toInstance(List.of(
+                new MySqlJdbcPropertiesProvider(),
+                new BasicJdbcPropertiesProvider()));
+
+        bind(JdbcPropertiesProviderFactory.class).in(Singleton.class);
     }
 
     @Provides
-    public JdbcConnectionManager getConnectionManager()
+    @Singleton
+    public Jdbi provideJdbi(
+            DataStoreConfiguration configuration,
+            JdbcPropertiesProviderFactory providerFactory)
     {
-        return this.connectionManager;
+        Properties props = providerFactory
+                .forConfig(configuration)
+                .getProperties(configuration);
+        Jdbi jdbi = Jdbi.create(configuration.getJdbcUrl(), props);
+        jdbi.installPlugin(new SqlObjectPlugin());
+        return jdbi;
     }
 
     @Provides
-    public ResourceGroupsManager getResourceGroupsManager()
+    @Singleton
+    public JdbcConnectionManager provideConnectionManager(
+            Jdbi jdbi,
+            DataStoreConfiguration configuration,
+            JdbcPropertiesProviderFactory providerFactory)
     {
-        return this.resourceGroupsManager;
-    }
-
-    @Provides
-    public GatewayBackendManager getGatewayBackendManager()
-    {
-        return this.gatewayBackendManager;
-    }
-
-    @Provides
-    public QueryHistoryManager getQueryHistoryManager()
-    {
-        return this.queryHistoryManager;
+        return new JdbcConnectionManager(jdbi, configuration, providerFactory.forConfig(configuration));
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/module/StochasticRoutingManagerProvider.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/module/StochasticRoutingManagerProvider.java
@@ -14,30 +14,34 @@
 package io.trino.gateway.ha.module;
 
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.router.GatewayBackendManager;
+import io.trino.gateway.ha.router.QueryHistoryManager;
 import io.trino.gateway.ha.router.RoutingManager;
 import io.trino.gateway.ha.router.StochasticRoutingManager;
 
 public class StochasticRoutingManagerProvider
             extends RouterBaseModule
 {
-    private final StochasticRoutingManager routingManager;
-
     public StochasticRoutingManagerProvider(HaGatewayConfiguration configuration)
     {
         super(configuration);
-        routingManager = new StochasticRoutingManager(gatewayBackendManager, queryHistoryManager);
     }
 
     @Provides
-    public StochasticRoutingManager getHaRoutingManager()
+    @Singleton
+    public StochasticRoutingManager provideStochasticRoutingManager(
+            GatewayBackendManager gatewayBackendManager,
+            QueryHistoryManager queryHistoryManager)
     {
-        return this.routingManager;
+        return new StochasticRoutingManager(gatewayBackendManager, queryHistoryManager);
     }
 
     @Provides
-    public RoutingManager getRoutingManager()
+    @Singleton
+    public RoutingManager provideRoutingManager(StochasticRoutingManager routingManager)
     {
-        return getHaRoutingManager();
+        return routingManager;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/BasicJdbcPropertiesProvider.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/BasicJdbcPropertiesProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.persistence;
+
+import io.trino.gateway.ha.config.DataStoreConfiguration;
+
+import java.util.Properties;
+
+public class BasicJdbcPropertiesProvider
+        implements JdbcPropertiesProvider
+{
+    @Override
+    public boolean supports(DataStoreConfiguration configuration)
+    {
+        return true;
+    }
+
+    @Override
+    public Properties getProperties(DataStoreConfiguration configuration)
+    {
+        Properties props = new Properties();
+        props.setProperty("user", configuration.getUser());
+        props.setProperty("password", configuration.getPassword());
+        return props;
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/JdbcConnectionManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/JdbcConnectionManager.java
@@ -13,6 +13,8 @@
  */
 package io.trino.gateway.ha.persistence;
 
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import io.airlift.log.Logger;
 import io.trino.gateway.ha.config.DataStoreConfiguration;
 import io.trino.gateway.ha.persistence.dao.QueryHistoryDao;
@@ -20,27 +22,32 @@ import jakarta.annotation.Nullable;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 
+import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Objects.requireNonNull;
 
+@Singleton
 public class JdbcConnectionManager
 {
     private static final Logger log = Logger.get(JdbcConnectionManager.class);
 
     private final Jdbi jdbi;
     private final DataStoreConfiguration configuration;
+    private final JdbcPropertiesProvider jdbcPropertiesProvider;
     private final ScheduledExecutorService executorService =
             Executors.newSingleThreadScheduledExecutor();
 
-    public JdbcConnectionManager(Jdbi jdbi, DataStoreConfiguration configuration)
+    @Inject
+    public JdbcConnectionManager(Jdbi jdbi, DataStoreConfiguration configuration, JdbcPropertiesProvider jdbcPropertiesProvider)
     {
         this.jdbi = requireNonNull(jdbi, "jdbi is null")
                 .installPlugin(new SqlObjectPlugin())
                 .registerRowMapper(new RecordAndAnnotatedConstructorMapper());
         this.configuration = configuration;
+        this.jdbcPropertiesProvider = requireNonNull(jdbcPropertiesProvider, "jdbcPropertiesProvider is null");
         startCleanUps();
     }
 
@@ -54,8 +61,9 @@ public class JdbcConnectionManager
         if (routingGroupDatabase == null) {
             return jdbi;
         }
+        Properties props = jdbcPropertiesProvider.getProperties(configuration);
 
-        return Jdbi.create(buildJdbcUrl(routingGroupDatabase), configuration.getUser(), configuration.getPassword())
+        return Jdbi.create(buildJdbcUrl(routingGroupDatabase), props)
                 .installPlugin(new SqlObjectPlugin())
                 .registerRowMapper(new RecordAndAnnotatedConstructorMapper());
     }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/JdbcPropertiesProvider.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/JdbcPropertiesProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.persistence;
+
+import io.trino.gateway.ha.config.DataStoreConfiguration;
+
+import java.util.Properties;
+
+/**
+ * Given a DataStoreConfiguration, produce the proper JDBC driver properties.
+ * Different implementations can handle MySQL, Postgres, H2, etc.
+ */
+public interface JdbcPropertiesProvider
+{
+    boolean supports(DataStoreConfiguration config);
+
+    Properties getProperties(DataStoreConfiguration config);
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/JdbcPropertiesProviderFactory.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/JdbcPropertiesProviderFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.persistence;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.trino.gateway.ha.config.DataStoreConfiguration;
+
+import java.util.List;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+@Singleton
+public class JdbcPropertiesProviderFactory
+{
+    private final List<JdbcPropertiesProvider> providers;
+
+    @Inject
+    public JdbcPropertiesProviderFactory(List<JdbcPropertiesProvider> orderedProviders)
+    {
+        this.providers = requireNonNull(orderedProviders, "providers is null");
+    }
+
+    public JdbcPropertiesProvider forConfig(DataStoreConfiguration config)
+    {
+        return providers.stream()
+                .filter(p -> p.supports(config))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        format("No JdbcPropertiesProvider for driver: %s", config.getDriver())));
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/MySqlJdbcPropertiesProvider.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/MySqlJdbcPropertiesProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.persistence;
+
+import com.mysql.cj.conf.PropertyDefinitions.SslMode;
+import com.mysql.cj.conf.PropertyKey;
+import io.trino.gateway.ha.config.DataStoreConfiguration;
+import io.trino.gateway.ha.config.MysqlConfiguration;
+
+import java.util.Locale;
+import java.util.Properties;
+
+import static java.util.Objects.requireNonNull;
+
+public class MySqlJdbcPropertiesProvider
+        implements JdbcPropertiesProvider
+{
+    @Override
+    public boolean supports(DataStoreConfiguration configuration)
+    {
+        return configuration.getDriver() != null
+                && configuration.getJdbcUrl() != null
+                && configuration.getJdbcUrl().toLowerCase(Locale.ROOT).startsWith("jdbc:mysql");
+    }
+
+    @Override
+    public Properties getProperties(DataStoreConfiguration configuration)
+    {
+        Properties props = new Properties();
+        props.setProperty("user", configuration.getUser());
+
+        MysqlConfiguration mysqlConfiguration = configuration.getMysqlConfiguration();
+        props.setProperty(PropertyKey.sslMode.getKeyName(), mysqlConfiguration.getSslMode().toString());
+
+        if (SslMode.VERIFY_CA.equals(mysqlConfiguration.getSslMode())) {
+            requireNonNull(mysqlConfiguration.getClientCertificateKeyStoreUrl(),
+                    "clientCertificateKeyStoreUrl must be set when sslMode=VERIFY_CA");
+            requireNonNull(mysqlConfiguration.getClientCertificateKeyStorePassword(),
+                    "clientCertificateKeyStorePassword must be set when sslMode=VERIFY_CA");
+            requireNonNull(mysqlConfiguration.getTrustCertificateKeyStoreUrl(),
+                    "trustCertificateKeyStoreUrl must be set when sslMode=VERIFY_CA");
+            requireNonNull(mysqlConfiguration.getTrustCertificateKeyStorePassword(),
+                    "trustCertificateKeyStorePassword must be set when sslMode=VERIFY_CA");
+
+            props.setProperty(PropertyKey.clientCertificateKeyStoreUrl.getKeyName(),
+                    mysqlConfiguration.getClientCertificateKeyStoreUrl());
+            props.setProperty(PropertyKey.clientCertificateKeyStorePassword.getKeyName(),
+                    mysqlConfiguration.getClientCertificateKeyStorePassword());
+            if (mysqlConfiguration.getClientCertificateKeyStoreType() != null) {
+                props.setProperty(
+                        PropertyKey.clientCertificateKeyStoreType.getKeyName(),
+                        mysqlConfiguration.getClientCertificateKeyStoreType());
+            }
+            props.setProperty(PropertyKey.trustCertificateKeyStoreUrl.getKeyName(),
+                    mysqlConfiguration.getTrustCertificateKeyStoreUrl());
+            props.setProperty(PropertyKey.trustCertificateKeyStorePassword.getKeyName(),
+                    mysqlConfiguration.getTrustCertificateKeyStorePassword());
+        }
+        else {
+            props.setProperty("password", configuration.getPassword());
+        }
+        return props;
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaGatewayManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaGatewayManager.java
@@ -14,6 +14,7 @@
 package io.trino.gateway.ha.router;
 
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 import io.trino.gateway.ha.persistence.dao.GatewayBackend;
@@ -33,6 +34,7 @@ public class HaGatewayManager
 
     private final GatewayBackendDao dao;
 
+    @Inject
     public HaGatewayManager(Jdbi jdbi)
     {
         dao = requireNonNull(jdbi, "jdbi is null").onDemand(GatewayBackendDao.class);

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
@@ -14,6 +14,8 @@
 package io.trino.gateway.ha.router;
 
 import com.google.common.base.Strings;
+import com.google.inject.Inject;
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
 import io.trino.gateway.ha.domain.TableData;
 import io.trino.gateway.ha.domain.request.QueryHistoryRequest;
 import io.trino.gateway.ha.domain.response.DistributionResponse;
@@ -40,10 +42,11 @@ public class HaQueryHistoryManager
     private final QueryHistoryDao dao;
     private final boolean isOracleBackend;
 
-    public HaQueryHistoryManager(Jdbi jdbi, boolean isOracleBackend)
+    @Inject
+    public HaQueryHistoryManager(Jdbi jdbi, HaGatewayConfiguration configuration)
     {
         dao = requireNonNull(jdbi, "jdbi is null").onDemand(QueryHistoryDao.class);
-        this.isOracleBackend = isOracleBackend;
+        this.isOracleBackend = configuration.isOracleBackend();
     }
 
     @Override

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaResourceGroupsManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaResourceGroupsManager.java
@@ -14,6 +14,7 @@
 package io.trino.gateway.ha.router;
 
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
 import io.trino.gateway.ha.persistence.JdbcConnectionManager;
 import io.trino.gateway.ha.persistence.dao.ExactMatchSourceSelectors;
 import io.trino.gateway.ha.persistence.dao.ExactMatchSourceSelectorsDao;
@@ -36,6 +37,7 @@ public class HaResourceGroupsManager
     private final JdbcConnectionManager connectionManager;
     private final ExactMatchSourceSelectorsDao exactMatchSourceSelectorsDao;
 
+    @Inject
     public HaResourceGroupsManager(JdbcConnectionManager connectionManager)
     {
         this.connectionManager = connectionManager;

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestTrinoResource.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestTrinoResource.java
@@ -15,6 +15,7 @@ package io.trino.gateway.ha;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.trino.gateway.ha.config.DataStoreConfiguration;
+import io.trino.gateway.ha.persistence.BasicJdbcPropertiesProvider;
 import io.trino.gateway.ha.persistence.JdbcConnectionManager;
 import io.trino.gateway.ha.router.HaResourceGroupsManager;
 import okhttp3.MediaType;
@@ -66,7 +67,7 @@ final class TestTrinoResource
         // Setup resource group manager
         DataStoreConfiguration db = new DataStoreConfiguration(postgresql.getJdbcUrl(), postgresql.getUsername(), postgresql.getPassword(), "org.postgresql.Driver", 4, true);
         Jdbi jdbi = Jdbi.create(postgresql.getJdbcUrl(), postgresql.getUsername(), postgresql.getPassword());
-        connectionManager = new JdbcConnectionManager(jdbi, db);
+        connectionManager = new JdbcConnectionManager(jdbi, db, new BasicJdbcPropertiesProvider());
         resourceGroupManager = new HaResourceGroupsManager(connectionManager);
 
         // Start Trino Gateway so migrations are run to create tables before inserting test data

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestingJdbcConnectionManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestingJdbcConnectionManager.java
@@ -14,6 +14,7 @@
 package io.trino.gateway.ha;
 
 import io.trino.gateway.ha.config.DataStoreConfiguration;
+import io.trino.gateway.ha.persistence.BasicJdbcPropertiesProvider;
 import io.trino.gateway.ha.persistence.JdbcConnectionManager;
 import org.jdbi.v3.core.Jdbi;
 import org.testcontainers.containers.JdbcDatabaseContainer;
@@ -33,12 +34,12 @@ public final class TestingJdbcConnectionManager
         HaGatewayTestUtils.seedRequiredData(tempH2DbDir.getAbsolutePath());
         DataStoreConfiguration db = new DataStoreConfiguration(jdbcUrl, "sa", "sa", "org.h2.Driver", 4, false);
         Jdbi jdbi = Jdbi.create(jdbcUrl, "sa", "sa");
-        return new JdbcConnectionManager(jdbi, db);
+        return new JdbcConnectionManager(jdbi, db, new BasicJdbcPropertiesProvider());
     }
 
     public static JdbcConnectionManager createTestingJdbcConnectionManager(JdbcDatabaseContainer<?> container, DataStoreConfiguration config)
     {
         Jdbi jdbi = Jdbi.create(container.getJdbcUrl(), container.getUsername(), container.getPassword());
-        return new JdbcConnectionManager(jdbi, config);
+        return new JdbcConnectionManager(jdbi, config, new BasicJdbcPropertiesProvider());
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestJdbcPropertiesProviderFactory.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestJdbcPropertiesProviderFactory.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.persistence;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.mysql.cj.conf.PropertyDefinitions.SslMode;
+import com.mysql.cj.conf.PropertyKey;
+import io.trino.gateway.ha.config.DataStoreConfiguration;
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.config.MysqlConfiguration;
+import io.trino.gateway.ha.module.RouterBaseModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestJdbcPropertiesProviderFactory
+{
+    private JdbcPropertiesProviderFactory factory;
+
+    @BeforeEach
+    void setUp()
+    {
+        DataStoreConfiguration db = new DataStoreConfiguration("jdbc:h2:mem:test", "sa",
+                "sa", "org.h2.Driver", 4, false);
+        HaGatewayConfiguration haConfiguration = new HaGatewayConfiguration();
+        haConfiguration.setDataStore(db);
+
+        Injector injector = Guice.createInjector(new RouterBaseModule(haConfiguration));
+        factory = injector.getInstance(JdbcPropertiesProviderFactory.class);
+    }
+
+    private DataStoreConfiguration makeMysqlConfig(SslMode mode)
+    {
+        DataStoreConfiguration db = new DataStoreConfiguration();
+        db.setDriver("com.mysql.Driver");
+        db.setJdbcUrl("jdbc:mysql://host/db");
+        db.setUser("root");
+        db.setPassword("root123");
+        MysqlConfiguration mysqlConfig = db.getMysqlConfiguration();
+        mysqlConfig.setSslMode(mode);
+        return db;
+    }
+
+    private DataStoreConfiguration makeH2Config()
+    {
+        DataStoreConfiguration db = new DataStoreConfiguration();
+        db.setDriver("org.h2.Driver");
+        db.setJdbcUrl("jdbc:h2:mem:test");
+        db.setUser("sa");
+        db.setPassword("sa");
+        return db;
+    }
+
+    @Test
+    void testBasicProviderWhenH2()
+    {
+        var cfg = makeH2Config();
+        var provider = factory.forConfig(cfg);
+        assertThat(provider).isInstanceOf(BasicJdbcPropertiesProvider.class);
+
+        Properties props = provider.getProperties(cfg);
+        assertThat(props)
+                .hasSize(2)
+                .containsEntry("user", "sa")
+                .containsEntry("password", "sa");
+    }
+
+    @Test
+    void testMysqlProviderWhenSslDisabled()
+    {
+        var cfg = makeMysqlConfig(SslMode.DISABLED);
+
+        var provider = factory.forConfig(cfg);
+        assertThat(provider).isInstanceOf(MySqlJdbcPropertiesProvider.class);
+
+        Properties props = provider.getProperties(cfg);
+        assertThat(props.getProperty("user")).isEqualTo("root");
+        assertThat(props.getProperty("password")).isEqualTo("root123");
+        assertThat(props.getProperty(PropertyKey.sslMode.getKeyName()))
+                .isEqualTo("DISABLED");
+
+        assertThat(props).doesNotContainKeys(
+                PropertyKey.clientCertificateKeyStoreUrl.getKeyName(),
+                PropertyKey.clientCertificateKeyStorePassword.getKeyName(),
+                PropertyKey.clientCertificateKeyStoreType.getKeyName(),
+                PropertyKey.trustCertificateKeyStoreUrl.getKeyName(),
+                PropertyKey.trustCertificateKeyStorePassword.getKeyName());
+    }
+
+    @Test
+    void testMysqlProviderWhenVerifyCa()
+    {
+        var cfg = makeMysqlConfig(SslMode.VERIFY_CA);
+        var mysqlConfig = cfg.getMysqlConfiguration();
+        mysqlConfig.setClientCertificateKeyStoreUrl("file:/tmp/cli.p12")
+                .setClientCertificateKeyStorePassword("cpw")
+                .setClientCertificateKeyStoreType("PKCS12")
+                .setTrustCertificateKeyStoreUrl("file:/tmp/trs.p12")
+                .setTrustCertificateKeyStorePassword("tpw");
+
+        var provider = factory.forConfig(cfg);
+        assertThat(provider).isInstanceOf(MySqlJdbcPropertiesProvider.class);
+
+        var props = provider.getProperties(cfg);
+        assertThat(props.getProperty("user")).isEqualTo("root");
+        assertThat(props.getProperty(PropertyKey.sslMode.getKeyName()))
+                .isEqualTo("VERIFY_CA");
+        assertThat(props.getProperty(PropertyKey.clientCertificateKeyStoreUrl.getKeyName()))
+                .isEqualTo("file:/tmp/cli.p12");
+        assertThat(props.getProperty(PropertyKey.trustCertificateKeyStoreUrl.getKeyName()))
+                .isEqualTo("file:/tmp/trs.p12");
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/BaseTestQueryHistoryManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/BaseTestQueryHistoryManager.java
@@ -14,6 +14,7 @@
 package io.trino.gateway.ha.router;
 
 import io.trino.gateway.ha.config.DataStoreConfiguration;
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
 import io.trino.gateway.ha.domain.response.DistributionResponse;
 import io.trino.gateway.ha.persistence.FlywayMigration;
 import io.trino.gateway.ha.persistence.JdbcConnectionManager;
@@ -50,7 +51,9 @@ abstract class BaseTestQueryHistoryManager
                 true);
         FlywayMigration.migrate(config);
         JdbcConnectionManager jdbcConnectionManager = createTestingJdbcConnectionManager(container, config);
-        queryHistoryManager = new HaQueryHistoryManager(jdbcConnectionManager.getJdbi(), container.getJdbcUrl().startsWith("jdbc:oracle"));
+        HaGatewayConfiguration haGatewayConfiguration = new HaGatewayConfiguration();
+        haGatewayConfiguration.setOracleBackend(container.getJdbcUrl().startsWith("jdbc:oracle"));
+        queryHistoryManager = new HaQueryHistoryManager(jdbcConnectionManager.getJdbi(), haGatewayConfiguration);
     }
 
     @AfterAll

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestSpecificDbResourceGroupsManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestSpecificDbResourceGroupsManager.java
@@ -13,10 +13,13 @@
  */
 package io.trino.gateway.ha.router;
 
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 import io.trino.gateway.ha.HaGatewayTestUtils;
 import io.trino.gateway.ha.config.DataStoreConfiguration;
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.module.RouterBaseModule;
 import io.trino.gateway.ha.persistence.JdbcConnectionManager;
-import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -47,8 +50,12 @@ final class TestSpecificDbResourceGroupsManager
         HaGatewayTestUtils.seedRequiredData(tempH2DbDir.getAbsolutePath());
         DataStoreConfiguration db = new DataStoreConfiguration(jdbcUrl, "sa",
                 "sa", "org.h2.Driver", 4, false);
-        Jdbi jdbi = Jdbi.create(jdbcUrl, "sa", "sa");
-        JdbcConnectionManager connectionManager = new JdbcConnectionManager(jdbi, db);
+        HaGatewayConfiguration configuration = new HaGatewayConfiguration();
+        configuration.setDataStore(db);
+        Injector injector = Guice.createInjector(
+                new RouterBaseModule(configuration));
+
+        JdbcConnectionManager connectionManager = injector.getInstance(JdbcConnectionManager.class);
         super.resourceGroupManager = new HaResourceGroupsManager(connectionManager);
     }
 

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
@@ -14,6 +14,7 @@
 package io.trino.gateway.ha.router;
 
 import io.trino.gateway.ha.clustermonitor.TrinoStatus;
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 import io.trino.gateway.ha.persistence.JdbcConnectionManager;
 import org.junit.jupiter.api.BeforeAll;
@@ -36,7 +37,7 @@ final class TestStochasticRoutingManager
     {
         JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager();
         backendManager = new HaGatewayManager(connectionManager.getJdbi());
-        historyManager = new HaQueryHistoryManager(connectionManager.getJdbi(), false);
+        historyManager = new HaQueryHistoryManager(connectionManager.getJdbi(), new HaGatewayConfiguration());
         haRoutingManager = new StochasticRoutingManager(backendManager, historyManager);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Summary: Today, the Trino Gateway only supports very basic JDBC connection initialization, assuming standard username/password settings. It lacks support for important real-world features like client-side certificates (mTLS), custom truststore setups, or fine-grained SSL configurations when connecting to databases (e.g., MySQL).
I would like to help contributing a more flexible, extensible JDBC connection management system.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Right now, current gateway code hardcodes simple username/password based JDBC setup.
It is difficult to configure SSL/TLS for databases that require client certificates (e.g., `SslMode=VERIFY_CA` for `MySQL`). Gateway users with stricter security requirements (like us at **LinkedIn**) must patch or fork the code. And it is not cleanly extensible for new future other database types. At **LinkedIn**, We already implemented the following internally and would like to contribute it upstream:

- Introduce a `JdbcPropertiesProvider `interface for generating connection properties.
- Add `BasicJdbcPropertiesProvider` (default simple username/password).
- Add `MySqlJdbcPropertiesProvider` to handle MySQL-specific SSL properties:
- Handles `clientCertificateKeyStoreUrl, clientCertificateKeyStorePassword`, etc.
- Supports different `SslMode` settings (`DISABLED`, `VERIFY_CA`, etc.).
- Introduce a `JdbcPropertiesProviderFactory` to pick the right provider automatically based on configuration.
- Refactor `JdbcConnectionManager `to use these properties instead of hardcoded username/password.
- Add Airlift-compliant `@Singleton` / Guice bindings for better dependency injection.

**Benefits:**
The changes will help 
- Secure and flexible database connections (support MySQL client cert auth, etc.).
- Easily extensible for Oracle, or other databases in the future.
- More separation of concerns: connection properties logic decoupled from connection management.
- Retains full backward compatibility (H2, MySQL username/password still work out of the box).

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
