### PR TITLE
Encode the user’s roles directly into the JWT

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
@@ -104,9 +104,10 @@ public class HaGatewayProviderModule
         Map<String, UserConfiguration> presetUsers = configuration.getPresetUsers();
 
         oauthManager = getOAuthManager(configuration);
-        formAuthManager = getFormAuthManager(configuration);
 
         authorizationManager = new AuthorizationManager(configuration.getAuthorization(), presetUsers);
+        formAuthManager = getFormAuthManager(configuration);
+
         resourceSecurityDynamicFeature = getAuthFilter(configuration);
         backendStateConnectionManager = new BackendStateManager();
 
@@ -137,7 +138,7 @@ public class HaGatewayProviderModule
         AuthenticationConfiguration authenticationConfiguration = configuration.getAuthentication();
         if (authenticationConfiguration != null && authenticationConfiguration.getForm() != null) {
             return new LbFormAuthManager(authenticationConfiguration.getForm(),
-                    configuration.getPresetUsers(), configuration.getPagePermissions());
+                    configuration.getPresetUsers(), configuration.getPagePermissions(), authorizationManager);
         }
         return null;
     }
@@ -156,7 +157,7 @@ public class HaGatewayProviderModule
 
         if (formAuthManager != null) {
             authFilters.add(new LbFilter(
-                    new FormAuthenticator(formAuthManager, authorizationManager),
+                    new FormAuthenticator(formAuthManager),
                     authorizer,
                     "Bearer",
                     new LbUnauthorizedHandler(defaultType)));
@@ -174,7 +175,7 @@ public class HaGatewayProviderModule
     {
         AuthorizationConfiguration authorizationConfig = configuration.getAuthorization();
         Authorizer authorizer = (authorizationConfig != null)
-                ? new LbAuthorizer(authorizationConfig) : new NoopAuthorizer();
+                ? new LbAuthorizer() : new NoopAuthorizer();
 
         AuthenticationConfiguration authenticationConfig = configuration.getAuthentication();
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbAuthenticator.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbAuthenticator.java
@@ -70,7 +70,7 @@ public class LbAuthenticator
                 privileges = Optional.ofNullable(role);
             }
 
-            return Optional.of(new LbPrincipal(userId, privileges));
+            return Optional.of(new LbPrincipal(userId, privileges.orElse("")));
         }
         return oauthManager
                 .getClaimsFromIdToken(idToken)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbFormAuthManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbFormAuthManager.java
@@ -45,10 +45,12 @@ public class LbFormAuthManager
     private final Map<String, UserConfiguration> presetUsers;
     private final Map<String, String> pagePermissions;
     private final LbLdapClient lbLdapClient;
+    private final AuthorizationManager authorizationManager;
 
     public LbFormAuthManager(FormAuthConfiguration configuration,
             Map<String, UserConfiguration> presetUsers,
-            Map<String, String> pagePermissions)
+            Map<String, String> pagePermissions,
+            AuthorizationManager authorizationManager)
     {
         this.presetUsers = presetUsers;
         this.pagePermissions = pagePermissions.entrySet().stream()
@@ -69,11 +71,17 @@ public class LbFormAuthManager
         else {
             lbLdapClient = null;
         }
+        this.authorizationManager = authorizationManager;
     }
 
     public String getUserIdField()
     {
         return "sub";
+    }
+
+    public String getPrivilegesField()
+    {
+        return "privileges";
     }
 
     /**
@@ -128,6 +136,7 @@ public class LbFormAuthManager
                     .withHeader(headers)
                     .withIssuer(SessionCookie.SELF_ISSUER_ID)
                     .withSubject(username)
+                    .withClaim(getPrivilegesField(), authorizationManager.getPrivileges(username))
                     .sign(algorithm);
         }
         catch (JWTCreationException exception) {

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbPrincipal.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbPrincipal.java
@@ -15,18 +15,17 @@ package io.trino.gateway.ha.security;
 
 import java.security.Principal;
 import java.util.Objects;
-import java.util.Optional;
 
 public class LbPrincipal
         implements Principal
 {
     private final String name;
-    private final Optional<String> memberOf;
+    private final String privileges;
 
-    public LbPrincipal(String name, Optional<String> memberOf)
+    public LbPrincipal(String name, String privileges)
     {
         this.name = name;
-        this.memberOf = memberOf;
+        this.privileges = privileges;
     }
 
     @Override
@@ -39,13 +38,13 @@ public class LbPrincipal
             return false;
         }
         LbPrincipal that = (LbPrincipal) o;
-        return name.equals(that.name) && memberOf.equals(that.memberOf);
+        return name.equals(that.name) && privileges.equals(that.privileges);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, memberOf);
+        return Objects.hash(name, privileges);
     }
 
     @Override
@@ -54,8 +53,8 @@ public class LbPrincipal
         return name;
     }
 
-    public Optional<String> getMemberOf()
+    public String getPrivileges()
     {
-        return this.memberOf;
+        return this.privileges;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/NoopFilter.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/NoopFilter.java
@@ -20,7 +20,6 @@ import jakarta.ws.rs.core.SecurityContext;
 
 import java.io.IOException;
 import java.security.Principal;
-import java.util.Optional;
 
 import static jakarta.ws.rs.Priorities.AUTHENTICATION;
 
@@ -37,7 +36,7 @@ public class NoopFilter
             @Override
             public Principal getUserPrincipal()
             {
-                return new LbPrincipal("user", Optional.of("ADMIN_USER_API"));
+                return new LbPrincipal("user", "ADMIN_USER_API");
             }
 
             @Override


### PR DESCRIPTION

## Description
Currently, when navigating between pages in the Trino-gateway UI, each page transition triggers API calls to the gateway. For every API call, a new LbPrincipal is generated by decoding the JWT and fetching the memberOf attribute from LDAP. This causes unnecessary and excessive LDAP queries on every API request, even within the same authenticated session.

To reduce the LDAP calls , i have encoded the roles in the JWT claims and decode it instead of calling LDAP server.

Note: we should use short-lived JWTs  to minimize the risk of stale role data
https://github.com/trinodb/trino-gateway/issues/715
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required, with the following suggested text: