### PR TITLE
Updates to enable new release method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [23, 24-ea]
+        java-version: [23, 24]
     timeout-minutes: 20
     steps:
       - name: Checkout source

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-s
+${session.rootDirectory}/.mvn/settings.xml

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,16 @@
+<settings>
+    <pluginGroups>
+        <pluginGroup>eu.maveniverse.maven.plugins</pluginGroup>
+    </pluginGroups>
+    <servers>
+        <server>
+            <id>sonatype-central-portal</id>
+            <username>${env.MAVENCENTRAL_USERNAME}</username>
+            <password>${env.MAVENCENTRAL_PASSWORD}</password>
+            <configuration>
+                <njord.publisher>sonatype-cp</njord.publisher>
+                <njord.releaseUrl>njord:template:release-sca</njord.releaseUrl>
+            </configuration>
+        </server>
+    </servers>
+</settings>

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -13,6 +13,7 @@
     <artifactId>gateway-ha</artifactId>
     <packaging>jar</packaging>
     <name>gateway-ha</name>
+    <description>Core of Trino Gateway</description>
 
     <properties>
         <environments>development</environments>
@@ -74,6 +75,7 @@
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
+            <classifier>classes</classifier>
         </dependency>
 
         <dependency>

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestExternalUrlQueryHistoryOracle.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestExternalUrlQueryHistoryOracle.java
@@ -13,13 +13,13 @@
  */
 package io.trino.gateway.ha.router;
 
-import org.testcontainers.containers.OracleContainer;
+import static io.trino.gateway.ha.HaGatewayTestUtils.getOracleContainer;
 
 public class TestExternalUrlQueryHistoryOracle
         extends BaseExternalUrlQueryHistoryTest
 {
     public TestExternalUrlQueryHistoryOracle()
     {
-        super(new OracleContainer("gvenzl/oracle-xe:21-slim"));
+        super(getOracleContainer());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,13 @@
                                 <bannedImport>org.junit.jupiter.api.Assertions.*</bannedImport>
                             </bannedImports>
                         </RestrictImports>
+                        <requirePropertyDiverges>
+                            <property>project.description</property>
+                        </requirePropertyDiverges>
+                        <requireProperty>
+                            <property>project.name</property>
+                            <message>Project name must be set in the pom.xml</message>
+                        </requireProperty>
                     </rules>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>262</version>
+        <version>277</version>
     </parent>
 
     <groupId>io.trino.gateway</groupId>
@@ -51,7 +51,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>bom</artifactId>
-                <version>335</version>
+                <version>339</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Description

Update project to enable using Njord for releaseing to Maven Central via the new required Sonatype portal.

## Additional context and related issues

* http://maveniverse.eu/docs/njord/migration/
* https://github.com/trinodb/trino/pull/26160
* https://github.com/trinodb/trino/pull/26156

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
