### PR TITLE
Cleanup backendmappings in history UI page

### DIFF
--- a/webapp/src/components/history.tsx
+++ b/webapp/src/components/history.tsx
@@ -30,9 +30,7 @@ export function History() {
         const mapping: Record<string, string> = {};
         for (let index = 0; index < data.length; index++) {
           const backend = data[index] as BackendData;
-          mapping[backend.name] = backend.proxyTo;
           mapping[backend.proxyTo] = backend.name;
-          mapping[backend.externalUrl] = backend.name;
         }
         setBackendMapping(mapping);
       }).catch(() => { });
@@ -96,7 +94,7 @@ export function History() {
               <Form.Select field="backendUrl" label='RoutedTo' style={{ width: 200 }} showClear placeholder={Locale.History.RoutedToTip}>
                 {backendData?.map(b => (
                   <Form.Select.Option key={b.externalUrl} value={b.externalUrl}>
-                    <Tag color={'blue'} style={{ marginRight: '5px' }}>{backendMapping[b.externalUrl]}</Tag>
+                    <Tag color={'blue'} style={{ marginRight: '5px' }}>{b.name}</Tag>
                     <Text>{b.externalUrl}</Text>
                   </Form.Select.Option>
                 ))}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Currently the history.tsx which is for rendering the Query history page has backendMapping defined at https://github.com/trinodb/trino-gateway/blob/main/webapp/src/components/history.tsx#L18

It stores mapping between:
backend name -> backend proxy URL
backend proxy URL -> backend name
backend external Url -> backend name.

From usage, only the ProxyUrl -> backend Name mapping is used while displaying the backend name in the list of query history, rest mapping can be cleaned up.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

