### PR TITLE
userId null check and logging

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbAuthenticator.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbAuthenticator.java
@@ -51,7 +51,13 @@ public class LbAuthenticator
         Optional<String> privilegesField = oauthManager.getPrivilegesField();
         if (privilegesField.isPresent()) {
             Map<String, Claim> claims = oauthManager.getClaimsFromIdToken(idToken).orElseThrow();
-            String userId = claims.get(userIdField).asString().replace("\"", "");
+            
+            Claim userIdClaim = claims.get(userIdField);
+            if (claim == null) {
+                log.error("Required userId field %s not found", userIdField.orElseThrow());
+                throw new AuthenticationException("UserId field does not exist");
+            }
+            String userId = userIdClaim.asString().replace("\"", "");
 
             Claim claim = claims.get(privilegesField.orElseThrow());
             if (claim == null) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Currently there are no null check on the userId field, this causes authenticator to raise NPE and filter skips the LbFilter(which is fine). But I was clueless about the issue when auth config has the wrong userId as there are no logging. 

Added a log statement which will help in triaging the issue.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Added a null check and logging statement when userId field does not exist in the claim


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
