### PR TITLE
Remove unused methods for routers

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/QueryCountBasedRouter.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/QueryCountBasedRouter.java
@@ -243,20 +243,7 @@ public class QueryCountBasedRouter
         stats.runningQueryCount(stats.runningQueryCount() + 1);
     }
 
-    private synchronized Optional<String> getBackendForRoutingGroup(String routingGroup, String user)
-    {
-        Optional<LocalStats> cluster = getClusterToRoute(user, routingGroup);
-        cluster.ifPresent(c -> updateLocalStats(c, user));
-        return cluster.map(c -> c.proxyTo());
-    }
-
-    @Override
-    public String provideDefaultCluster(String user)
-    {
-        return getBackendForRoutingGroup(defaultRoutingGroup, user).orElseThrow(() -> new RouterException("did not find any cluster for the default routing group: " + defaultRoutingGroup));
-    }
-
-    public Optional<ProxyBackendConfiguration> getBackendConfigurationForRoutingGroup(String routingGroup, String user)
+    public synchronized Optional<ProxyBackendConfiguration> getBackendConfigurationForRoutingGroup(String routingGroup, String user)
     {
         Optional<LocalStats> localStats = getClusterToRoute(user, routingGroup);
         localStats.ifPresent(stats -> updateLocalStats(stats, user));
@@ -269,13 +256,6 @@ public class QueryCountBasedRouter
         return getBackendConfigurationForRoutingGroup(routingGroup, user)
                 .orElseGet(() -> getBackendConfigurationForRoutingGroup(defaultRoutingGroup, user)
                         .orElseThrow(() -> new RouterException("did not find any cluster for the default routing group: " + defaultRoutingGroup)));
-    }
-
-    @Override
-    public String provideClusterForRoutingGroup(String routingGroup, String user)
-    {
-        return getBackendForRoutingGroup(routingGroup, user)
-                .orElse(provideDefaultCluster(user));
     }
 
     @Override

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
@@ -136,11 +136,6 @@ public abstract class RoutingManager
         return backends.get(backendId);
     }
 
-    public String provideDefaultCluster(String user)
-    {
-        return provideDefaultBackendConfiguration().getProxyTo();
-    }
-
     /**
      * Performs routing to a given cluster group. This falls back to a default backend, if no scheduled
      * backend is found.
@@ -155,11 +150,6 @@ public abstract class RoutingManager
         }
         int backendId = Math.abs(RANDOM.nextInt()) % backends.size();
         return backends.get(backendId);
-    }
-
-    public String provideClusterForRoutingGroup(String routingGroup, String user)
-    {
-        return provideBackendConfiguration(routingGroup, user).getProxyTo();
     }
 
     /**

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingManagerNotFound.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingManagerNotFound.java
@@ -40,7 +40,7 @@ final class TestRoutingManagerNotFound
     void testNonExistentRoutingGroupThrowsNotFoundException()
     {
         // When requesting a non-existent routing group, an IllegalStateException should be thrown
-        assertThatThrownBy(() -> routingManager.provideClusterForRoutingGroup("non_existent_group", "user"))
+        assertThatThrownBy(() -> routingManager.provideBackendConfiguration("non_existent_group", "user"))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Number of active backends found zero");
     }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
@@ -69,7 +69,7 @@ final class TestStochasticRoutingManager
             haRoutingManager.updateBackEndHealth(backend, TrinoStatus.UNHEALTHY);
         }
 
-        assertThat(haRoutingManager.provideClusterForRoutingGroup(groupName, ""))
+        assertThat(haRoutingManager.provideBackendConfiguration(groupName, "").getProxyTo())
                 .isEqualTo("test_group0.trino.example.com");
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Remove the unused methods from the router flow.
Use the new methods in the tests
Make the `getBackendConfigurationForRoutingGroup` method thread safe like the earlier version


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
