### PR TITLE
Add forward proto header configuration for cluster monitoring

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -362,6 +362,23 @@ that are marked as active.
 See [TrinoStatus](routing-rules.md#trinostatus) for more details on 
 what each Trino status means.
 
+Username and password for the health check can be configured by adding 
+`backendState` to your configuration. The username and password must be valid
+across all backends.
+
+SSL and xForwardProtoHeader can be configured based on whether the 
+connection between the Trino Gateway and the backend is secure. 
+By default, both are set to false.
+Find more information in [the related Trino documentation](https://trino.io/docs/current/security/tls.html#use-a-load-balancer-to-terminate-tls-https).
+
+```yaml
+backendState:
+  username: "user"
+  password: "password"
+  ssl: <false/true>
+  xForwardedProtoHeader: <false/true>  
+```
+
 The type of health check is configured by setting
 
 ```yaml
@@ -442,15 +459,7 @@ monitor:
 This uses a JDBC connection to query `system.runtime` tables for cluster 
 information. It is required for the query count based routing strategy. This is
 recommended over `UI_API` since it does not restrict the Web UI authentication
-method of backend clusters. Configure a username and password by adding
-`backendState` to your configuration. The username and password must be valid 
-across all backends.
-
-```yaml
-backendState:
-  username: "user"
-  password: "password"
-```
+method of backend clusters. 
 
 Trino Gateway uses `explicitPrepare=false` by default. This property was introduced
 in Trino 431, and uses a single query for prepared statements, instead of a 

--- a/docs/routers.md
+++ b/docs/routers.md
@@ -67,6 +67,7 @@ backendState:
   username: <usernme>
   password: <password>
   ssl: <false/true>
+  xForwardedProtoHeader: <false/true>
 
 clusterStatsConfiguration:
   monitorType: UI_API

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/BackendStateConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/BackendStateConfiguration.java
@@ -18,6 +18,7 @@ public class BackendStateConfiguration
     private String username;
     private String password = "";
     private Boolean ssl = false;
+    private boolean xForwardedProtoHeader;
 
     public BackendStateConfiguration() {}
 
@@ -49,5 +50,15 @@ public class BackendStateConfiguration
     public void setSsl(Boolean ssl)
     {
         this.ssl = ssl;
+    }
+
+    public boolean getXForwardedProtoHeader()
+    {
+        return xForwardedProtoHeader;
+    }
+
+    public void setXForwardedProtoHeader(boolean xForwardedProtoHeader)
+    {
+        this.xForwardedProtoHeader = xForwardedProtoHeader;
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

As documented at https://trino.io/docs/current/security/tls.html#use-a-load-balancer-to-terminate-tls-https, when Trino is behind a loadbalancer or proxy like Trino Gateway, it's common that the TLS is terminated at Trino Gateway. 

Correspondingly when Trino Gateway forwards the request to Trino clusters, Gateway adds X-Forwarded-* headers in code [here](https://github.com/trinodb/trino-gateway/blob/main/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java#L317). Relevant documentation is [here](https://trinodb.github.io/trino-gateway/installation/#trino-configuration) where users can optionally disable this by setting routing.addXForwardedHeaders to false.

This MR is to add the same Header while making [health check calls](https://trinodb.github.io/trino-gateway/installation/#health-checks-on-trino-clusters) to get cluster stats like queued queries or running queries. Since it's possible that TLS is terminated at Gateway, a similar header would be required when making the http calls to fetch the cluster stats, for example using the /metrics or /v1/jmx/mbean endpoints 

If such a header isn't added, the http call to fetch metrics would fail with an error like:
```
UnexpectedResponseException{message=Request is missing required keys: 
presto_execution_name_QueryManager_RunningQueries
presto_execution_name_QueryManager_QueuedQueries
trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount
in response: 'Error 403 Forbidden: Authentication over HTTP is not enabled', request=GET http://xxxxxxx/metrics?xxxx
```

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required, with the following suggested text:

```markdown
* Add option to add `X-Forwarded-Proto` when fetching cluster stats.
```
