### PR TITLE
add configurable default routing group, add indicative errors, use ex…

### DIFF
--- a/docs/routing-rules.md
+++ b/docs/routing-rules.md
@@ -3,8 +3,14 @@
 Trino Gateway includes a routing rules engine.
 
 By default, Trino Gateway reads the `X-Trino-Routing-Group` request header to
-route requests. If this header is not specified, requests are sent to the
-default routing group called `adhoc`.
+route requests. Use the `defaultRoutingGroup` setting to specify a fallback group, 
+defaults to the `adhoc` group.
+
+
+```yaml
+routing:
+    defaultRoutingGroup: "test-group"
+```
 
 The routing rules engine feature enables you to either write custom logic to
 route requests based on the request info such as any of the [request
@@ -40,6 +46,7 @@ routingRules:
         excludeHeaders:
             - 'Authorization'
             - 'Accept-Encoding'
+        propagateErrors: false
 ```
 
 * Redirect URLs are not supported.
@@ -47,6 +54,8 @@ routingRules:
   corresponding header values from being sent in the POST request.
 * Check headers to exclude when making API requests, specifics depend on the
   network configuration.
+* Set `propagateErrors` to `true` to forward routing service errors to  
+  clients if present in the response.
 
 If there is error parsing the routing rules configuration file, an error is
 logged, and requests are routed using the routing group header
@@ -93,7 +102,7 @@ return a result with the following criteria:
 * Response status code of OK (200)
 * Message in JSON format
 * Only one group can be returned
-* If errors is not null, then query would route to default routing group adhoc
+* If `errors` is not null, the query is routed to the configured default group
 
 #### Request headers modification
 
@@ -151,7 +160,7 @@ In addition to the default objects, rules may optionally utilize
 , which provide information about the user and query respectively.
 You must include an action of the form `result.put(\"routingGroup\", \"foo\")`
 to trigger routing of a request that satisfies the condition to the specific
-routing group. Without this action, the default adhoc group is used and the
+routing group. Without this action, the configured default group is used and the
 whole routing rule is redundant.
 
 The condition and actions are written in [MVEL](http://mvel.documentnode.com/),
@@ -184,8 +193,7 @@ You can use the `contains` operator
 condition: 'request.getHeader("X-Trino-Client-Tags") contains "label=foo"'
 ```
 
-If no rules match, then the request is routed to the default `adhoc` routing
-group.
+If no rules match, then the request is routed to the configured default routing group.
 
 ### TrinoStatus
 

--- a/gateway-ha/src/main/java/io/trino/gateway/baseapp/BaseApp.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/baseapp/BaseApp.java
@@ -22,6 +22,7 @@ import io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor;
 import io.trino.gateway.ha.clustermonitor.ClusterMetricsStatsExporter;
 import io.trino.gateway.ha.clustermonitor.ForMonitor;
 import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.config.RoutingConfiguration;
 import io.trino.gateway.ha.handler.ProxyHandlerStats;
 import io.trino.gateway.ha.handler.RoutingTargetHandler;
 import io.trino.gateway.ha.resource.EntityEditorResource;
@@ -122,6 +123,7 @@ public class BaseApp
     public void configure(Binder binder)
     {
         binder.bind(HaGatewayConfiguration.class).toInstance(configuration);
+        binder.bind(RoutingConfiguration.class).toInstance(configuration.getRouting());
         binder.bind(ActiveClusterMonitor.class).in(Scopes.SINGLETON);
         registerAuthFilters(binder);
         registerResources(binder);

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/RoutingConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/RoutingConfiguration.java
@@ -23,6 +23,8 @@ public class RoutingConfiguration
 
     private boolean addXForwardedHeaders = true;
 
+    private String defaultRoutingGroup = "adhoc";
+
     public Duration getAsyncTimeout()
     {
         return asyncTimeout;
@@ -41,5 +43,15 @@ public class RoutingConfiguration
     public void setAddXForwardedHeaders(boolean addXForwardedHeaders)
     {
         this.addXForwardedHeaders = addXForwardedHeaders;
+    }
+
+    public String getDefaultRoutingGroup()
+    {
+        return defaultRoutingGroup;
+    }
+
+    public void setDefaultRoutingGroup(String defaultRoutingGroup)
+    {
+        this.defaultRoutingGroup = defaultRoutingGroup;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/RulesExternalConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/RulesExternalConfiguration.java
@@ -19,6 +19,7 @@ public class RulesExternalConfiguration
 {
     private String urlPath;
     private List<String> excludeHeaders;
+    private boolean propagateErrors;
 
     public String getUrlPath()
     {
@@ -38,5 +39,15 @@ public class RulesExternalConfiguration
     public void setExcludeHeaders(List<String> excludeHeaders)
     {
         this.excludeHeaders = excludeHeaders;
+    }
+
+    public boolean isPropagateErrors()
+    {
+        return this.propagateErrors;
+    }
+
+    public void setPropagateErrors(boolean propagateErrors)
+    {
+        this.propagateErrors = propagateErrors;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
@@ -119,7 +119,7 @@ public class HaGatewayProviderModule
         Jdbi jdbi = Jdbi.create(configuration.getDataStore().getJdbcUrl(), configuration.getDataStore().getUser(), configuration.getDataStore().getPassword());
         JdbcConnectionManager connectionManager = new JdbcConnectionManager(jdbi, configuration.getDataStore());
         resourceGroupsManager = new HaResourceGroupsManager(connectionManager);
-        gatewayBackendManager = new HaGatewayManager(jdbi);
+        gatewayBackendManager = new HaGatewayManager(jdbi, configuration.getRouting());
         queryHistoryManager = new HaQueryHistoryManager(jdbi, configuration.getDataStore().getJdbcUrl().startsWith("jdbc:oracle"));
     }
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/GatewayBackendDao.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/GatewayBackendDao.java
@@ -31,12 +31,6 @@ public interface GatewayBackendDao
 
     @SqlQuery("""
             SELECT * FROM gateway_backend
-            WHERE active = true AND routing_group = 'adhoc'
-            """)
-    List<GatewayBackend> findActiveAdhocBackend();
-
-    @SqlQuery("""
-            SELECT * FROM gateway_backend
             WHERE active = true AND routing_group = :routingGroup
             """)
     List<GatewayBackend> findActiveBackendByRoutingGroup(String routingGroup);

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/GatewayBackendManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/GatewayBackendManager.java
@@ -24,7 +24,7 @@ public interface GatewayBackendManager
 
     List<ProxyBackendConfiguration> getAllActiveBackends();
 
-    List<ProxyBackendConfiguration> getActiveAdhocBackends();
+    List<ProxyBackendConfiguration> getActiveDefaultBackends();
 
     List<ProxyBackendConfiguration> getActiveBackends(String routingGroup);
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
@@ -125,7 +125,7 @@ public abstract class RoutingManager
     /**
      * Performs routing to a default backend.
      */
-    private ProxyBackendConfiguration provideDefaultCluster()
+    private ProxyBackendConfiguration provideDefaultBackendConfiguration()
     {
         List<ProxyBackendConfiguration> backends = gatewayBackendManager.getActiveDefaultBackends();
         backends.removeIf(backend -> isBackendNotHealthy(backend.getName()));
@@ -134,6 +134,11 @@ public abstract class RoutingManager
         }
         int backendId = Math.abs(RANDOM.nextInt()) % backends.size();
         return backends.get(backendId);
+    }
+
+    public String provideDefaultCluster(String user)
+    {
+        return provideDefaultBackendConfiguration().getProxyTo();
     }
 
     /**
@@ -146,7 +151,7 @@ public abstract class RoutingManager
                 gatewayBackendManager.getActiveBackends(routingGroup);
         backends.removeIf(backend -> isBackendNotHealthy(backend.getName()));
         if (backends.isEmpty()) {
-            return provideDefaultCluster();
+            return provideDefaultBackendConfiguration();
         }
         int backendId = Math.abs(RANDOM.nextInt()) % backends.size();
         return backends.get(backendId);

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/StochasticRoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/StochasticRoutingManager.java
@@ -16,6 +16,7 @@ package io.trino.gateway.ha.router;
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
+import io.trino.gateway.ha.config.RoutingConfiguration;
 
 public class StochasticRoutingManager
         extends RoutingManager
@@ -25,9 +26,11 @@ public class StochasticRoutingManager
 
     @Inject
     public StochasticRoutingManager(
-            GatewayBackendManager gatewayBackendManager, QueryHistoryManager queryHistoryManager)
+            GatewayBackendManager gatewayBackendManager,
+            QueryHistoryManager queryHistoryManager,
+            RoutingConfiguration routingConfiguration)
     {
-        super(gatewayBackendManager, queryHistoryManager);
+        super(gatewayBackendManager, queryHistoryManager, routingConfiguration);
         this.queryHistoryManager = queryHistoryManager;
     }
 

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestHaGatewayManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestHaGatewayManager.java
@@ -55,7 +55,7 @@ final class TestHaGatewayManager
         assertThat(haGatewayManager.getActiveBackends("unknown")).isEmpty();
         assertThat(haGatewayManager.getActiveDefaultBackends()).hasSize(1);
 
-        assertThat(haGatewayManager.getActiveAdhocBackends().getFirst().getExternalUrl()).isEqualTo("adhoc1.external.trino.gateway.io");
+        assertThat(haGatewayManager.getActiveDefaultBackends().getFirst().getExternalUrl()).isEqualTo("adhoc1.external.trino.gateway.io");
 
         // Update a backend
         ProxyBackendConfiguration adhoc = new ProxyBackendConfiguration();

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestHaGatewayManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestHaGatewayManager.java
@@ -14,6 +14,7 @@
 package io.trino.gateway.ha.router;
 
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
+import io.trino.gateway.ha.config.RoutingConfiguration;
 import io.trino.gateway.ha.persistence.JdbcConnectionManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,8 @@ final class TestHaGatewayManager
     void setUp()
     {
         JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager();
-        haGatewayManager = new HaGatewayManager(connectionManager.getJdbi());
+        RoutingConfiguration routingConfiguration = new RoutingConfiguration();
+        haGatewayManager = new HaGatewayManager(connectionManager.getJdbi(), routingConfiguration);
     }
 
     @Test
@@ -51,7 +53,7 @@ final class TestHaGatewayManager
         assertThat(haGatewayManager.getAllBackends()).hasSize(1);
         assertThat(haGatewayManager.getActiveBackends("adhoc")).hasSize(1);
         assertThat(haGatewayManager.getActiveBackends("unknown")).isEmpty();
-        assertThat(haGatewayManager.getActiveAdhocBackends()).hasSize(1);
+        assertThat(haGatewayManager.getActiveDefaultBackends()).hasSize(1);
 
         assertThat(haGatewayManager.getActiveAdhocBackends().getFirst().getExternalUrl()).isEqualTo("adhoc1.external.trino.gateway.io");
 

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryCountBasedRouter.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryCountBasedRouter.java
@@ -16,6 +16,7 @@ package io.trino.gateway.ha.router;
 import com.google.common.collect.ImmutableList;
 import io.trino.gateway.ha.clustermonitor.ClusterStats;
 import io.trino.gateway.ha.clustermonitor.TrinoStatus;
+import io.trino.gateway.ha.config.RoutingConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -155,7 +156,8 @@ final class TestQueryCountBasedRouter
                 .addAll(getClusterStatsList("etl"))
                 .build();
 
-        queryCountBasedRouter = new QueryCountBasedRouter(null, null);
+        RoutingConfiguration routingConfiguration = new RoutingConfiguration();
+        queryCountBasedRouter = new QueryCountBasedRouter(null, null, routingConfiguration);
         queryCountBasedRouter.updateBackEndStats(clusters);
     }
 
@@ -190,7 +192,7 @@ final class TestQueryCountBasedRouter
     {
         // The user u2 has different number of queries queued on each cluster
         // The query needs to be routed to cluster with least number of queued for that user
-        String proxyTo = queryCountBasedRouter.provideAdhocCluster("u2");
+        String proxyTo = queryCountBasedRouter.provideDefaultCluster("u2");
         assertThat(BACKEND_URL_2).isEqualTo(proxyTo);
         assertThat(BACKEND_URL_UNHEALTHY).isNotEqualTo(proxyTo);
     }
@@ -198,7 +200,7 @@ final class TestQueryCountBasedRouter
     @Test
     void testUserWithDifferentQueueLengthUser2()
     {
-        String proxyTo = queryCountBasedRouter.provideAdhocCluster("u3");
+        String proxyTo = queryCountBasedRouter.provideDefaultCluster("u3");
         assertThat(BACKEND_URL_1).isEqualTo(proxyTo);
         assertThat(BACKEND_URL_UNHEALTHY).isNotEqualTo(proxyTo);
     }
@@ -206,7 +208,7 @@ final class TestQueryCountBasedRouter
     @Test
     void testUserWithNoQueuedQueries()
     {
-        String proxyTo = queryCountBasedRouter.provideAdhocCluster("u101");
+        String proxyTo = queryCountBasedRouter.provideDefaultCluster("u101");
         assertThat(BACKEND_URL_3).isEqualTo(proxyTo);
     }
 

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingManagerExternalUrlCache.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingManagerExternalUrlCache.java
@@ -13,6 +13,7 @@
  */
 package io.trino.gateway.ha.router;
 
+import io.trino.gateway.ha.config.RoutingConfiguration;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -29,6 +30,7 @@ final class TestRoutingManagerExternalUrlCache
     private GatewayBackendManager backendManager;
     private QueryHistoryManager queryHistoryManager;
     private QueryHistoryManager mockQueryHistoryManager;
+    private RoutingConfiguration routingConfiguration;
 
     @BeforeAll
     void setUp()
@@ -36,8 +38,9 @@ final class TestRoutingManagerExternalUrlCache
         backendManager = Mockito.mock(GatewayBackendManager.class);
         queryHistoryManager = Mockito.mock(QueryHistoryManager.class);
         mockQueryHistoryManager = Mockito.mock(QueryHistoryManager.class);
+        routingConfiguration = Mockito.mock(RoutingConfiguration.class);
 
-        routingManager = new TestRoutingManager(backendManager, queryHistoryManager);
+        routingManager = new TestRoutingManager(backendManager, queryHistoryManager, routingConfiguration);
     }
 
     @Test
@@ -113,7 +116,8 @@ final class TestRoutingManagerExternalUrlCache
     @Test
     void testCacheWithMockQueryHistoryManager()
     {
-        RoutingManager mockRoutingManager = new TestRoutingManager(backendManager, mockQueryHistoryManager);
+        RoutingManager mockRoutingManager = new TestRoutingManager(backendManager, mockQueryHistoryManager,
+                routingConfiguration);
 
         String queryId = "mock-test-query";
         String expectedUrl = "https://mock-gateway.example.com";
@@ -128,9 +132,10 @@ final class TestRoutingManagerExternalUrlCache
     private static class TestRoutingManager
             extends RoutingManager
     {
-        public TestRoutingManager(GatewayBackendManager gatewayBackendManager, QueryHistoryManager queryHistoryManager)
+        public TestRoutingManager(GatewayBackendManager gatewayBackendManager, QueryHistoryManager queryHistoryManager,
+                                  RoutingConfiguration routingConfiguration)
         {
-            super(gatewayBackendManager, queryHistoryManager);
+            super(gatewayBackendManager, queryHistoryManager, routingConfiguration);
         }
 
         @Override

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingManagerNotFound.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingManagerNotFound.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import io.trino.gateway.ha.config.RoutingConfiguration;
+import io.trino.gateway.ha.persistence.JdbcConnectionManager;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.gateway.ha.TestingJdbcConnectionManager.createTestingJdbcConnectionManager;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestRoutingManagerNotFound
+{
+    private final RoutingManager routingManager;
+
+    public TestRoutingManagerNotFound()
+    {
+        JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager();
+        RoutingConfiguration routingConfiguration = new RoutingConfiguration();
+        routingConfiguration.setDefaultRoutingGroup("default");
+
+        GatewayBackendManager backendManager = new HaGatewayManager(connectionManager.getJdbi(), routingConfiguration);
+        QueryHistoryManager historyManager = new HaQueryHistoryManager(connectionManager.getJdbi(), false);
+
+        this.routingManager = new StochasticRoutingManager(backendManager, historyManager, routingConfiguration);
+    }
+
+    @Test
+    void testNonExistentRoutingGroupThrowsNotFoundException()
+    {
+        // When requesting a non-existent routing group, an IllegalStateException should be thrown
+        assertThatThrownBy(() -> routingManager.provideClusterForRoutingGroup("non_existent_group", "user"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Number of active backends found zero");
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
@@ -15,6 +15,7 @@ package io.trino.gateway.ha.router;
 
 import io.trino.gateway.ha.clustermonitor.TrinoStatus;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
+import io.trino.gateway.ha.config.RoutingConfiguration;
 import io.trino.gateway.ha.persistence.JdbcConnectionManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -35,9 +36,10 @@ final class TestStochasticRoutingManager
     void setUp()
     {
         JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager();
-        backendManager = new HaGatewayManager(connectionManager.getJdbi());
+        RoutingConfiguration routingConfiguration = new RoutingConfiguration();
+        backendManager = new HaGatewayManager(connectionManager.getJdbi(), routingConfiguration);
         historyManager = new HaQueryHistoryManager(connectionManager.getJdbi(), false);
-        haRoutingManager = new StochasticRoutingManager(backendManager, historyManager);
+        haRoutingManager = new StochasticRoutingManager(backendManager, historyManager, routingConfiguration);
     }
 
     @Test


### PR DESCRIPTION
# Improve external routing with error propagation and configurable defaults

<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This PR is to solve request of Git Issue https://github.com/trinodb/trino-gateway/issues/658
This PR enhances Trino Gateway's external routing capabilities with three key improvements:

1. **Error Propagation**: Ensures errors from the external routing API are properly passed to clients rather than being silently ignored, addressing issue #658.

2. **Configurable Default Routing**: Adds the ability to configure a default routing group when the external router fails or is unavailable, improving system resilience.

3. **Meaningful Error Messages**: Enhances error reporting with detailed, structured messages that provide clear information about routing failures.

These changes improve both the reliability and usability of Trino Gateway when using external routing services.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The main changes include:

- Modified the `ExternalRoutingGroupProvider` to capture and propagate errors from the external API
- Added configuration options for specifying a default routing group to use as fallback
- Improved error message formatting to include specific details about the failure cause
- Added appropriate HTTP status code mapping based on error conditions
- Included request tracing information for better debugging of routing failures

Related issues:
- #658: Errors from External Routing Service Are Not Propagated to Clients
- Builds upon the external routing API functionality introduced in earlier releases

These enhancements make external routing more robust while giving administrators better visibility into routing problems, supporting more advanced multi-cluster deployment scenarios.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
* Improve external routing with three key enhancements:
  * Fix issue where errors from external routing services were not propagated to clients (#658)
  * Add support for configurable default routing groups when external routing fails
  * Enhance error messages with detailed information about routing failures
```
```

This revised PR description:

1. **Highlights all three improvements** you mentioned in a clear, organized way
2. **Expands the technical details** to cover the implementation of all three features
3. **Updates the release notes** to succinctly mention all three improvements
4. **Maintains the reference** to issue #658 for the error propagation component

The description now provides a complete overview of the changes while helping reviewers understand how each component fits together to improve the external routing experience in Trino Gateway.