### PR TITLE
Add sorting for clusters and query history page columns

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,6 @@ ij_java_doc_align_param_comments = false
 
 [*.yml]
 indent_size = 2
+
+[*.tsx]
+indent_size = 2

--- a/webapp/src/components/cluster.tsx
+++ b/webapp/src/components/cluster.tsx
@@ -92,8 +92,16 @@ export function Cluster() {
     <>
       <Card bordered={false} className={styles.card} bodyStyle={{ padding: '10px' }}>
         <Table dataSource={backendData} pagination={false} rowKey={"name"}>
-          <Column title="Name" dataIndex="name" key="name" />
+          <Column title="Name" dataIndex="name" key="name"
+            sorter={(a, b) => {
+              if (!a || !b) return 0;
+              return a.name.localeCompare(b.name)
+            }} />
           <Column title="RoutingGroup" dataIndex="routingGroup" key="routingGroup"
+            sorter={(a, b) => {
+              if (!a || !b) return 0;
+              return a.routingGroup.localeCompare(b.routingGroup)
+            }}
             filters={
               [...new Set(backendData?.map(b => b.routingGroup))]
                 .map(routingGroup => {
@@ -108,8 +116,8 @@ export function Cluster() {
             }} />
           <Column title="ProxyToUrl" dataIndex="proxyTo" key="proxyTo" render={linkRender} />
           <Column title="ExternalUrl" dataIndex="externalUrl" key="externalUrl" render={linkRender} />
-          <Column title="Queued" dataIndex="queued" key="queued" />
-          <Column title="Running" dataIndex="running" key="running" />
+          <Column title="Queued" dataIndex="queued" key="queued" sorter={(a, b) => (!a || !b) ? 0 : a.queued - b.queued} />
+          <Column title="Running" dataIndex="running" key="running" sorter={(a, b) => (!a || !b) ? 0 : a.running - b.running} />
           <Column title="Active" dataIndex="active" key="active" render={switchRender} />
           <Column title="Status" dataIndex="status" key="status" render={statusRender}/>
           {access.hasRole(Role.ADMIN) && (

--- a/webapp/src/components/history.tsx
+++ b/webapp/src/components/history.tsx
@@ -133,13 +133,33 @@ export function History() {
           onPageChange: list,
         }}>
           <Column title="QueryId" dataIndex="queryId" key="queryId" render={linkQueryRender} />
-          <Column title="RoutingGroup" dataIndex="routingGroup" key="routingGroup" render={routingGroupRender} />
+          <Column title="RoutingGroup" dataIndex="routingGroup" key="routingGroup"
+            sorter={(a, b) => {
+              if (!a || !b) return 0;
+              return a.routingGroup.localeCompare(b.routingGroup);
+            }}
+            filters={
+                [...new Set(backendData?.map(b => b.routingGroup))]
+                        .map(routingGroup => {
+                            return {
+                                text: routingGroup,
+                                value: routingGroup
+                            }
+                        })}
+            onFilter={(value, record) => {
+                if (!record) return false;
+                return value === record.routingGroup
+            }}
+            render={routingGroupRender} />
           <Column title="Name" dataIndex="backendUrl" key="backendUrlName" render={(text: string) => <Text>{backendMapping[text]}</Text>} />
           <Column title="RoutedTo" dataIndex="externalUrl" key="externalUrl" render={linkRender} />
           <Column title="User" dataIndex="user" key="user" />
           <Column title="Source" dataIndex="source" key="source" />
           <Column title="QueryText" dataIndex="queryText" key="queryText" width={300} render={queryTextRender} />
-          <Column title="SubmissionTime" dataIndex="captureTime" key="captureTime" render={timeRender} />
+          <Column title="SubmissionTime" dataIndex="captureTime" key="captureTime" render={timeRender} sorter={(a, b) => {
+            if (!a || !b) return 0;
+            return a.captureTime - b.captureTime;
+          }} />
         </Table>
       </Card>
       <Modal


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Added sort options for clusters based on name, queued query count and running query count.
Added filter option for routingGroup and sort options for routignGroup and submission time in query history page.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Clusters page header [3 new sort icons on Name, Queued, Running]:
<img width="1699" height="120" alt="Screenshot 2025-08-19 at 11 12 21 AM" src="https://github.com/user-attachments/assets/522dd18a-20f2-48cc-ae3c-d13be7499a30" />

History Page [Sort and Filter option on RoutingGroup] - 
<img width="2123" height="350" alt="Screenshot 2025-08-19 at 11 12 40 AM" src="https://github.com/user-attachments/assets/71b3a61c-6818-4670-b695-163481d58d8a" />


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( X) Release notes are required, with the following suggested text:
