### PR TITLE
Refactor LbAuthorizer logging: log role identification only after authorization check

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbAuthorizer.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbAuthorizer.java
@@ -37,27 +37,27 @@ public class LbAuthorizer
     {
         switch (role) {
             case "ADMIN":
-                log.info("User '%s' with memberOf(%s) was identified as ADMIN(%s)",
-                        principal.getName(), principal.getMemberOf(), configuration.getAdmin());
-                return principal.getMemberOf()
-                        .filter(m -> m.matches(configuration.getAdmin()))
-                        .isPresent();
+                return hasRole(principal, role, configuration.getAdmin());
             case "USER":
-                log.info("User '%s' with memberOf(%s) identified as USER(%s)",
-                        principal.getName(), principal.getMemberOf(), configuration.getUser());
-                return principal.getMemberOf()
-                        .filter(m -> m.matches(configuration.getUser()))
-                        .isPresent();
+                return hasRole(principal, role, configuration.getUser());
             case "API":
-                log.info("User '%s' with memberOf(%s) identified as API(%s)",
-                        principal.getName(), principal.getMemberOf(), configuration.getApi());
-                return principal.getMemberOf()
-                        .filter(m -> m.matches(configuration.getApi()))
-                        .isPresent();
+                return hasRole(principal, role, configuration.getApi());
             default:
                 log.warn("User '%s' with role %s has no regex match based on ldap search",
                         principal.getName(), role);
                 return false;
         }
+    }
+
+    private static boolean hasRole(LbPrincipal principal, String role, String regex)
+    {
+        boolean matched = principal.getMemberOf()
+                .filter(m -> m.matches(regex))
+                .isPresent();
+        if (matched) {
+            log.info("User '%s' with memberOf(%s) is identified as %s(%s)",
+                    principal.getName(), principal.getMemberOf(), role, regex);
+        }
+        return matched;
     }
 }


### PR DESCRIPTION
This PR refactors the logging logic in LbAuthorizer to ensure that log messages about user role identification (ADMIN, USER, API) are only written after the corresponding authorization check passes. Previously, the log messages could misleadingly indicate a user was identified as a role before the check was performed. Now, the logs clearly state whether a user is or is not identified as a given role, based on the actual result of the authorization check. The log message wording and style have also been improved for clarity and consistency.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
