### PR TITLE
Add username info on Non OK HTTP Status code

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
@@ -289,7 +289,7 @@ public class ProxyRequestHandler
             }
         }
         else {
-            log.error("Non OK HTTP Status code with response [%s] , Status code [%s]", response.body(), response.statusCode());
+            log.error("Non OK HTTP Status code with response [%s] , Status code [%s], user: [%s]", response.body(), response.statusCode(), username.orElse(null));
         }
         queryDetail.setRoutingGroup(routingDestination.routingGroup());
         queryDetail.setExternalUrl(routingDestination.externalUrl());


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Currently, when Trino Gateway logs non-OK HTTP status codes, such as 401 Unauthorized, it does not include information about the user who initiated the request. This lack of context makes troubleshooting difficult, as it requires manually cross-referencing timestamps with external logs (e.g., Ingress) to identify the source of the problematic requests.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Just to include the username in the log output for these error scenarios, significantly speeding up diagnostics and reducing needed to find those users in another place.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:
