### PR TITLE
Make externalHeaders optional in external service response

### DIFF
--- a/docs/routing-rules.md
+++ b/docs/routing-rules.md
@@ -95,6 +95,14 @@ return a result with the following criteria:
 * Only one group can be returned
 * If errors is not null, then query would route to default routing group adhoc
 
+#### Request headers modification
+
+The external routing service can optionally return an `externalHeaders` map in its response
+to add or modify HTTP headers before the request is forwarded.
+
+This enables dynamic customization of request behavior, such as injecting session properties
+or setting client tags before the request reaches the Trino cluster.
+
 ```json
 {
     "routingGroup": "test-group",
@@ -102,7 +110,11 @@ return a result with the following criteria:
         "Error1",
         "Error2",
         "Error3"
-    ]
+    ],
+    "externalHeaders": {
+        "x-trino-client-tags": "['etl']",
+        "x-trino-session": "query_max_memory=50GB,optimize_metadata_queries=false"
+    }
 }
 ```
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/ExternalRouterResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/ExternalRouterResponse.java
@@ -28,10 +28,10 @@ import java.util.Map;
 public record ExternalRouterResponse(
         @Nullable String routingGroup,
         List<String> errors,
-        Map<String, String> externalHeaders)
+        @Nullable Map<String, String> externalHeaders)
         implements RoutingGroupResponse
 {
     public ExternalRouterResponse {
-        externalHeaders = ImmutableMap.copyOf(externalHeaders);
+        externalHeaders = externalHeaders == null ? ImmutableMap.of() : ImmutableMap.copyOf(externalHeaders);
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelectorExternal.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingGroupSelectorExternal.java
@@ -288,6 +288,23 @@ final class TestRoutingGroupSelectorExternal
     }
 
     @Test
+    void testHeaderModificationWithNoExternalHeaders()
+    {
+        RoutingGroupSelector selector = RoutingGroupSelector.byRoutingExternal(httpClient, provideRoutingRuleExternalConfig(), requestAnalyzerConfig);
+        HttpServletRequest mockRequest = prepareMockRequest();
+        setMockHeaders(mockRequest);
+
+        ExternalRouterResponse mockResponse = new ExternalRouterResponse("test-group", ImmutableList.of(), null);
+
+        when(httpClient.execute(any(), any())).thenReturn(mockResponse);
+
+        RoutingSelectorResponse routingSelectorResponse = selector.findRoutingDestination(mockRequest);
+
+        assertThat(routingSelectorResponse.routingGroup()).isEqualTo("test-group");
+        assertThat(routingSelectorResponse.externalHeaders()).isEmpty();
+    }
+
+    @Test
     void testHeaderModificationWithEmptyRoutingGroup()
             throws Exception
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This PR makes the externalHeaders field optional in the external routing service response.
If omitted, the request proceeds without modifying headers.

It also updates the documentation to describe the externalHeaders feature, which allows external services to add or override request headers dynamically before forwarding.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
related pull -  ({pull} #654 )
related issue -  ({issue} #699 )


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

```markdown
* Fix - external routing service requires the externalHeaders field in response. ({issue} #699 )
```
Do not need release note because issue is fixed before next release