### PR TITLE
Align Resource Group Tables with Trino v476

### DIFF
--- a/gateway-ha/src/main/resources/mysql/V3__align_with_trino_476.sql
+++ b/gateway-ha/src/main/resources/mysql/V3__align_with_trino_476.sql
@@ -1,0 +1,51 @@
+-- Align `exact_match_source_selectors` table
+
+-- Adjust primary key
+ALTER TABLE exact_match_source_selectors
+  DROP PRIMARY KEY;
+
+ALTER TABLE exact_match_source_selectors
+  ADD PRIMARY KEY (environment, source(128), resource_group_id);
+
+-- Modify `query_type` to be nullable
+ALTER TABLE exact_match_source_selectors
+  MODIFY COLUMN query_type VARCHAR(512) DEFAULT NULL;
+
+
+-- Align `resource_groups` table
+
+-- Drop the unique constraint on `name`
+ALTER TABLE resource_groups
+  DROP INDEX name;
+
+-- Make `soft_memory_limit` nullable
+ALTER TABLE resource_groups
+  MODIFY COLUMN soft_memory_limit VARCHAR(128) DEFAULT NULL;
+
+-- Drop and recreate the `parent` foreign key with ON DELETE CASCADE
+ALTER TABLE resource_groups
+  DROP FOREIGN KEY resource_groups_ibfk_1;
+
+ALTER TABLE resource_groups
+  ADD CONSTRAINT resource_groups_ibfk_1
+  FOREIGN KEY (parent) REFERENCES resource_groups(resource_group_id)
+  ON DELETE CASCADE;
+
+
+-- Align `selectors` table
+
+-- Add missing columns
+ALTER TABLE selectors
+  ADD COLUMN user_group_regex VARCHAR(2048) DEFAULT NULL,
+  ADD COLUMN original_user_regex VARCHAR(512) DEFAULT NULL,
+  ADD COLUMN authenticated_user_regex VARCHAR(512) DEFAULT NULL,
+  ADD COLUMN id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY;
+
+-- Drop and recreate the `resource_group_id` foreign key with ON DELETE CASCADE
+ALTER TABLE selectors DROP FOREIGN KEY selectors_ibfk_1;
+
+ALTER TABLE selectors
+  ADD CONSTRAINT selectors_ibfk_1
+  FOREIGN KEY (resource_group_id)
+  REFERENCES resource_groups(resource_group_id)
+  ON DELETE CASCADE;

--- a/gateway-ha/src/main/resources/oracle/V3__align_with_trino_476.sql
+++ b/gateway-ha/src/main/resources/oracle/V3__align_with_trino_476.sql
@@ -1,0 +1,21 @@
+-- Align `exact_match_source_selectors` table
+
+-- Shrink `environment` column length
+ALTER TABLE exact_match_source_selectors MODIFY environment VARCHAR(128);
+
+
+-- Align `resource_groups` table
+
+-- Make `soft_memory_limit` nullable
+ALTER TABLE resource_groups MODIFY soft_memory_limit VARCHAR(128) NULL;
+
+
+-- Align `selectors` table
+
+-- Add missing columns
+ALTER TABLE selectors ADD (
+  user_group_regex VARCHAR2(2048),
+  original_user_regex VARCHAR2(512),
+  authenticated_user_regex VARCHAR2(512),
+  id NUMBER GENERATED ALWAYS as IDENTITY(START with 1 INCREMENT by 1) PRIMARY KEY
+);

--- a/gateway-ha/src/main/resources/postgresql/V3__align_with_trino_476.sql
+++ b/gateway-ha/src/main/resources/postgresql/V3__align_with_trino_476.sql
@@ -1,0 +1,50 @@
+-- Align `exact_match_source_selectors` table
+
+-- Adjust primary key
+ALTER TABLE exact_match_source_selectors
+    DROP CONSTRAINT IF EXISTS exact_match_source_selectors_pkey;
+
+ALTER TABLE exact_match_source_selectors
+    ADD PRIMARY KEY (environment, source, resource_group_id);
+
+-- Extend the length of `query_type`
+ALTER TABLE exact_match_source_selectors
+    ALTER COLUMN query_type TYPE VARCHAR(512);
+
+
+-- Align resource_groups table
+
+-- Drop the unique constraint on `name` if it exists
+ALTER TABLE resource_groups DROP CONSTRAINT IF EXISTS resource_groups_name_key;
+
+-- Alter `resource_group_id` from integer to bigint
+ALTER TABLE resource_groups ALTER COLUMN resource_group_id TYPE bigint;
+
+-- Make `soft_memory_limit` nullable
+ALTER TABLE resource_groups ALTER COLUMN soft_memory_limit DROP NOT NULL;
+
+-- Drop and recreate the `parent` foreign key with ON DELETE CASCADE
+ALTER TABLE resource_groups DROP CONSTRAINT IF EXISTS resource_groups_parent_fkey;
+
+ALTER TABLE resource_groups
+  ADD CONSTRAINT resource_groups_parent_fkey
+  FOREIGN KEY (parent) REFERENCES resource_groups(resource_group_id) ON DELETE CASCADE;
+
+
+-- Align `selectors` table
+
+-- Add missing columns
+ALTER TABLE selectors
+    ADD COLUMN user_group_regex VARCHAR(2048),
+    ADD COLUMN original_user_regex VARCHAR(512),
+    ADD COLUMN authenticated_user_regex VARCHAR(512),
+    ADD COLUMN id BIGSERIAL PRIMARY KEY;
+
+-- Drop and recreate the `resource_group_id` foreign key with ON DELETE CASCADE
+ALTER TABLE selectors DROP CONSTRAINT IF EXISTS selectors_resource_group_id_fkey;
+
+ALTER TABLE selectors
+  ADD CONSTRAINT selectors_resource_group_id_fkey
+  FOREIGN KEY (resource_group_id)
+  REFERENCES resource_groups(resource_group_id)
+  ON DELETE CASCADE;


### PR DESCRIPTION
## Description

This PR updates the resource groups–related tables to match the schemas used by Trino (v476).


## Additional context and related issues

Since version 14, automatic database migrations have been enabled in the gateway (I believe in [this PR](https://github.com/trinodb/trino-gateway/pull/575)).
This causes conflicts (different Flyway migration checksums) with the automatic migrations triggered during Trino’s startup. As a result, when sharing the database between the gateway and one or more Trino instances, migration immediately fails.

If we decide to enable only the gateway migrations, we must ensure the schemas match Trino’s. Otherwise, it fails due to missing columns.  This PR addresses that schema alignment.


### a Few Disclaimers

* I believe we need to **disable** one of the migrations (either Trino's or the gateway's) or at least document this. Currently, it does not work with the default configuration if resource groups are enabled and Trino shares the database with the gateway.
* I have not verified compatibility with older Trino versions that haven’t updated their schemas while the gateway has, only with v476 for the different db implementations.
* I had to reduce the maximum length of the environment column in `exact_match_source_selectors` in Oracle to match Trino’s schema. This change might be unsafe and prone to failures.
* I have not updated either the UI forms for resource groups/selectors creation or the underlying SQL statements (DAO classes). I wasn’t sure if this effort was worthwhile, given that this feature is about to be removed from the gateway and the existing implementation has issues updating via the UI.

Refers [this issue](https://github.com/trinodb/trino-gateway/issues/708).

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text.
