### PR TITLE
logout when restart the server

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/FormAuthConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/FormAuthConfiguration.java
@@ -13,10 +13,15 @@
  */
 package io.trino.gateway.ha.config;
 
+import io.airlift.units.Duration;
+
+import java.util.concurrent.TimeUnit;
+
 public class FormAuthConfiguration
 {
     private SelfSignKeyPairConfiguration selfSignKeyPair;
     private String ldapConfigPath;
+    private Duration sessionTimeout = new Duration(30, TimeUnit.MINUTES);
 
     public FormAuthConfiguration(SelfSignKeyPairConfiguration selfSignKeyPair, String ldapConfigPath)
     {
@@ -44,5 +49,15 @@ public class FormAuthConfiguration
     public void setLdapConfigPath(String ldapConfigPath)
     {
         this.ldapConfigPath = ldapConfigPath;
+    }
+
+    public Duration getSessionTimeout()
+    {
+        return this.sessionTimeout;
+    }
+
+    public void setSessionTimeout(Duration sessionTimeout)
+    {
+        this.sessionTimeout = sessionTimeout;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/LoginResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/LoginResource.java
@@ -185,4 +185,18 @@ public class LoginResource
         }
         return Response.ok(Result.ok("Ok", loginType)).build();
     }
+
+    @POST
+    @Path("serverInfo")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response serverInfo()
+    {
+        long serverStartTime = System.currentTimeMillis();
+        if (formAuthManager != null) {
+            serverStartTime = formAuthManager.getServerStartTime();
+        }
+        Map<String, Object> serverInfo = Map.of("serverStart", serverStartTime);
+        return Response.ok(Result.ok(serverInfo)).build();
+    }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/SessionCookie.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/SessionCookie.java
@@ -30,7 +30,7 @@ public final class SessionCookie
                 .path("/")
                 .domain("")
                 .comment("")
-                .maxAge(60 * 60 * 24)
+                .maxAge(60 * 15) // 15 minutes session timeout
                 .secure(true)
                 .build();
     }

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -16,6 +16,7 @@ import { useEffect } from 'react';
 import { getCSSVar } from './utils/utils';
 import { IllustrationIdle, IllustrationIdleDark } from '@douyinfe/semi-illustrations';
 import Cookies from 'js-cookie';
