### PR TITLE
Improve PR template for release notes entry

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,9 +17,8 @@ More info at https://trino.io/development/process#release-note -->
 ## Release notes
 
 ( ) This is not user-visible or is docs only, and no release notes are required.
-( ) Release notes are required. Please propose a release note for me.
 ( ) Release notes are required, with the following suggested text:
 
 ```markdown
-* Fix some things. ({issue}`issuenumber`)
+* Fix some things.
 ```


### PR DESCRIPTION
## Description

Template wrongly used sphinx markdown. Also removing option to not even think about a release notes entry.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

N.a.


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
