### PR TITLE
Make user filter in history page more configurable

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
@@ -126,18 +126,7 @@ public class GatewayWebAppResource
     public Response findQueryHistory(QueryHistoryRequest query, @Context SecurityContext securityContext)
     {
         TableData<?> queryHistory;
-        if (!securityContext.isUserInRole("ADMIN")) {
-            queryHistory = queryHistoryManager.findQueryHistory(new QueryHistoryRequest(
-                    query.page(),
-                    query.size(),
-                    securityContext.getUserPrincipal().getName(),
-                    query.backendUrl(),
-                    query.queryId(),
-                    query.source()));
-        }
-        else {
-            queryHistory = queryHistoryManager.findQueryHistory(query);
-        }
+        queryHistory = queryHistoryManager.findQueryHistory(query);
         return Response.ok(Result.ok(queryHistory)).build();
     }
 

--- a/webapp/src/components/history.tsx
+++ b/webapp/src/components/history.tsx
@@ -7,7 +7,7 @@ import { queryHistoryApi } from "../api/webapp/history";
 import { HistoryData, HistoryDetail } from "../types/history";
 import { formatTimestamp } from "../utils/time";
 import { backendsApi } from "../api/webapp/cluster";
-import { Role, useAccessStore } from "../store";
+import { useAccessStore } from "../store";
 import { BackendData } from "../types/cluster";
 
 export function History() {
@@ -101,7 +101,7 @@ export function History() {
                   </Form.Select.Option>
                 ))}
               </Form.Select>
-              <Form.Input field='user' label='User' initValue={form.user} disabled={!access.hasRole(Role.ADMIN)} style={{ width: 150 }} showClear />
+              <Form.Input field='user' label='User' initValue={form.user} style={{ width: 150 }} showClear />
               <Form.Input field='queryId' label='QueryId' style={{ width: 260 }} showClear placeholder={Locale.History.QueryIdTip} />
               <Form.Input field='source' label='Source' style={{ width:150 }} showClear />
               <Button htmlType='submit' style={{ width: 70 }}>{Locale.UI.Query}</Button>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Currently only admins are allowed to filter the username for the query history field. However there are cases where queries aren't always tied to the user who is looking for the query information. 

For example a user is looking for a query submitted by a scheduled non-human workload which maybe using separate authentication mechanism like [jwt auth](https://trino.io/docs/current/security/jwt.html) or [kerberos](https://trino.io/docs/current/security/kerberos.html) which is more common for non-human workloads and not tied to the human looking for routing history. 

As part of this issue, provide alternatives for users to be able to configure user filter in history query page.

~~[Trino web UI ](https://trino.io/docs/current/admin/web-interface.html) also doesn't restrict the query filtering and allows all users to filter all queries submitted to the Trino cluster.~~ This is incorrect. Thanks to @Chaho12 for correction! 

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required, with the following suggested text:

```markdown
* All all users to filter query history page based on user field. 
```