+import { SessionManager } from './utils/session';
 
 function App() {
   return (
@@ -40,6 +41,18 @@ function Screen() {
       access.updateToken(token);
       Cookies.remove('token');
     }
+    // Initialize session management
+    const sessionManager = SessionManager.getInstance();
+    sessionManager.setSessionExpiredCallback(() => {
+        access.logout();
+    });
+
+    // Check token validity on app start
+    access.checkTokenValidity().catch(console.error);
+
+    return () => {
+        sessionManager.clearTimeout();
+      };
   }, [])
   return (
     <>

--- a/webapp/src/api/webapp/login.ts
+++ b/webapp/src/api/webapp/login.ts
@@ -23,3 +23,7 @@ export async function loginTypeApi(): Promise<any> {
 export async function getUIConfiguration(): Promise<any> {
     return api.get('/webapp/getUIConfiguration')
 }
+
+export async function serverInfoApi(): Promise<any> {
+    return api.post('/serverInfo', {})
+}

--- a/webapp/src/store/access.ts
+++ b/webapp/src/store/access.ts
@@ -1,7 +1,8 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { StoreKey } from "../constant";
-import { getInfoApi } from "../api/webapp/login";
+import { getInfoApi, serverInfoApi } from "../api/webapp/login";
+import { SessionManager } from "../utils/session";
 
 export enum Role {
   ADMIN = "ADMIN",
@@ -28,6 +29,8 @@ export interface AccessControlStore {
   getUserInfo: (_?: boolean) => void;
   hasRole: (role: Role) => boolean;
   hasPermission: (permission: string | undefined) => boolean;
+  logout: () => void;
+  checkTokenValidity: () => Promise<boolean>;
 }
 
 let fetchState: number = 0; // 0 not fetch, 1 fetching, 2 done
@@ -78,6 +81,51 @@ export const useAccessStore = create<AccessControlStore>()(
         const permissions = get().permissions
         return permission == undefined || permissions == null || permissions.length == 0 || permissions.includes(permission);
       },
+        logout() {
+            const sessionManager = SessionManager.getInstance();
+            sessionManager.clearTimeout();
+            set(() => ({
+                token: "",
+                userId: "",
+                userName: "",
+                nickName: "",
+                userType: "",
+                email: "",
+                phonenumber: "",
+                sex: "",
+                avatar: "",
+                permissions: [],
+                roles: [],
+            }));
+            fetchState = 0;
+        },
+        async checkTokenValidity() {
+            const token = get().token;
+            if (!token) return false;
+
+            const sessionManager = SessionManager.getInstance();
+
+            // Check if token is expired
+            if (sessionManager.isTokenExpired(token)) {
+                get().logout();
+                return false;
+            }
+
+            // Check for server restart
+            try {
+                const serverInfo = await serverInfoApi();
+                if (sessionManager.checkServerRestart(token, serverInfo.serverStart)) {
+                    console.log('Server restart detected, logging out');
+                    get().logout();
+                    return false;
+                }
+            } catch (error) {
+                console.error('Error checking server info:', error);
+                // Don't logout on API error, just continue
+            }
+
+            return true;
+        },
     }),
     {
       name: StoreKey.Access,

--- a/webapp/src/utils/session.ts
+++ b/webapp/src/utils/session.ts
@@ -1,0 +1,102 @@
+export class SessionManager {
+    private static instance: SessionManager;
+    private timeoutId: number | null = null;
+    private readonly TIMEOUT_MINUTES = 15;
+    private readonly CHECK_INTERVAL = 60000; // Check every minute
+    private lastActivity: number = Date.now();
+    private onSessionExpired?: () => void;
+
+    private constructor() {
+        this.setupActivityListeners();
+        this.startTimeoutCheck();
+    }
+
+    public static getInstance(): SessionManager {
+        if (!SessionManager.instance) {
+            SessionManager.instance = new SessionManager();
+        }
+        return SessionManager.instance;
+    }
+
+    public setSessionExpiredCallback(callback: () => void): void {
+        this.onSessionExpired = callback;
+    }
+
+    public resetTimeout(): void {
+        this.lastActivity = Date.now();
+    }
+
+    public clearTimeout(): void {
+        if (this.timeoutId) {
+            clearInterval(this.timeoutId);
+            this.timeoutId = null;
+        }
+    }
+
+    private setupActivityListeners(): void {
+        const events = ['mousedown', 'mousemove', 'keypress', 'scroll', 'touchstart', 'click'];
+
+        events.forEach(event => {
+            document.addEventListener(event, () => {
+                this.resetTimeout();
+            }, true);
+        });
+    }
+
+    private startTimeoutCheck(): void {
+        this.timeoutId = setInterval(() => {
+            const now = Date.now();
+            const timeSinceLastActivity = now - this.lastActivity;
+            const timeoutMs = this.TIMEOUT_MINUTES * 60 * 1000;
+
+            if (timeSinceLastActivity >= timeoutMs) {
+                this.handleSessionExpired();
+            }
+        }, this.CHECK_INTERVAL);
+    }
+
+    private handleSessionExpired(): void {
+        this.clearTimeout();
+        if (this.onSessionExpired) {
+            this.onSessionExpired();
+        }
+    }
+
+    public isTokenExpired(token: string): boolean {
+        if (!token) return true;
+
+        try {
+            // Decode JWT token to check expiration
+            const payload = JSON.parse(atob(token.split('.')[1]));
+            const currentTime = Math.floor(Date.now() / 1000);
+
+            // Check if token has expired
+            if (payload.exp && payload.exp < currentTime) {
+                return true;
+            }
+
+            return false;
+        } catch (error) {
+            console.error('Error decoding token:', error);
+            return true;
+        }
+    }
+
+    public checkServerRestart(token: string, currentServerStart: number): boolean {
+        if (!token) return false;
+
+        try {
+            const payload = JSON.parse(atob(token.split('.')[1]));
+
+            // Check if token was issued before server restart
+            if (payload.server_start && payload.server_start !== currentServerStart) {
+                return true;
+            }
+
+            return false;
+        } catch (error) {
+            console.error('Error checking server restart:', error);
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

fixes https://github.com/trinodb/trino-gateway/issues/717

Features Implemented

1. 15-minute Session Timeout

Backend: JWT tokens now expire after 15 minutes instead of 24 hours
Frontend: Client-side session management tracks user activity and automatically logs out after 15 minutes of inactivity
Activity Detection: Mouse movements, clicks, keyboard input, scrolling, and touch events reset the timeout

2. Server Restart Detection

Backend: JWT tokens include a server start timestamp claim
Frontend: Checks server start time on every API call to detect server restarts immediately
Automatic Logout: Users are automatically logged out on any action after server restart


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
