### PR TITLE
Fix query distribution chart keeping the legends more than an hour

### DIFF
--- a/webapp/src/components/dashboard.tsx
+++ b/webapp/src/components/dashboard.tsx
@@ -18,7 +18,7 @@ export function Dashboard() {
   const [distributionDetail, setDistributionDetail] = useState<DistributionDetail>();
 
   useEffect(() => {
-    distributionApi({})
+    distributionApi({ latestHour: 1 })
       .then(data => {
         setDistributionDetail(data);
       }).catch(() => { });


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

previously , it is showing more than 1 hour data like the screenshot : - 

<img width="1702" height="851" alt="image (2) (1)" src="https://github.com/user-attachments/assets/526e0c46-b44d-4a01-87f3-a3a208a7c36f" />

this pr fixes this issue which shows only last 1 hour's query distribution.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
