### PR TITLE
Exclude vulnerable protobuf-java dependency from MySQL Connector/J

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -281,6 +281,12 @@
             <artifactId>mysql-connector-j</artifactId>
             <version>9.3.0</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This PR addresses security vulnerability CVE-2024-7254 found in protobuf-java 3.25.1, which is a transitive dependency brought in by MySQL Connector/J 9.3.0.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
### Vulnerability Details

- __CVE ID__: CVE-2024-7254
- __Affected Component__: protobuf-java 3.25.1
- __Introduced Through__: Transitive dependency via mysql-connector-j 9.3.0

### Changes Made

- Added an exclusion for `com.google.protobuf:protobuf-java` in the MySQL Connector/J dependency configuration
- This prevents the vulnerable version (3.25.1) from being included in the project's dependency tree

### Technical Details

- MySQL Connector/J 9.3.0 depends on protobuf-java 3.25.1, which has a known vulnerability
- Since our application code doesn't directly use protobuf-java functionality, we can safely exclude this transitive dependency
- MySQL Connector/J can still function without the external protobuf-java dependency as it has internal mechanisms to handle this scenario

### Testing Considerations

- The application should continue to function normally with MySQL databases
- No code changes were required, only dependency management
- The fix is minimally invasive, reducing the risk of unintended side effects

### Security Impact

This change eliminates the vulnerable protobuf-java 3.25.1 from our dependency tree, resolving the security vulnerability without affecting application functionality.
https://nexus-iq.visa.com/assets/index.html#/vulnerabilities/CVE-2024-7254


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
