### PR TITLE
Show cluster healthy/unhealthy status count on dashboard

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/response/DistributionResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/response/DistributionResponse.java
@@ -23,6 +23,8 @@ public class DistributionResponse
     private Integer totalBackendCount;
     private Integer offlineBackendCount;
     private Integer onlineBackendCount;
+    private Integer healthyBackendCount;
+    private Integer unhealthyBackendCount;
 
     /**
      * Total number of queries.
@@ -54,6 +56,28 @@ public class DistributionResponse
      */
     private Map<String, List<LineChart>> lineChart;
     private String startTime;
+
+    @JsonProperty
+    public Integer getHealthyBackendCount()
+    {
+        return healthyBackendCount;
+    }
+
+    public void setHealthyBackendCount(Integer healthyBackendCount)
+    {
+        this.healthyBackendCount = healthyBackendCount;
+    }
+
+    @JsonProperty
+    public Integer getUnhealthyBackendCount()
+    {
+        return unhealthyBackendCount;
+    }
+
+    public void setUnhealthyBackendCount(Integer unhealthyBackendCount)
+    {
+        this.unhealthyBackendCount = unhealthyBackendCount;
+    }
 
     @JsonProperty
     public String getStartTime()

--- a/webapp/src/components/dashboard.tsx
+++ b/webapp/src/components/dashboard.tsx
@@ -50,6 +50,14 @@ export function Dashboard() {
       value: distributionDetail?.offlineBackendCount
     },
     {
+      key: Locale.Dashboard.BackendsHealthy,
+      value: distributionDetail?.healthyBackendCount,
+    },
+    {
+      key: Locale.Dashboard.BackendsUnhealthy,
+      value: distributionDetail?.unhealthyBackendCount
+    },
+    {
       key: (
         <div className={styles.tip}>
           <span className={styles.title}>{Locale.Dashboard.QPH}</span>

--- a/webapp/src/locales/en_US.ts
+++ b/webapp/src/locales/en_US.ts
@@ -12,6 +12,8 @@ const en_US = {
     Backends: "Backends",
     BackendsOffline: "Backends offline",
     BackendsOnline: "Backends online",
+    BackendsHealthy: "Backends healthy",
+    BackendsUnhealthy: "Backends unhealthy",
     StartTime: "Started at",
     Summary: "Summary",
     QueryDistribution: "Query distribution in last hour",

--- a/webapp/src/types/dashboard.d.ts
+++ b/webapp/src/types/dashboard.d.ts
@@ -2,6 +2,8 @@ export interface  DistributionDetail {
   totalBackendCount: number;
   offlineBackendCount: number;
   onlineBackendCount: number;
+  healthyBackendCount: number;
+  unhealthyBackendCount: number;
   totalQueryCount: number;
   averageQueryCountMinute: number;
   averageQueryCountSecond: number;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Display the cluster healthy/unhealthy status count on the Dashboard

<img width="1351" height="195" alt="Screenshot 2025-08-22 at 4 47 36 PM" src="https://github.com/user-attachments/assets/fdd8625e-2eec-4723-8a39-571784f1b55b" />

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
