### PR TITLE
Add request filter for early user and query parsing

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/baseapp/BaseApp.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/baseapp/BaseApp.java
@@ -39,6 +39,8 @@ import io.trino.gateway.ha.router.RoutingManager;
 import io.trino.gateway.ha.router.RoutingRulesManager;
 import io.trino.gateway.ha.router.StochasticRoutingManager;
 import io.trino.gateway.ha.security.AuthorizedExceptionMapper;
+import io.trino.gateway.ha.security.QueryMetadataParser;
+import io.trino.gateway.ha.security.QueryUserInfoParser;
 import io.trino.gateway.proxyserver.ForProxy;
 import io.trino.gateway.proxyserver.ProxyRequestHandler;
 import io.trino.gateway.proxyserver.RouteToBackendResource;
@@ -187,6 +189,8 @@ public class BaseApp
     {
         jaxrsBinder(binder).bind(RouteToBackendResource.class);
         jaxrsBinder(binder).bind(RouterPreMatchContainerRequestFilter.class);
+        jaxrsBinder(binder).bind(QueryUserInfoParser.class);
+        jaxrsBinder(binder).bind(QueryMetadataParser.class);
         jaxrsBinder(binder).bind(ProxyRequestHandler.class);
         httpClientBinder(binder).bindHttpClient("proxy", ForProxy.class);
         httpClientBinder(binder).bindHttpClient("monitor", ForMonitor.class);

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/HttpUtils.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/HttpUtils.java
@@ -25,6 +25,8 @@ public class HttpUtils
     public static final String TRINO_UI_PATH = "/ui";
     public static final String OAUTH_PATH = "/oauth2";
     public static final String USER_HEADER = "X-Trino-User";
+    public static final String TRINO_REQUEST_USER = "trinoRequestUser";
+    public static final String TRINO_QUERY_PROPERTIES = "trinoQueryProperties";
 
     private HttpUtils() {}
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/ProxyUtils.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/ProxyUtils.java
@@ -30,6 +30,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.trino.gateway.ha.handler.HttpUtils.TRINO_QUERY_PROPERTIES;
 import static io.trino.gateway.ha.handler.HttpUtils.TRINO_UI_PATH;
 import static io.trino.gateway.ha.handler.HttpUtils.V1_QUERY_PATH;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -78,7 +79,7 @@ public final class ProxyUtils
             throw new RuntimeException("Error reading request body", e);
         }
         if (!isNullOrEmpty(queryText) && queryText.toLowerCase(ENGLISH).contains("kill_query")) {
-            TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(request, requestAnalyserClientsUseV2Format, requestAnalyserMaxBodySize);
+            TrinoQueryProperties trinoQueryProperties = (TrinoQueryProperties) request.getAttribute(TRINO_QUERY_PROPERTIES);
             return trinoQueryProperties.getQueryId();
         }
         return Optional.empty();

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
@@ -47,6 +47,7 @@ import io.trino.gateway.ha.router.GatewayBackendManager;
 import io.trino.gateway.ha.router.HaGatewayManager;
 import io.trino.gateway.ha.router.HaQueryHistoryManager;
 import io.trino.gateway.ha.router.HaResourceGroupsManager;
+import io.trino.gateway.ha.router.PathFilter;
 import io.trino.gateway.ha.router.QueryHistoryManager;
 import io.trino.gateway.ha.router.ResourceGroupsManager;
 import io.trino.gateway.ha.router.RoutingGroupSelector;
@@ -88,6 +89,7 @@ public class HaGatewayProviderModule
     private final ResourceGroupsManager resourceGroupsManager;
     private final GatewayBackendManager gatewayBackendManager;
     private final QueryHistoryManager queryHistoryManager;
+    private final PathFilter pathFilter;
 
     @Override
     protected void configure()
@@ -97,11 +99,13 @@ public class HaGatewayProviderModule
         binder().bind(GatewayBackendManager.class).toInstance(gatewayBackendManager);
         binder().bind(QueryHistoryManager.class).toInstance(queryHistoryManager);
         binder().bind(BackendStateManager.class).in(Scopes.SINGLETON);
