### PR TITLE
Enhance the MultiReadHttpServletRequest stream

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/MultiReadHttpServletRequest.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/MultiReadHttpServletRequest.java
@@ -45,13 +45,15 @@ public class MultiReadHttpServletRequest
             @Override
             public boolean isFinished()
             {
-                return byteArrayInputStream.available() > 0;
+                // Determine if data is available for reading.
+                return byteArrayInputStream.available() <= 0;
             }
 
             @Override
             public boolean isReady()
             {
-                return false;
+                // It's an in memory stream, so it's ready to be read
+                return true;
             }
 
             @Override
@@ -62,6 +64,21 @@ public class MultiReadHttpServletRequest
                     throws IOException
             {
                 return byteArrayInputStream.read();
+            }
+
+            // Add multibyte read versions for efficiency
+            @Override
+            public int read(byte[] b, int off, int len)
+                    throws IOException
+            {
+                return byteArrayInputStream.read(b, off, len);
+            }
+
+            @Override
+            public int read(byte[] b)
+                    throws IOException
+            {
+                return byteArrayInputStream.read(b);
             }
         };
     }


### PR DESCRIPTION
## Description
- The return values of the function `isFinished` should be true only no bytes are available in the input stream to read
- `isReady` should always return true, since the inputstream should be ready all the time and never be false.
- Added methods to so that multiple bytes can be read for better performance.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
@Chaho12 has idea on the issue with this code. @willmostly is the original author.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

