### PR TITLE
Use external url for query routing history

### DIFF
--- a/docs/routing-logic.md
+++ b/docs/routing-logic.md
@@ -75,3 +75,16 @@ oauth2GatewayCookieConfiguration:
     - "/custom/logout"
   lifetime: "5m"
 ```
+
+## Routing URLs
+
+Each Trino cluster configured with the Trino Gateway includes both a `proxyTo` 
+URL and an `externalURL`. The `proxyTo` URL is used internally by the Trino 
+Gateway to route requests based on routing rules and query identifiers, whereas 
+the `externalURL` serves as a UI-accessible or publicly reachable address for 
+the Trino cluster, and is commonly used to access [Trino web UI](https://trino.io/docs/current/admin/web-interface.html)  
+
+For example, in a Kubernetes environment, the `proxyTo` URL might be 
+`trino-backend-service.trino-namespace.svc.cluster.local:8083` for communication 
+between the Trino Gateway and Trino clusters, and the external URL for the same 
+backend cluster might be `trino.domain.com`.

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/QueryHistory.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/QueryHistory.java
@@ -25,7 +25,8 @@ public record QueryHistory(
         @ColumnName("user_name") @Nullable String userName,
         @ColumnName("source") @Nullable String source,
         @ColumnName("created") long created,
-        @ColumnName("routing_group") String routingGroup)
+        @ColumnName("routing_group") String routingGroup,
+        @ColumnName("external_url") String externalUrl)
 {
     public QueryHistory
     {

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/QueryHistoryDao.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/QueryHistoryDao.java
@@ -84,6 +84,12 @@ public interface QueryHistoryDao
     String findRoutingGroupByQueryId(String queryId);
 
     @SqlQuery("""
+            SELECT external_url FROM query_history
+            WHERE query_id = :queryId
+            """)
+    String findExternalUrlByQueryId(String queryId);
+
+    @SqlQuery("""
             SELECT * FROM query_history
             WHERE 1 = 1 <condition>
             ORDER BY created DESC
@@ -110,10 +116,10 @@ public interface QueryHistoryDao
     List<Map<String, Object>> findDistribution(long created);
 
     @SqlUpdate("""
-            INSERT INTO query_history (query_id, query_text, backend_url, user_name, source, created, routing_group)
-            VALUES (:queryId, :queryText, :backendUrl, :userName, :source, :created, :routingGroup)
+            INSERT INTO query_history (query_id, query_text, backend_url, user_name, source, created, routing_group, external_url)
+            VALUES (:queryId, :queryText, :backendUrl, :userName, :source, :created, :routingGroup, :externalUrl)
             """)
-    void insertHistory(String queryId, String queryText, String backendUrl, String userName, String source, long created, String routingGroup);
+    void insertHistory(String queryId, String queryText, String backendUrl, String userName, String source, long created, String routingGroup, String externalUrl);
 
     @SqlUpdate("""
             DELETE FROM query_history

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
@@ -61,7 +61,8 @@ public class HaQueryHistoryManager
                 queryDetail.getUser(),
                 queryDetail.getSource(),
                 queryDetail.getCaptureTime(),
-                queryDetail.getRoutingGroup());
+                queryDetail.getRoutingGroup(),
+                queryDetail.getExternalUrl());
     }
 
     @Override
@@ -89,6 +90,7 @@ public class HaQueryHistoryManager
             queryDetail.setUser(dao.userName());
             queryDetail.setSource(dao.source());
             queryDetail.setRoutingGroup(dao.routingGroup());
+            queryDetail.setExternalUrl(dao.externalUrl());
             queryDetails.add(queryDetail);
         }
         return queryDetails;
@@ -104,6 +106,12 @@ public class HaQueryHistoryManager
     public String getRoutingGroupForQueryId(String queryId)
     {
         return dao.findRoutingGroupByQueryId(queryId);
+    }
+
+    @Override
+    public String getExternalUrlForQueryId(String queryId)
+    {
+        return dao.findExternalUrlByQueryId(queryId);
     }
 
     @Override

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/QueryHistoryManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/QueryHistoryManager.java
@@ -68,7 +68,7 @@ public interface QueryHistoryManager
         @JsonProperty
         public String getQueryId()
         {
-            return this.queryId;
+            return queryId;
         }
 
         public void setQueryId(String queryId)
@@ -79,7 +79,7 @@ public interface QueryHistoryManager
         @JsonProperty
         public String getQueryText()
         {
-            return this.queryText;
+            return queryText;
         }
 
         public void setQueryText(String queryText)
@@ -90,7 +90,7 @@ public interface QueryHistoryManager
         @JsonProperty
         public String getUser()
         {
-            return this.user;
+            return user;
         }
 
         public void setUser(String user)
@@ -101,7 +101,7 @@ public interface QueryHistoryManager
         @JsonProperty
         public String getSource()
         {
-            return this.source;
+            return source;
         }
 
         public void setSource(String source)
@@ -112,7 +112,7 @@ public interface QueryHistoryManager
         @JsonProperty
         public String getBackendUrl()
         {
-            return this.backendUrl;
+            return backendUrl;
         }
 
         public void setBackendUrl(String backendUrl)
@@ -123,7 +123,7 @@ public interface QueryHistoryManager
         @JsonProperty
         public long getCaptureTime()
         {
-            return this.captureTime;
+            return captureTime;
         }
 
         public void setCaptureTime(long captureTime)
@@ -134,7 +134,7 @@ public interface QueryHistoryManager
         @JsonProperty
         public String getRoutingGroup()
         {
-            return this.routingGroup;
+            return routingGroup;
         }
 
         public void setRoutingGroup(String routingGroup)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/QueryHistoryManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/QueryHistoryManager.java
@@ -34,6 +34,8 @@ public interface QueryHistoryManager
 
     String getRoutingGroupForQueryId(String queryId);
 
+    String getExternalUrlForQueryId(String queryId);
+
     TableData<QueryDetail> findQueryHistory(QueryHistoryRequest query);
 
     List<DistributionResponse.LineChart> findDistribution(Long ts);
@@ -48,6 +50,7 @@ public interface QueryHistoryManager
         private String backendUrl;
         private long captureTime;
         private String routingGroup;
+        private String externalUrl;
 
         public QueryDetail() {}
 
@@ -139,6 +142,17 @@ public interface QueryHistoryManager
             this.routingGroup = routingGroup;
         }
 
+        @JsonProperty
+        public String getExternalUrl()
+        {
+            return externalUrl;
+        }
+
+        public void setExternalUrl(String externalUrl)
+        {
+            this.externalUrl = externalUrl;
+        }
+
         @Override
         public boolean equals(Object o)
         {
@@ -155,13 +169,14 @@ public interface QueryHistoryManager
                     Objects.equals(user, that.user) &&
                     Objects.equals(source, that.source) &&
                     Objects.equals(backendUrl, that.backendUrl) &&
-                    Objects.equals(routingGroup, that.routingGroup);
+                    Objects.equals(routingGroup, that.routingGroup) &&
+                    Objects.equals(externalUrl, that.externalUrl);
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(queryId, queryText, user, source, backendUrl, captureTime, routingGroup);
+            return Objects.hash(queryId, queryText, user, source, backendUrl, captureTime, routingGroup, externalUrl);
         }
 
         @Override
@@ -175,6 +190,7 @@ public interface QueryHistoryManager
                     .add("backendUrl", backendUrl)
                     .add("captureTime", captureTime)
                     .add("routingGroup", routingGroup)
+                    .add("externalUrl", externalUrl)
                     .toString();
         }
     }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
@@ -61,7 +61,7 @@ public abstract class RoutingManager
                         .maximumSize(10000)
                         .expireAfterAccess(30, TimeUnit.MINUTES)
                         .build(
-                                new CacheLoader<String, String>()
+                                new CacheLoader<>()
                                 {
                                     @Override
                                     public String load(String queryId)
@@ -74,7 +74,7 @@ public abstract class RoutingManager
                         .maximumSize(10000)
                         .expireAfterAccess(30, TimeUnit.MINUTES)
                         .build(
-                                new CacheLoader<String, String>()
+                                new CacheLoader<>()
                                 {
                                     @Override
                                     public String load(String queryId)

--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
@@ -293,6 +293,7 @@ public class ProxyRequestHandler
             log.error("Non OK HTTP Status code with response [%s] , Status code [%s]", response.body(), response.statusCode());
         }
         queryDetail.setRoutingGroup(routingDestination.routingGroup());
+        queryDetail.setExternalUrl(routingDestination.externalUrl());
         queryHistoryManager.submitQueryDetail(queryDetail);
         return response;
     }

--- a/gateway-ha/src/main/resources/mysql/V3__add_externalUrl_to_query_history.sql
+++ b/gateway-ha/src/main/resources/mysql/V3__add_externalUrl_to_query_history.sql
@@ -1,0 +1,2 @@
+ALTER TABLE query_history
+    ADD external_url VARCHAR(255);

--- a/gateway-ha/src/main/resources/oracle/V3__add_externalUrl_to_query_history.sql
+++ b/gateway-ha/src/main/resources/oracle/V3__add_externalUrl_to_query_history.sql
@@ -1,0 +1,2 @@
+ALTER TABLE query_history
+    ADD external_url VARCHAR(255);

--- a/gateway-ha/src/main/resources/postgresql/V3__add_externalUrl_to_query_history.sql
+++ b/gateway-ha/src/main/resources/postgresql/V3__add_externalUrl_to_query_history.sql
@@ -1,0 +1,2 @@
+ALTER TABLE query_history
+    ADD external_url VARCHAR(255);

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandler.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandler.java
@@ -18,6 +18,7 @@ import io.airlift.http.client.HttpClient;
 import io.trino.gateway.ha.config.GatewayCookieConfiguration;
 import io.trino.gateway.ha.config.GatewayCookieConfigurationPropertiesProvider;
 import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 import io.trino.gateway.ha.config.RequestAnalyzerConfig;
 import io.trino.gateway.ha.config.RulesExternalConfiguration;
 import io.trino.gateway.ha.handler.schema.RoutingTargetResponse;
@@ -104,6 +105,7 @@ class TestRoutingTargetHandler
         config = provideGatewayConfiguration();
         httpClient = Mockito.mock(HttpClient.class);
         routingManager = Mockito.mock(RoutingManager.class);
+        when(routingManager.provideBackendConfiguration(any(), any())).thenReturn(new ProxyBackendConfiguration());
         request = prepareMockRequest();
 
         // Initialize the handler with the configuration

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/BaseExternalUrlQueryHistoryTest.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/BaseExternalUrlQueryHistoryTest.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import io.trino.gateway.ha.config.DataStoreConfiguration;
+import io.trino.gateway.ha.persistence.FlywayMigration;
+import io.trino.gateway.ha.persistence.JdbcConnectionManager;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.gateway.ha.TestingJdbcConnectionManager.createTestingJdbcConnectionManager;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(Lifecycle.PER_CLASS)
+abstract class BaseExternalUrlQueryHistoryTest
+{
+    private final JdbcDatabaseContainer<?> container;
+    private final QueryHistoryManager queryHistoryManager;
+
+    protected BaseExternalUrlQueryHistoryTest(JdbcDatabaseContainer<?> container)
+    {
+        this.container = requireNonNull(container, "container is null");
+        this.container.start();
+
+        DataStoreConfiguration config = new DataStoreConfiguration(
+                container.getJdbcUrl(),
+                container.getUsername(),
+                container.getPassword(),
+                container.getDriverClassName(),
+                4,
+                true);
+        FlywayMigration.migrate(config);
+        JdbcConnectionManager jdbcConnectionManager = createTestingJdbcConnectionManager(container, config);
+        queryHistoryManager = new HaQueryHistoryManager(jdbcConnectionManager.getJdbi(), container.getJdbcUrl().startsWith("jdbc:oracle"));
+    }
+
+    @AfterAll
+    public final void close()
+    {
+        container.close();
+    }
+
+    @Test
+    void testSubmitQueryWithExternalUrl()
+    {
+        // Clear existing data
+        List<QueryHistoryManager.QueryDetail> queryDetails = queryHistoryManager.fetchQueryHistory(Optional.empty());
+        assertThat(queryDetails).isEmpty();
+
+        // Create and submit query with external URL
+        QueryHistoryManager.QueryDetail queryDetail = new QueryHistoryManager.QueryDetail();
+        queryDetail.setQueryId("test-query-123");
+        queryDetail.setQueryText("SELECT * FROM test_table");
+        queryDetail.setBackendUrl("http://localhost:8080");
+        queryDetail.setUser("test-user");
+        queryDetail.setSource("sqlWorkbench");
+        queryDetail.setRoutingGroup("adhoc");
+        queryDetail.setExternalUrl("https://external-gateway.example.com");
+        queryDetail.setCaptureTime(System.currentTimeMillis());
+
+        queryHistoryManager.submitQueryDetail(queryDetail);
+
+        // Verify the query was stored with external URL
+        queryDetails = queryHistoryManager.fetchQueryHistory(Optional.empty());
+        assertThat(queryDetails).hasSize(1);
+
+        QueryHistoryManager.QueryDetail retrievedQuery = queryDetails.getFirst();
+        assertThat(retrievedQuery.getQueryId()).isEqualTo("test-query-123");
+        assertThat(retrievedQuery.getExternalUrl()).isEqualTo("https://external-gateway.example.com");
+    }
+
+    @Test
+    void testGetExternalUrlByQueryId()
+    {
+        // Create and submit query with external URL
+        QueryHistoryManager.QueryDetail queryDetail = new QueryHistoryManager.QueryDetail();
+        queryDetail.setQueryId("external-url-test-456");
+        queryDetail.setQueryText("SELECT count(*) FROM users");
+        queryDetail.setBackendUrl("http://backend:8080");
+        queryDetail.setUser("admin");
+        queryDetail.setSource("trino-cli");
+        queryDetail.setRoutingGroup("analytics");
+        queryDetail.setExternalUrl("https://analytics-gateway.company.com");
+        queryDetail.setCaptureTime(System.currentTimeMillis());
+
+        queryHistoryManager.submitQueryDetail(queryDetail);
+
+        // Test retrieving external URL by query ID
+        String externalUrl = queryHistoryManager.getExternalUrlForQueryId("external-url-test-456");
+        assertThat(externalUrl).isEqualTo("https://analytics-gateway.company.com");
+    }
+
+    @Test
+    void testGetExternalUrlForNonExistentQuery()
+    {
+        // Test retrieving external URL for non-existent query
+        String externalUrl = queryHistoryManager.getExternalUrlForQueryId("non-existent-query");
+        assertThat(externalUrl).isNull();
+    }
+
+    @Test
+    void testSubmitQueryWithNullExternalUrl()
+    {
+        // Create and submit query with null external URL
+        QueryHistoryManager.QueryDetail queryDetail = new QueryHistoryManager.QueryDetail();
+        queryDetail.setQueryId("null-external-url-test");
+        queryDetail.setQueryText("SELECT 1");
+        queryDetail.setBackendUrl("http://localhost:8080");
+        queryDetail.setUser("test-user");
+        queryDetail.setSource("sqlWorkbench");
+        queryDetail.setRoutingGroup("adhoc");
+        queryDetail.setExternalUrl(null);
+        queryDetail.setCaptureTime(System.currentTimeMillis());
+
+        queryHistoryManager.submitQueryDetail(queryDetail);
+
+        // Verify the query was stored with null external URL
+        List<QueryHistoryManager.QueryDetail> queryDetails = queryHistoryManager.fetchQueryHistory(Optional.empty());
+        QueryHistoryManager.QueryDetail retrievedQuery = queryDetails.stream()
+                .filter(q -> "null-external-url-test".equals(q.getQueryId()))
+                .findFirst()
+                .orElse(null);
+
+        assertThat(retrievedQuery).isNotNull();
+        assertThat(retrievedQuery.getExternalUrl()).isNull();
+    }
+
+    @Test
+    void testMultipleQueriesWithDifferentExternalUrls()
+    {
+        // Submit multiple queries with different external URLs
+        for (int i = 1; i <= 3; i++) {
+            QueryHistoryManager.QueryDetail queryDetail = new QueryHistoryManager.QueryDetail();
+            queryDetail.setQueryId("multi-external-url-test-" + i);
+            queryDetail.setQueryText("SELECT " + i);
+            queryDetail.setBackendUrl("http://backend-" + i + ":8080");
+            queryDetail.setUser("user-" + i);
+            queryDetail.setSource("source-" + i);
+            queryDetail.setRoutingGroup("group-" + i);
+            queryDetail.setExternalUrl("https://external-" + i + ".example.com");
+            queryDetail.setCaptureTime(System.currentTimeMillis());
+
+            queryHistoryManager.submitQueryDetail(queryDetail);
+        }
+
+        // Verify all queries were stored with correct external URLs
+        for (int i = 1; i <= 3; i++) {
+            String externalUrl = queryHistoryManager.getExternalUrlForQueryId("multi-external-url-test-" + i);
+            assertThat(externalUrl).isEqualTo("https://external-" + i + ".example.com");
+        }
+    }
+
+    @Test
+    void testQueryDetailEqualsAndHashCodeWithExternalUrl()
+    {
+        QueryHistoryManager.QueryDetail queryDetail1 = new QueryHistoryManager.QueryDetail();
+        queryDetail1.setQueryId("equals-test-1");
+        queryDetail1.setQueryText("SELECT 1");
+        queryDetail1.setBackendUrl("http://localhost:8080");
+        queryDetail1.setUser("test-user");
+        queryDetail1.setSource("sqlWorkbench");
+        queryDetail1.setRoutingGroup("adhoc");
+        queryDetail1.setExternalUrl("https://external.example.com");
+        queryDetail1.setCaptureTime(System.currentTimeMillis());
+
+        QueryHistoryManager.QueryDetail queryDetail2 = new QueryHistoryManager.QueryDetail();
+        queryDetail2.setQueryId("equals-test-1");
+        queryDetail2.setQueryText("SELECT 1");
+        queryDetail2.setBackendUrl("http://localhost:8080");
+        queryDetail2.setUser("test-user");
+        queryDetail2.setSource("sqlWorkbench");
+        queryDetail2.setRoutingGroup("adhoc");
+        queryDetail2.setExternalUrl("https://external.example.com");
+        queryDetail2.setCaptureTime(System.currentTimeMillis());
+
+        // Test equals
+        assertThat(queryDetail1).isEqualTo(queryDetail2);
+        assertThat(queryDetail1.hashCode()).isEqualTo(queryDetail2.hashCode());
+
+        // Test with different external URL
+        queryDetail2.setExternalUrl("https://different.example.com");
+        assertThat(queryDetail1).isNotEqualTo(queryDetail2);
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestExternalUrlQueryHistoryMySql.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestExternalUrlQueryHistoryMySql.java
@@ -11,8 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.gateway.ha.handler.schema;
+package io.trino.gateway.ha.router;
 
-import java.net.URI;
+import org.testcontainers.containers.MySQLContainer;
 
-public record RoutingDestination(String routingGroup, String clusterHost, URI clusterUri, String externalUrl) {}
+public class TestExternalUrlQueryHistoryMySql
+        extends BaseExternalUrlQueryHistoryTest
+{
+    public TestExternalUrlQueryHistoryMySql()
+    {
+        super(new MySQLContainer<>("mysql:8.0.36"));
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestExternalUrlQueryHistoryOracle.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestExternalUrlQueryHistoryOracle.java
@@ -11,8 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.gateway.ha.handler.schema;
+package io.trino.gateway.ha.router;
 
-import java.net.URI;
+import org.testcontainers.containers.OracleContainer;
 
-public record RoutingDestination(String routingGroup, String clusterHost, URI clusterUri, String externalUrl) {}
+public class TestExternalUrlQueryHistoryOracle
+        extends BaseExternalUrlQueryHistoryTest
+{
+    public TestExternalUrlQueryHistoryOracle()
+    {
+        super(new OracleContainer("gvenzl/oracle-xe:21-slim"));
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestExternalUrlQueryHistoryPostgreSql.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestExternalUrlQueryHistoryPostgreSql.java
@@ -11,8 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.gateway.ha.handler.schema;
+package io.trino.gateway.ha.router;
 
-import java.net.URI;
+import org.testcontainers.containers.PostgreSQLContainer;
 
-public record RoutingDestination(String routingGroup, String clusterHost, URI clusterUri, String externalUrl) {}
+public class TestExternalUrlQueryHistoryPostgreSql
+        extends BaseExternalUrlQueryHistoryTest
+{
+    public TestExternalUrlQueryHistoryPostgreSql()
+    {
+        super(new PostgreSQLContainer<>("postgres:15.5"));
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestHaGatewayManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestHaGatewayManager.java
@@ -43,7 +43,7 @@ final class TestHaGatewayManager
         backend.setRoutingGroup("adhoc");
         backend.setName("adhoc1");
         backend.setProxyTo("adhoc1.trino.gateway.io");
-        backend.setExternalUrl("adhoc1.trino.gateway.io");
+        backend.setExternalUrl("adhoc1.external.trino.gateway.io");
         ProxyBackendConfiguration updated = haGatewayManager.addBackend(backend);
         assertThat(updated).isEqualTo(backend);
 
@@ -52,6 +52,8 @@ final class TestHaGatewayManager
         assertThat(haGatewayManager.getActiveBackends("adhoc")).hasSize(1);
         assertThat(haGatewayManager.getActiveBackends("unknown")).isEmpty();
         assertThat(haGatewayManager.getActiveAdhocBackends()).hasSize(1);
+
+        assertThat(haGatewayManager.getActiveAdhocBackends().getFirst().getExternalUrl()).isEqualTo("adhoc1.external.trino.gateway.io");
 
         // Update a backend
         ProxyBackendConfiguration adhoc = new ProxyBackendConfiguration();
@@ -82,6 +84,16 @@ final class TestHaGatewayManager
         assertThat(haGatewayManager.getAllBackends())
                 .extracting(ProxyBackendConfiguration::getRoutingGroup)
                 .containsExactly("adhoc");
+
+        // Test default externalUrl to proxyUrl
+        ProxyBackendConfiguration adhoc2 = new ProxyBackendConfiguration();
+        adhoc2.setActive(true);
+        adhoc2.setRoutingGroup("adhoc2");
+        adhoc2.setName("adhoc2");
+        adhoc2.setProxyTo("adhoc2.trino.gateway.io");
+        haGatewayManager.addBackend(adhoc2);
+        ProxyBackendConfiguration backendConfigurationAdhoc2 = haGatewayManager.getActiveBackends("adhoc2").getFirst();
+        assertThat(backendConfigurationAdhoc2.getExternalUrl()).isEqualTo(adhoc2.getExternalUrl());
     }
 
     @Test

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingManagerExternalUrlCache.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingManagerExternalUrlCache.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@TestInstance(Lifecycle.PER_CLASS)
+final class TestRoutingManagerExternalUrlCache
+{
+    private RoutingManager routingManager;
+    private GatewayBackendManager backendManager;
+    private QueryHistoryManager queryHistoryManager;
+    private QueryHistoryManager mockQueryHistoryManager;
+
+    @BeforeAll
+    void setUp()
+    {
+        backendManager = Mockito.mock(GatewayBackendManager.class);
+        queryHistoryManager = Mockito.mock(QueryHistoryManager.class);
+        mockQueryHistoryManager = Mockito.mock(QueryHistoryManager.class);
+
+        routingManager = new TestRoutingManager(backendManager, queryHistoryManager);
+    }
+
+    @Test
+    void testSetAndGetExternalUrlFromCache()
+    {
+        String queryId = "test-query-123";
+        String externalUrl = "https://external-gateway.example.com";
+
+        routingManager.setExternalUrlForQueryId(queryId, externalUrl);
+
+        String retrievedUrl = routingManager.findExternalUrlForQueryId(queryId);
+
+        assertThat(retrievedUrl).isEqualTo(externalUrl);
+    }
+
+    @Test
+    void testCacheMissAndFallbackToQueryHistory()
+    {
+        String queryId = "cache-miss-query-456";
+        String expectedExternalUrl = "https://fallback-gateway.example.com";
+        when(queryHistoryManager.getExternalUrlForQueryId(queryId)).thenReturn(expectedExternalUrl);
+        String retrievedUrl = routingManager.findExternalUrlForQueryId(queryId);
+
+        assertThat(retrievedUrl).isEqualTo(expectedExternalUrl);
+        Mockito.verify(queryHistoryManager).getExternalUrlForQueryId(queryId);
+    }
+
+    @Test
+    void testCacheOverwrite()
+    {
+        String queryId = "overwrite-test-query";
+        String initialUrl = "https://initial-gateway.example.com";
+        String updatedUrl = "https://updated-gateway.example.com";
+
+        routingManager.setExternalUrlForQueryId(queryId, initialUrl);
+        assertThat(routingManager.findExternalUrlForQueryId(queryId)).isEqualTo(initialUrl);
+
+        routingManager.setExternalUrlForQueryId(queryId, updatedUrl);
+        assertThat(routingManager.findExternalUrlForQueryId(queryId)).isEqualTo(updatedUrl);
+    }
+
+    @Test
+    void testMultipleQueryIdsWithDifferentExternalUrls()
+    {
+        String[] queryIds = {"multi-test-1", "multi-test-2", "multi-test-3"};
+        String[] externalUrls = {
+                "https://gateway1.example.com",
+                "https://gateway2.example.com",
+                "https://gateway3.example.com"
+        };
+
+        for (int i = 0; i < queryIds.length; i++) {
+            routingManager.setExternalUrlForQueryId(queryIds[i], externalUrls[i]);
+        }
+
+        for (int i = 0; i < queryIds.length; i++) {
+            String retrievedUrl = routingManager.findExternalUrlForQueryId(queryIds[i]);
+            assertThat(retrievedUrl).isEqualTo(externalUrls[i]);
+        }
+    }
+
+    @Test
+    void testEmptyStringExternalUrl()
+    {
+        String queryId = "empty-url-test";
+        String emptyUrl = "";
+        routingManager.setExternalUrlForQueryId(queryId, emptyUrl);
+        String retrievedUrl = routingManager.findExternalUrlForQueryId(queryId);
+
+        assertThat(retrievedUrl).isEqualTo(emptyUrl);
+    }
+
+    @Test
+    void testCacheWithMockQueryHistoryManager()
+    {
+        RoutingManager mockRoutingManager = new TestRoutingManager(backendManager, mockQueryHistoryManager);
+
+        String queryId = "mock-test-query";
+        String expectedUrl = "https://mock-gateway.example.com";
+
+        when(mockQueryHistoryManager.getExternalUrlForQueryId(queryId)).thenReturn(expectedUrl);
+        String retrievedUrl = mockRoutingManager.findExternalUrlForQueryId(queryId);
+
+        assertThat(retrievedUrl).isEqualTo(expectedUrl);
+        Mockito.verify(mockQueryHistoryManager).getExternalUrlForQueryId(queryId);
+    }
+
+    private static class TestRoutingManager
+            extends RoutingManager
+    {
+        public TestRoutingManager(GatewayBackendManager gatewayBackendManager, QueryHistoryManager queryHistoryManager)
+        {
+            super(gatewayBackendManager, queryHistoryManager);
+        }
+
+        @Override
+        protected String findBackendForUnknownQueryId(String queryId)
+        {
+            // Simple implementation for testing - return a default backend
+            return "http://default-backend:8080";
+        }
+    }
+}

--- a/webapp/src/components/history.tsx
+++ b/webapp/src/components/history.tsx
@@ -59,7 +59,7 @@ export function History() {
 
   const linkQueryRender = (text: string, record: HistoryDetail) => {
     return (
-      <Text link={{ href: `${record.backendUrl}/ui/query.html?${text}`, target: '_blank' }} underline>{text}</Text>
+      <Text link={{ href: `${record.externalUrl}/ui/query.html?${text}`, target: '_blank' }} underline>{text}</Text>
     );
   }
 
@@ -95,9 +95,9 @@ export function History() {
             <>
               <Form.Select field="backendUrl" label='RoutedTo' style={{ width: 200 }} showClear placeholder={Locale.History.RoutedToTip}>
                 {backendData?.map(b => (
-                  <Form.Select.Option key={b.proxyTo} value={b.proxyTo}>
-                    <Tag color={'blue'} style={{ marginRight: '5px' }}>{backendMapping[b.proxyTo]}</Tag>
-                    <Text>{b.proxyTo}</Text>
+                  <Form.Select.Option key={b.externalUrl} value={b.externalUrl}>
+                    <Tag color={'blue'} style={{ marginRight: '5px' }}>{backendMapping[b.externalUrl]}</Tag>
+                    <Text>{b.externalUrl}</Text>
                   </Form.Select.Option>
                 ))}
               </Form.Select>
@@ -123,7 +123,7 @@ export function History() {
           <Column title="QueryId" dataIndex="queryId" key="queryId" render={linkQueryRender} />
           <Column title="RoutingGroup" dataIndex="routingGroup" key="routingGroup" render={routingGroupRender} />
           <Column title="Name" dataIndex="backendUrl" key="backendUrlName" render={(text: string) => <Text>{backendMapping[text]}</Text>} />
-          <Column title="RoutedTo" dataIndex="backendUrl" key="backendUrl" render={linkRender} />
+          <Column title="RoutedTo" dataIndex="externalUrl" key="externalUrl" render={linkRender} />
           <Column title="User" dataIndex="user" key="user" />
           <Column title="Source" dataIndex="source" key="source" />
           <Column title="QueryText" dataIndex="queryText" key="queryText" ellipsis={true} width={300} render={ellipsisRender} />

--- a/webapp/src/types/history.d.ts
+++ b/webapp/src/types/history.d.ts
@@ -6,6 +6,7 @@ export interface HistoryDetail {
   backendUrl: string;
   captureTime: number;
   routingGroup: string;
+  externalUrl: string;
 }
 
 export interface HistoryData {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Use external url field for query routing history page

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The backendUrl used by Trino gateway may not be accessible for users, instead the external url field is used to indicate the hostname that's accessible by Trino users.  

For example, when hosted on Kubernetes, it's common to use [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/) for inter apps communication like between Gateway and Trino clusters, in such cases the hostname used by Gateway would be something like `service-name.namespace.svc.cluster.local` which is only accessible from within the Kubernetes cluster. 

https://github.com/trinodb/trino-gateway/issues/81 is relevant issue with other discussion points.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
