### PR TITLE
Fix timing race condition in QueryDetail equals test

### DIFF
--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/BaseExternalUrlQueryHistoryTest.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/BaseExternalUrlQueryHistoryTest.java
@@ -171,6 +171,8 @@ abstract class BaseExternalUrlQueryHistoryTest
     @Test
     void testQueryDetailEqualsAndHashCodeWithExternalUrl()
     {
+        long captureTime = System.currentTimeMillis();
+
         QueryHistoryManager.QueryDetail queryDetail1 = new QueryHistoryManager.QueryDetail();
         queryDetail1.setQueryId("equals-test-1");
         queryDetail1.setQueryText("SELECT 1");
@@ -179,7 +181,7 @@ abstract class BaseExternalUrlQueryHistoryTest
         queryDetail1.setSource("sqlWorkbench");
         queryDetail1.setRoutingGroup("adhoc");
         queryDetail1.setExternalUrl("https://external.example.com");
-        queryDetail1.setCaptureTime(System.currentTimeMillis());
+        queryDetail1.setCaptureTime(captureTime);
 
         QueryHistoryManager.QueryDetail queryDetail2 = new QueryHistoryManager.QueryDetail();
         queryDetail2.setQueryId("equals-test-1");
@@ -189,7 +191,7 @@ abstract class BaseExternalUrlQueryHistoryTest
         queryDetail2.setSource("sqlWorkbench");
         queryDetail2.setRoutingGroup("adhoc");
         queryDetail2.setExternalUrl("https://external.example.com");
-        queryDetail2.setCaptureTime(System.currentTimeMillis());
+        queryDetail2.setCaptureTime(captureTime);
 
         // Test equals
         assertThat(queryDetail1).isEqualTo(queryDetail2);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fix timing race condition in QueryDetail equals test

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Build failed in PR and I noticed there is timing issue 
<img width="1739" height="222" alt="image" src="https://github.com/user-attachments/assets/4166ce4d-a360-4eb7-b78c-f752ae5a7c0d" />
https://github.com/trinodb/trino-gateway/actions/runs/17041586772/job/48306428182?pr=721

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
