### PR TITLE
Fix mistake in deactivation status log

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaGatewayManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaGatewayManager.java
@@ -105,7 +105,7 @@ public class HaGatewayManager
     private static void logActivationStatusChange(String clusterName, boolean newStatus, boolean previousStatus)
     {
         if (previousStatus != newStatus) {
-            log.info("Backend cluster %s activation status set to active=%s (previous status: active=%s).", clusterName, previousStatus, newStatus);
+            log.info("Backend cluster %s activation status set to active=%s (previous status: active=%s).", clusterName, newStatus, previousStatus);
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

As apart of efforts to improve telemetry as described in Issue https://github.com/trinodb/trino-gateway/issues/649, PR [#672](https://github.com/trinodb/trino-gateway/pull/672) added logging for whenever a backend cluster is activated/deactivated. However, there's one log line that mixes up previous status and new status. This PR fixes it.

## Testing
- built and ran locally
- deactivated/activated via UI and API call and confirmed status is accurate to activation status

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things. ({issue}`issuenumber`)
```
