### PR TITLE
Revert "Exclude mina-core from Apache Directory LDAP API library"

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -228,10 +228,6 @@
             <version>2.1.7</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.mina</groupId>
-                    <artifactId>mina-core</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.apache.servicemix.bundles</groupId>
                     <artifactId>org.apache.servicemix.bundles.dom4j</artifactId>
                 </exclusion>


### PR DESCRIPTION
## Description

Fixes #745

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