+        binder().bind(PathFilter.class).toInstance(pathFilter);
     }
 
     public HaGatewayProviderModule(HaGatewayConfiguration configuration)
     {
         this.configuration = requireNonNull(configuration, "configuration is null");
+        pathFilter = new PathFilter(configuration.getStatementPaths(), configuration.getExtraWhitelistPaths());
         Map<String, UserConfiguration> presetUsers = configuration.getPresetUsers();
 
         oauthManager = getOAuthManager(configuration);

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/PathFilter.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/PathFilter.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.gateway.ha.handler.HttpUtils.OAUTH_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.TRINO_UI_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.UI_API_STATS_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.V1_INFO_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.V1_NODE_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.V1_QUERY_PATH;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A filter component that determines whether a given path should be whitelisted
+ * for routing to Trino clusters.
+ */
+@Singleton
+public class PathFilter
+{
+    private final Set<String> statementPaths;
+    private final List<Pattern> extraWhitelistPatterns;
+
+    @Inject
+    public PathFilter(
+            List<String> statementPaths,
+            List<String> extraWhitelistPaths)
+    {
+        this.statementPaths = Set.copyOf(requireNonNull(statementPaths, "Required configuration 'statementPaths' can't be null"));
+        this.extraWhitelistPatterns = requireNonNull(extraWhitelistPaths, "extraWhitelistPaths cannot be null").stream()
+                .map(pattern -> {
+                    try {
+                        return Pattern.compile(pattern);
+                    }
+                    catch (PatternSyntaxException e) {
+                        throw new IllegalArgumentException("Invalid regex pattern: " + pattern, e);
+                    }
+                })
+                .collect(toImmutableList());
+    }
+
+    /**
+     * Determines if the given path is whitelisted for routing to backend.
+     *
+     * @param path the request path to check
+     * @return true if the path should be routed to backend, false otherwise
+     */
+    public boolean isPathWhiteListed(String path)
+    {
+        return statementPaths.stream().anyMatch(path::startsWith)
+                || path.startsWith(V1_QUERY_PATH)
+                || path.startsWith(TRINO_UI_PATH)
+                || path.startsWith(V1_INFO_PATH)
+                || path.startsWith(V1_NODE_PATH)
+                || path.startsWith(UI_API_STATS_PATH)
+                || path.startsWith(OAUTH_PATH)
+                || extraWhitelistPatterns.stream().anyMatch(pattern -> pattern.matcher(path).matches());
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/QueryMetadataParser.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/QueryMetadataParser.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.security;
+
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.config.RequestAnalyzerConfig;
+import io.trino.gateway.ha.router.PathFilter;
+import io.trino.gateway.ha.router.TrinoQueryProperties;
+import io.trino.gateway.ha.security.util.GatewayFilterPriorities;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.PreMatching;
+import org.glassfish.jersey.server.ContainerRequest;
+
+import java.io.IOException;
+
+import static io.trino.gateway.ha.handler.HttpUtils.TRINO_QUERY_PROPERTIES;
+
+/**
+ *
+ * This filter parses the query statement and stores the TrinoQueryProperties object
+ * as a property to be accessed in the later processing
+ */
+@PreMatching
+@Priority(GatewayFilterPriorities.PRE_AUTHORIZATION)
+public class QueryMetadataParser
+        implements ContainerRequestFilter
+{
+    private static final Logger log = Logger.get(QueryMetadataParser.class);
+    private static final int MAX_QUERY_TEXT_LOG_LENGTH = 100;
+    private final boolean isAnalyzeRequest;
+    private final boolean isClientsUseV2Format;
+    private final int maxBodySize;
+    private final PathFilter pathFilter;
+
+    @Inject
+    public QueryMetadataParser(HaGatewayConfiguration config, PathFilter pathFilter)
+    {
+        RequestAnalyzerConfig analyzerConfig = config.getRequestAnalyzerConfig();
+        this.isAnalyzeRequest = analyzerConfig.isAnalyzeRequest();
+        this.isClientsUseV2Format = analyzerConfig.isClientsUseV2Format();
+        this.maxBodySize = analyzerConfig.getMaxBodySize();
+        this.pathFilter = pathFilter;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext)
+            throws IOException
+    {
+        String path = requestContext.getUriInfo().getRequestUri().getPath();
+        if (path == null || !isAnalyzeRequest || !pathFilter.isPathWhiteListed(path)) {
+            return;
+        }
+
+        log.debug("Processing query metadata for path: %s", path);
+        // Buffer the entity (aka body of the request) for future reads during request processing
+        ContainerRequest jerseyRequest = (ContainerRequest) requestContext;
+        jerseyRequest.bufferEntity();
+
+        TrinoQueryProperties queryProps;
+        try {
+            queryProps = new TrinoQueryProperties(requestContext, isClientsUseV2Format, maxBodySize);
+        }
+        catch (Exception ex) {
+            log.warn(ex, "Failed to parse query properties for query text: [%s]. Error: %s. Using empty properties.",
+                    getQueryTextForLogging(requestContext), ex.getMessage());
+            queryProps = new TrinoQueryProperties();
+        }
+
+        requestContext.setProperty(TRINO_QUERY_PROPERTIES, queryProps);
+    }
+
+    private String getQueryTextForLogging(ContainerRequestContext requestContext)
+    {
+        try {
+            ContainerRequest jerseyRequest = (ContainerRequest) requestContext;
+
+            String body = jerseyRequest.readEntity(String.class);
+            if (body == null || body.isEmpty()) {
+                return "<empty>";
+            }
+            else if (body.length() > MAX_QUERY_TEXT_LOG_LENGTH) {
+                return body.substring(0, MAX_QUERY_TEXT_LOG_LENGTH) + "...";
+            }
+
+            return body;
+        }
+
+        catch (Exception e) {
+            log.error(e, "unable to read query text");
+            return "<error reading query>";
+        }
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/QueryUserInfoParser.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/QueryUserInfoParser.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.gateway.ha.security;
+
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.config.RequestAnalyzerConfig;
+import io.trino.gateway.ha.router.PathFilter;
+import io.trino.gateway.ha.router.TrinoRequestUser;
+import io.trino.gateway.ha.security.util.GatewayFilterPriorities;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.PreMatching;
+
+import java.io.IOException;
+
+import static io.trino.gateway.ha.handler.HttpUtils.TRINO_REQUEST_USER;
+
+/**
+ * A filter which parses and extracts Trino user identity from incoming request headers
+ * and stores it in the request context property TRINO_REQUEST_USER
+ * for downstream filters and handlers to use.
+ */
+
+@PreMatching
+@Priority(GatewayFilterPriorities.PRE_AUTHENTICATION)
+public class QueryUserInfoParser
+        implements ContainerRequestFilter
+{
+    private static final Logger log = Logger.get(QueryUserInfoParser.class);
+    private final String tokenUserField;
+    private final String oauthTokenInfoUrl;
+    private final PathFilter pathFilter;
+
+    @Inject
+    public QueryUserInfoParser(HaGatewayConfiguration config, PathFilter pathFilter)
+    {
+        RequestAnalyzerConfig requestAnalyzerConfig = config.getRequestAnalyzerConfig();
+        this.tokenUserField = requestAnalyzerConfig.getTokenUserField();
+        this.oauthTokenInfoUrl = requestAnalyzerConfig.getOauthTokenInfoUrl();
+        this.pathFilter = pathFilter;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext)
+            throws IOException
+    {
+        String path = requestContext.getUriInfo().getRequestUri().getPath();
+        if (!pathFilter.isPathWhiteListed(path)) {
+            return;
+        }
+
+        RequestAnalyzerConfig requestAnalyzerConfig = new RequestAnalyzerConfig();
+        requestAnalyzerConfig.setTokenUserField(tokenUserField);
+        requestAnalyzerConfig.setOauthTokenInfoUrl(oauthTokenInfoUrl);
+
+        TrinoRequestUser user = new TrinoRequestUser.TrinoRequestUserProvider(requestAnalyzerConfig).getInstance(requestContext);
+        requestContext.setProperty(TRINO_REQUEST_USER, user);
+        log.debug("Parsed user %s", user.getUser().orElse("None"));
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/util/GatewayFilterPriorities.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/util/GatewayFilterPriorities.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.security.util;
+
+public final class GatewayFilterPriorities
+{
+    private GatewayFilterPriorities() {}
+
+    public static final int PRE_AUTHENTICATION = 500;
+    public static final int PRE_AUTHORIZATION = 1500;
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/RouterPreMatchContainerRequestFilter.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/RouterPreMatchContainerRequestFilter.java
@@ -14,15 +14,13 @@
 package io.trino.gateway.proxyserver;
 
 import com.google.inject.Inject;
-import io.trino.gateway.ha.handler.RoutingTargetHandler;
+import io.trino.gateway.ha.router.PathFilter;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.PreMatching;
 
 import java.io.IOException;
 import java.net.URI;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * This pre-matching ContainerRequestFilter catches all requests and forwards
@@ -35,19 +33,19 @@ public class RouterPreMatchContainerRequestFilter
 {
     public static final String ROUTE_TO_BACKEND = "/trino-gateway/internal/route_to_backend";
 
-    private final RoutingTargetHandler routingTargetHandler;
+    private final PathFilter pathFilter;
 
     @Inject
-    public RouterPreMatchContainerRequestFilter(RoutingTargetHandler routingTargetHandler)
+    public RouterPreMatchContainerRequestFilter(PathFilter pathFilter)
     {
-        this.routingTargetHandler = requireNonNull(routingTargetHandler);
+        this.pathFilter = pathFilter;
     }
 
     @Override
     public void filter(ContainerRequestContext request)
             throws IOException
     {
-        if (routingTargetHandler.isPathWhiteListed(request.getUriInfo().getRequestUri().getPath())) {
+        if (pathFilter.isPathWhiteListed(request.getUriInfo().getRequestUri().getPath())) {
             request.setRequestUri(URI.create(ROUTE_TO_BACKEND));
         }
     }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestPathFilter.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestPathFilter.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.trino.gateway.ha.handler.HttpUtils.OAUTH_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.TRINO_UI_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.UI_API_STATS_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.V1_INFO_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.V1_NODE_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.V1_QUERY_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.V1_STATEMENT_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestPathFilter
+{
+    private PathFilter pathFilter;
+
+    TestPathFilter()
+    {
+        List<String> statementPaths = ImmutableList.of(V1_STATEMENT_PATH, "/v2/statement");
+        List<String> extraWhitelistPaths = ImmutableList.of(
+                "/api/v1/custom/.*",
+                "/health/.*",
+                "/metrics");
+        pathFilter = new PathFilter(statementPaths, extraWhitelistPaths);
+    }
+
+    @Test
+    void testHardcodedTrinoQueryPath()
+    {
+        assertThat(pathFilter.isPathWhiteListed(V1_QUERY_PATH)).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(V1_QUERY_PATH + "/query123")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(V1_QUERY_PATH + "/query123/status")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(TRINO_UI_PATH)).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(TRINO_UI_PATH + "/query.html")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(TRINO_UI_PATH + "/assets/app.js")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(V1_INFO_PATH)).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(V1_INFO_PATH + "/status")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(V1_NODE_PATH)).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(V1_NODE_PATH + "/node123")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(V1_NODE_PATH + "/node123/status")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(UI_API_STATS_PATH)).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(UI_API_STATS_PATH + "/running")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(UI_API_STATS_PATH + "/completed")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(OAUTH_PATH)).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(OAUTH_PATH + "/callback")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(OAUTH_PATH + "/token")).isTrue();
+    }
+
+    @Test
+    void testConfiguredStatementPaths()
+    {
+        // Test V1 statement path
+        assertThat(pathFilter.isPathWhiteListed(V1_STATEMENT_PATH)).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(V1_STATEMENT_PATH + "/executing")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(V1_STATEMENT_PATH + "/queued")).isTrue();
+
+        // Test V2 statement path (from our configuration)
+        assertThat(pathFilter.isPathWhiteListed("/v2/statement")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed("/v2/statement/query456")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed("/v2/statement/batch")).isTrue();
+    }
+
+    @Test
+    void testDynamicRegexPaths()
+    {
+        // Test custom API regex pattern "/api/v1/custom/.*"
+        assertThat(pathFilter.isPathWhiteListed("/api/v1/custom/")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed("/api/v1/custom/users")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed("/api/v1/custom/users/123")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed("/api/v1/custom/reports/daily")).isTrue();
+
+        // Test health check regex pattern "/health/.*"
+        assertThat(pathFilter.isPathWhiteListed("/health/")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed("/health/status")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed("/health/ready")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed("/health/live")).isTrue();
+
+        // Test exact match for metrics
+        assertThat(pathFilter.isPathWhiteListed("/metrics")).isTrue();
+    }
+
+    @Test
+    void testNonWhitelistedPaths()
+    {
+        assertThat(pathFilter.isPathWhiteListed("/v3/statement")).isFalse(); // Not in our statement paths
+        assertThat(pathFilter.isPathWhiteListed("/api/v2/custom/users")).isFalse(); // Doesn't match v1 pattern
+        assertThat(pathFilter.isPathWhiteListed("/status")).isFalse(); // Not health/status
+        assertThat(pathFilter.isPathWhiteListed("/metrics/extra")).isFalse(); // metrics is exact match only
+        assertThat(pathFilter.isPathWhiteListed("")).isFalse(); // Empty path
+        assertThat(pathFilter.isPathWhiteListed("/")).isFalse(); // Root path
+    }
+
+    @Test
+    void testEdgeCases()
+    {
+        // Test case sensitivity
+        assertThat(pathFilter.isPathWhiteListed("/V1/query")).isFalse(); // Case sensitive
+        assertThat(pathFilter.isPathWhiteListed("/API/v1/custom/test")).isFalse(); // Case sensitive
+
+        // Test partial matches
+        assertThat(pathFilter.isPathWhiteListed("/v1/quer")).isFalse(); // Partial match of hardcoded path
+        assertThat(pathFilter.isPathWhiteListed("/api/v1/custo")).isFalse(); // Partial match of regex
+    }
+
+    @Test
+    void testRegexPattern()
+    {
+        List<String> complexStatementPaths = ImmutableList.of(V1_STATEMENT_PATH);
+        List<String> complexRegexPaths = ImmutableList.of(
+                "/api/v[1-9]/.*");
+        PathFilter complexFilter = new PathFilter(complexStatementPaths, complexRegexPaths);
+
+        // Test version pattern
+        assertThat(complexFilter.isPathWhiteListed("/api/v1/users")).isTrue();
+        assertThat(complexFilter.isPathWhiteListed("/api/v2/data")).isTrue();
+        assertThat(complexFilter.isPathWhiteListed("/api/v9/reports")).isTrue();
+        assertThat(complexFilter.isPathWhiteListed("/api/v0/test")).isFalse(); // v0 not in [1-9]
+        assertThat(complexFilter.isPathWhiteListed("/api/v10/test")).isFalse(); // v10 not single digit
+    }
+
+    @Test
+    void testEmptyConfiguration()
+    {
+        // Test PathFilter with empty lists
+        PathFilter emptyFilter = new PathFilter(ImmutableList.of(), ImmutableList.of());
+
+        // Should still allow hardcoded paths
+        assertThat(emptyFilter.isPathWhiteListed(V1_QUERY_PATH)).isTrue();
+        assertThat(emptyFilter.isPathWhiteListed(TRINO_UI_PATH)).isTrue();
+        assertThat(emptyFilter.isPathWhiteListed(V1_INFO_PATH)).isTrue();
+        assertThat(emptyFilter.isPathWhiteListed(OAUTH_PATH)).isTrue();
+
+        // Should not allow any custom paths
+        assertThat(emptyFilter.isPathWhiteListed(V1_STATEMENT_PATH)).isFalse();
+        assertThat(emptyFilter.isPathWhiteListed("/custom/path")).isFalse();
+    }
+
+    @Test
+    void testStatementPathsOnly()
+    {
+        // Test PathFilter with only statement paths, no regex patterns
+        PathFilter statementOnlyFilter = new PathFilter(
+                ImmutableList.of(V1_STATEMENT_PATH, "/v2/statement", "/custom/execute"),
+                ImmutableList.of());
+
+        // Should allow hardcoded paths
+        assertThat(statementOnlyFilter.isPathWhiteListed(V1_QUERY_PATH)).isTrue();
+        assertThat(statementOnlyFilter.isPathWhiteListed(TRINO_UI_PATH)).isTrue();
+
+        // Should allow configured statement paths
+        assertThat(statementOnlyFilter.isPathWhiteListed(V1_STATEMENT_PATH)).isTrue();
+        assertThat(statementOnlyFilter.isPathWhiteListed("/v2/statement")).isTrue();
+        assertThat(statementOnlyFilter.isPathWhiteListed("/custom/execute")).isTrue();
+        assertThat(statementOnlyFilter.isPathWhiteListed("/custom/execute/batch")).isTrue();
+
+        // Should not allow other paths
+        assertThat(statementOnlyFilter.isPathWhiteListed("/api/custom")).isFalse();
+        assertThat(statementOnlyFilter.isPathWhiteListed("/health")).isFalse();
+    }
+
+    @Test
+    void testInvalidRegexFilter()
+    {
+        List<String> statementPaths = ImmutableList.of(V1_STATEMENT_PATH, "/v2/statement");
+        List<String> extraWhitelistPaths = ImmutableList.of(
+                "[/api/v1/custom/.*");
+        assertThatThrownBy(() -> {
+            PathFilter invalidRegex = new PathFilter(statementPaths, extraWhitelistPaths);
+            invalidRegex.isPathWhiteListed("/api/v1/custom");
+        }).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testDefaultHaConfigurationForPaths()
+    {
+        HaGatewayConfiguration configuration = new HaGatewayConfiguration();
+        PathFilter filter = new PathFilter(configuration.getStatementPaths(),
+                configuration.getExtraWhitelistPaths());
+
+        assertThat(filter.isPathWhiteListed(V1_STATEMENT_PATH)).isTrue();
+        assertThat(filter.isPathWhiteListed(V1_STATEMENT_PATH + "/executing")).isTrue();
+        assertThat(filter.isPathWhiteListed(V1_STATEMENT_PATH + "/queued")).isTrue();
+        assertThat(filter.isPathWhiteListed(V1_QUERY_PATH)).isTrue();
+        assertThat(filter.isPathWhiteListed(TRINO_UI_PATH)).isTrue();
+        assertThat(filter.isPathWhiteListed(OAUTH_PATH)).isTrue();
+
+        assertThat(filter.isPathWhiteListed("/v2/statement")).isFalse();
+    }
+
+    @Test
+    void testDefaultHaConfigurationNullPaths()
+    {
+        HaGatewayConfiguration configuration = new HaGatewayConfiguration();
+
+        assertThatThrownBy(() -> {
+            new PathFilter(null,
+                    configuration.getExtraWhitelistPaths());
+        }).isInstanceOf(NullPointerException.class);
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestQueryMetadataParser.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestQueryMetadataParser.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.security;
+
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.config.RequestAnalyzerConfig;
+import io.trino.gateway.ha.handler.HttpUtils;
+import io.trino.gateway.ha.router.PathFilter;
+import io.trino.gateway.ha.router.TrinoQueryProperties;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriInfo;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+
+import static io.trino.gateway.ha.handler.HttpUtils.TRINO_QUERY_PROPERTIES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+final class TestQueryMetadataParser
+{
+    private QueryMetadataParser filter;
+    private RequestAnalyzerConfig requestAnalyzerConfig;
+    private PathFilter pathFilter;
+
+    TestQueryMetadataParser()
+    {
+        HaGatewayConfiguration config = new HaGatewayConfiguration();
+        requestAnalyzerConfig = new RequestAnalyzerConfig();
+        requestAnalyzerConfig.setAnalyzeRequest(true);
+        config.setRequestAnalyzerConfig(requestAnalyzerConfig);
+        pathFilter = new PathFilter(config.getStatementPaths(), config.getExtraWhitelistPaths());
+        filter = new QueryMetadataParser(config, pathFilter);
+    }
+
+    @Test
+    void testFilterSetsTrinoQueryPropertiesWithEntityBody()
+            throws Exception
+    {
+        ContainerRequestContext requestContext = mock(ContainerRequest.class);
+        when(requestContext.getMethod()).thenReturn("POST");
+
+        UriInfo uriInfo = mock(ExtendedUriInfo.class);
+        try {
+            when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost" + HttpUtils.V1_STATEMENT_PATH));
+        }
+        catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+        when(requestContext.getUriInfo()).thenReturn(uriInfo);
+
+        MediaType mediaType = new MediaType("application", "json", java.util.Map.of("charset", "UTF-8"));
+        when(requestContext.getMediaType()).thenReturn(mediaType);
+
+        String query = "Select xyz from cat1.schema1.table1";
+        InputStream entityStream = new ByteArrayInputStream(query.getBytes(StandardCharsets.UTF_8));
+        when(requestContext.getEntityStream()).thenReturn(entityStream);
+        when(requestContext.hasEntity()).thenReturn(true);
+        filter.filter(requestContext);
+
+        ArgumentCaptor<TrinoQueryProperties> captor = ArgumentCaptor.forClass(TrinoQueryProperties.class);
+        verify(requestContext).setProperty(eq(TRINO_QUERY_PROPERTIES), captor.capture());
+        verify((ContainerRequest) requestContext).bufferEntity();
+        verify(requestContext).getEntityStream();
+    }
+
+    @Test
+    void testFilterSetsTrinoQueryPropertiesWithNoV1Statement()
+            throws Exception
+    {
+        ContainerRequestContext requestContext = mock(ContainerRequest.class);
+        when(requestContext.getMethod()).thenReturn("POST");
+
+        UriInfo uriInfo = mock(ExtendedUriInfo.class);
+        try {
+            when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost" + HttpUtils.OAUTH_PATH));
+        }
+        catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+        when(requestContext.getUriInfo()).thenReturn(uriInfo);
+
+        MediaType mediaType = new MediaType("application", "json", java.util.Map.of("charset", "UTF-8"));
+        when(requestContext.getMediaType()).thenReturn(mediaType);
+
+        String query = "Select xyz from cat1.schema1.table1";
+        InputStream entityStream = new ByteArrayInputStream(query.getBytes(StandardCharsets.UTF_8));
+        when(requestContext.getEntityStream()).thenReturn(entityStream);
+        when(requestContext.hasEntity()).thenReturn(true);
+        filter.filter(requestContext);
+
+        ArgumentCaptor<TrinoQueryProperties> captor = ArgumentCaptor.forClass(TrinoQueryProperties.class);
+        verify(requestContext).setProperty(eq(TRINO_QUERY_PROPERTIES), captor.capture());
+        verify((ContainerRequest) requestContext).bufferEntity();
+        verify(requestContext).getEntityStream();
+    }
+
+    @Test
+    void testFilterSetsTrinoQueryPropertiesWithNoMedia()
+            throws Exception
+    {
+        ContainerRequestContext requestContext = mock(ContainerRequest.class);
+        when(requestContext.getMethod()).thenReturn("POST");
+
+        UriInfo uriInfo = mock(ExtendedUriInfo.class);
+        try {
+            when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost" + HttpUtils.V1_STATEMENT_PATH));
+        }
+        catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+        when(requestContext.getUriInfo()).thenReturn(uriInfo);
+
+        String query = "Select xyz from cat1.schema1.table1";
+        InputStream entityStream = new ByteArrayInputStream(query.getBytes(StandardCharsets.UTF_8));
+        when(requestContext.getEntityStream()).thenReturn(entityStream);
+        when(requestContext.hasEntity()).thenReturn(true);
+        filter.filter(requestContext);
+
+        ArgumentCaptor<TrinoQueryProperties> captor = ArgumentCaptor.forClass(TrinoQueryProperties.class);
+        verify(requestContext).setProperty(eq(TRINO_QUERY_PROPERTIES), captor.capture());
+        TrinoQueryProperties queryProperties = (TrinoQueryProperties) requestContext.getProperty(TRINO_QUERY_PROPERTIES);
+        assertThat(queryProperties).isEqualTo(null);
+        verify((ContainerRequest) requestContext).bufferEntity();
+    }
+
+    @Test
+    void testFilterSetsTrinoQueryPropertiesWithNoQueryText()
+            throws Exception
+    {
+        ContainerRequestContext requestContext = mock(ContainerRequest.class);
+        when(requestContext.getMethod()).thenReturn("POST");
+
+        UriInfo uriInfo = mock(ExtendedUriInfo.class);
+        try {
+            when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost" + HttpUtils.V1_STATEMENT_PATH));
+        }
+        catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+        when(requestContext.getUriInfo()).thenReturn(uriInfo);
+
+        MediaType mediaType = new MediaType("application", "json", java.util.Map.of("charset", "UTF-8"));
+        when(requestContext.getMediaType()).thenReturn(mediaType);
+
+        String query = "";
+        InputStream entityStream = new ByteArrayInputStream(query.getBytes(StandardCharsets.UTF_8));
+        when(requestContext.getEntityStream()).thenReturn(entityStream);
+        when(requestContext.hasEntity()).thenReturn(true);
+        filter.filter(requestContext);
+
+        ArgumentCaptor<TrinoQueryProperties> captor = ArgumentCaptor.forClass(TrinoQueryProperties.class);
+        verify(requestContext).setProperty(eq(TRINO_QUERY_PROPERTIES), captor.capture());
+        verify((ContainerRequest) requestContext).bufferEntity();
+        verify(requestContext).getEntityStream();
+
+        TrinoQueryProperties queryProperties = (TrinoQueryProperties) requestContext.getProperty(TRINO_QUERY_PROPERTIES);
+        assertThat(queryProperties).isEqualTo(null);
+    }
+
+    @Test
+    void testFilterSetsTrinoQueryPropertiesWithNoPostPayload()
+            throws Exception
+    {
+        ContainerRequestContext requestContext = mock(ContainerRequest.class);
+        when(requestContext.getMethod()).thenReturn("POST");
+
+        UriInfo uriInfo = mock(ExtendedUriInfo.class);
+        try {
+            when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost" + HttpUtils.V1_STATEMENT_PATH));
+        }
+        catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+        when(requestContext.getUriInfo()).thenReturn(uriInfo);
+
+        MediaType mediaType = new MediaType("application", "json", java.util.Map.of("charset", "UTF-8"));
+        when(requestContext.getMediaType()).thenReturn(mediaType);
+
+        filter.filter(requestContext);
+
+        ArgumentCaptor<TrinoQueryProperties> captor = ArgumentCaptor.forClass(TrinoQueryProperties.class);
+        verify(requestContext).setProperty(eq(TRINO_QUERY_PROPERTIES), captor.capture());
+        verify((ContainerRequest) requestContext).bufferEntity();
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestQueryUserInfoParser.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestQueryUserInfoParser.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.security;
+
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.config.RequestAnalyzerConfig;
+import io.trino.gateway.ha.handler.HttpUtils;
+import io.trino.gateway.ha.router.PathFilter;
+import io.trino.gateway.ha.router.TrinoRequestUser;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriInfo;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.net.URI;
+import java.util.Base64;
+
+import static io.trino.gateway.ha.handler.HttpUtils.V1_STATEMENT_PATH;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+final class TestQueryUserInfoParser
+{
+    private QueryUserInfoParser filter;
+
+    TestQueryUserInfoParser()
+    {
+        HaGatewayConfiguration config = new HaGatewayConfiguration();
+        RequestAnalyzerConfig requestAnalyzerConfig = new RequestAnalyzerConfig();
+        requestAnalyzerConfig.setAnalyzeRequest(true);
+        config.setRequestAnalyzerConfig(requestAnalyzerConfig);
+
+        PathFilter pathFilter = new PathFilter(config.getStatementPaths(), config.getExtraWhitelistPaths());
+
+        filter = new QueryUserInfoParser(config, pathFilter);
+    }
+
+    @Test
+    void testFilterSetsQueryUserInfo()
+            throws Exception
+    {
+        ContainerRequestContext requestContext = mock(ContainerRequest.class);
+        when(requestContext.getMethod()).thenReturn("POST");
+
+        UriInfo uriInfo = mock(ExtendedUriInfo.class);
+        when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost" + V1_STATEMENT_PATH));
+        when(requestContext.getUriInfo()).thenReturn(uriInfo);
+
+        MediaType mediaType = new MediaType("application", "json", java.util.Map.of("charset", "UTF-8"));
+        when(requestContext.getMediaType()).thenReturn(mediaType);
+
+        String encodedUsernamePassword = Base64.getEncoder().encodeToString("MrXYZ:OutInTheOpen".getBytes(UTF_8));
+        when(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Basic " + encodedUsernamePassword);
+
+        filter.filter(requestContext);
+
+        ArgumentCaptor<TrinoRequestUser> userCaptor = ArgumentCaptor.forClass(TrinoRequestUser.class);
+        verify(requestContext).setProperty(eq(HttpUtils.TRINO_REQUEST_USER), userCaptor.capture());
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/util/QueryRequestMock.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/util/QueryRequestMock.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.util;
+
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.config.RequestAnalyzerConfig;
+import io.trino.gateway.ha.handler.HttpUtils;
+import io.trino.gateway.ha.router.PathFilter;
+import io.trino.gateway.ha.router.TrinoQueryProperties;
+import io.trino.gateway.ha.router.TrinoRequestUser;
+import io.trino.gateway.ha.security.QueryMetadataParser;
+import io.trino.gateway.ha.security.QueryUserInfoParser;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.UriInfo;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.mockito.ArgumentCaptor;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+
+import static io.trino.gateway.ha.handler.HttpUtils.TRINO_QUERY_PROPERTIES;
+import static io.trino.gateway.ha.handler.HttpUtils.TRINO_REQUEST_USER;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class QueryRequestMock
+{
+    private RequestAnalyzerConfig requestAnalyzerConfig = new RequestAnalyzerConfig();
+    private ContainerRequestContext requestContext = mock(ContainerRequest.class);
+    private HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+
+    private void setDefaultMockParams()
+    {
+        when(requestContext.getMethod()).thenReturn("POST");
+        when(mockRequest.getMethod()).thenReturn(HttpMethod.POST);
+        UriInfo uriInfo = mock(ExtendedUriInfo.class);
+        try {
+            when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost" + HttpUtils.V1_STATEMENT_PATH));
+        }
+        catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+        when(requestContext.getUriInfo()).thenReturn(uriInfo);
+    }
+
+    public QueryRequestMock requestAnalyzerConfig(RequestAnalyzerConfig config)
+    {
+        requestAnalyzerConfig = config;
+        return this;
+    }
+
+    public QueryRequestMock query(String query)
+            throws IOException
+    {
+        if (!query.isEmpty()) {
+            MediaType mediaType = new MediaType("application", "json", java.util.Map.of("charset", "UTF-8"));
+            when(requestContext.getMediaType()).thenReturn(mediaType);
+            InputStream entityStream = new ByteArrayInputStream(query.getBytes(StandardCharsets.UTF_8));
+            when(requestContext.getEntityStream()).thenReturn(entityStream);
+            when(requestContext.hasEntity()).thenReturn(true);
+        }
+        else {
+            when(requestContext.hasEntity()).thenReturn(false);
+        }
+
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(query.getBytes(UTF_8));
+        when(mockRequest.getMethod()).thenReturn(HttpMethod.POST);
+        when(mockRequest.getInputStream()).thenReturn(new ServletInputStream()
+        {
+            @Override
+            public boolean isFinished()
+            {
+                return byteArrayInputStream.available() > 0;
+            }
+
+            @Override
+            public boolean isReady()
+            {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener)
+            {}
+
+            @Override
+            public int read()
+                    throws IOException
+            {
+                return byteArrayInputStream.read();
+            }
+        });
+
+        when(mockRequest.getReader()).thenReturn(new BufferedReader(new StringReader(query)));
+        when(mockRequest.getQueryString()).thenReturn("");
+        return this;
+    }
+
+    public QueryRequestMock httpHeader(String name, String value)
+    {
+        when(requestContext.getHeaderString(name)).thenReturn(value);
+        when(mockRequest.getHeader(name)).thenReturn(value);
+        return this;
+    }
+
+    public QueryRequestMock httpHeaders(MultivaluedMap<String, String> headers)
+    {
+        when(requestContext.getHeaders()).thenReturn(headers);
+        return this;
+    }
+
+    public HttpServletRequest getHttpServletRequest()
+    {
+        setDefaultMockParams();
+
+        HaGatewayConfiguration config = new HaGatewayConfiguration();
+        config.setRequestAnalyzerConfig(requestAnalyzerConfig);
+
+        PathFilter pathFilter = new PathFilter(config.getStatementPaths(), config.getExtraWhitelistPaths());
+
+        QueryUserInfoParser userInfoParser = new QueryUserInfoParser(config, pathFilter);
+        try {
+            userInfoParser.filter(requestContext);
+            ArgumentCaptor<TrinoRequestUser> captorUserInfo = ArgumentCaptor.forClass(TrinoRequestUser.class);
+            verify(requestContext).setProperty(eq(TRINO_REQUEST_USER), captorUserInfo.capture());
+            when(mockRequest.getAttribute(TRINO_REQUEST_USER)).thenReturn(captorUserInfo.getValue());
+        }
+        catch (IOException ex) {
+            return null;
+        }
+
+        QueryMetadataParser queryMetadataParser = new QueryMetadataParser(config, pathFilter);
+        try {
+            if (requestAnalyzerConfig.isAnalyzeRequest()) {
+                queryMetadataParser.filter(requestContext);
+                ArgumentCaptor<TrinoQueryProperties> captor = ArgumentCaptor.forClass(TrinoQueryProperties.class);
+                verify(requestContext).setProperty(eq(TRINO_QUERY_PROPERTIES), captor.capture());
+                when(mockRequest.getAttribute(TRINO_QUERY_PROPERTIES)).thenReturn(captor.getValue());
+            }
+        }
+        catch (IOException ex) {
+            return null;
+        }
+        return mockRequest;
+    }
+}


### PR DESCRIPTION
## Description
The parsing of the user and query was happening at different places and at a later stages, this PR structures it to happen at a early stage and a single point in time. 
<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- Early Request Parsing:  New JAX-RS filters have been added to intercept incoming requests. This filter is responsible for parsing essential user and query information at the earliest stage of processing under the PRE_AUTHENTICATION and PRE_AUTHORIZATION.
- Use of ContainerRequestContext: The implementation now uses ContainerRequestContext instead of HttpServletRequest to access request details, as this is the object available within the JAX-RS filter context.
- Injecting Request Attributes: The extracted user and query information is now passed along via request attributes, making it easily accessible in the later stages of request routing

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:
