### PR TITLE
Use Airlift Duration in MonitorConfiguration

### DIFF
--- a/docs/operation.md
+++ b/docs/operation.md
@@ -49,11 +49,11 @@ modules:
 ```
 - The router operates based on the stats it receives from the clusters, such as 
 the number of queued and running queries. These values are retrieved at regular 
-intervals. This interval can be configured by setting `taskDelaySeconds` under
-`monitor` section in the config file. The default interval is 60
+intervals. This interval can be configured by setting `taskDelay` under
+`monitor` section in the config file. The default interval is 1 minute
 ```yaml
 monitor:
-  taskDelaySeconds: 10
+  taskDelay: 1m
 ```
 
 ## Monitoring <a name="monitoring"></a>

--- a/docs/routers.md
+++ b/docs/routers.md
@@ -50,7 +50,7 @@ Use the following steps to create a new router:
 - The router listens to the list of `ClusterStats` via the`updateBackEndStats`
   method.
 - This method is called on regular intervals defined in the config 
-  parameter `monitor=>taskDelaySeconds`.
+  parameter `monitor=>taskDelay`.
 - Each element in the list corresponds to each backend cluster.
 - Only the stats from the healthy cluster are reported, unhealthy clusters are
   not included in the list. If you have three cluster backends and one is
@@ -70,9 +70,6 @@ backendState:
 
 clusterStatsConfiguration:
   monitorType: UI_API
-
-monitor:
-  taskDelaySeconds: 10
 
 modules:
   - io.trino.gateway.ha.module.QueryCountBasedRouterProvider

--- a/gateway-ha/config.yaml
+++ b/gateway-ha/config.yaml
@@ -18,4 +18,4 @@ clusterStatsConfiguration:
 
 # This can be adjusted based on the coordinator state
 monitor:
-  taskDelaySeconds: 10
+  taskDelay: 1m

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/MonitorConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/MonitorConfiguration.java
@@ -15,15 +15,15 @@ package io.trino.gateway.ha.config;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
-import io.trino.gateway.ha.clustermonitor.ActiveClusterMonitor;
 
 import java.util.Map;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class MonitorConfiguration
 {
-    private int taskDelaySeconds = ActiveClusterMonitor.MONITOR_TASK_DELAY_SECONDS;
+    private Duration taskDelay = new Duration(1, MINUTES);
 
     private int retries;
 
@@ -44,14 +44,14 @@ public class MonitorConfiguration
 
     public MonitorConfiguration() {}
 
-    public int getTaskDelaySeconds()
+    public Duration getTaskDelay()
     {
-        return this.taskDelaySeconds;
+        return this.taskDelay;
     }
 
-    public void setTaskDelaySeconds(int taskDelaySeconds)
+    public void setTaskDelay(Duration taskDelay)
     {
-        this.taskDelaySeconds = taskDelaySeconds;
+        this.taskDelay = taskDelay;
     }
 
     public int getRetries()

--- a/gateway-ha/src/test/resources/test-config-template.yml
+++ b/gateway-ha/src/test/resources/test-config-template.yml
@@ -13,7 +13,7 @@ clusterStatsConfiguration:
   monitorType: INFO_API
 
 monitor:
-  taskDelaySeconds: 1
+  taskDelay: 1s
 
 extraWhitelistPaths:
   - '/v1/custom.*'

--- a/gateway-ha/src/test/resources/test-config-with-routing-rules-api.yml
+++ b/gateway-ha/src/test/resources/test-config-with-routing-rules-api.yml
@@ -12,7 +12,7 @@ clusterStatsConfiguration:
   monitorType: INFO_API
 
 monitor:
-  taskDelaySeconds: 1
+  taskDelay: 1s
 
 extraWhitelistPaths:
   - '/v1/custom.*'

--- a/gateway-ha/src/test/resources/test-config-with-routing-template.yml
+++ b/gateway-ha/src/test/resources/test-config-with-routing-template.yml
@@ -12,7 +12,7 @@ clusterStatsConfiguration:
   monitorType: INFO_API
 
 monitor:
-  taskDelaySeconds: 1
+  taskDelay: 1s
 
 extraWhitelistPaths:
   - '/v1/custom.*'

--- a/gateway-ha/src/test/resources/test-config-without-x-forwarded-template.yml
+++ b/gateway-ha/src/test/resources/test-config-without-x-forwarded-template.yml
@@ -12,7 +12,7 @@ clusterStatsConfiguration:
   monitorType: INFO_API
 
 monitor:
-  taskDelaySeconds: 1
+  taskDelay: 1s
 
 extraWhitelistPaths:
   - '/v1/custom.*'


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Use Airlift Duration in MonitorConfiguration

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
() Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
* Fix monitor.taskDelaySeconds to use Airlift Duration
```
