### PR TITLE
Add support for request and response compression

### DIFF
--- a/gateway-ha/src/test/java/io/trino/gateway/proxyserver/TestProxyRequestHandler.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/proxyserver/TestProxyRequestHandler.java
@@ -51,16 +51,16 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 final class TestProxyRequestHandler
 {
+    private static final String OK = "OK";
+    private static final int NOT_FOUND = 404;
+    private static final MediaType MEDIA_TYPE = MediaType.parse("application/json; charset=utf-8");
+
     private final OkHttpClient httpClient = new OkHttpClient();
     private final MockWebServer mockTrinoServer = new MockWebServer();
     private final PostgreSQLContainer postgresql = createPostgreSqlContainer();
 
     private final int routerPort = 21001 + (int) (Math.random() * 1000);
     private final int customBackendPort = 21000 + (int) (Math.random() * 1000);
-
-    private static final String OK = "OK";
-    private static final int NOT_FOUND = 404;
-    private static final MediaType MEDIA_TYPE = MediaType.parse("application/json; charset=utf-8");
 
     private final String customPutEndpoint = "/v1/custom"; // this is enabled in test-config-template.yml
     private final String healthCheckEndpoint = "/v1/info";
@@ -70,7 +70,8 @@ final class TestProxyRequestHandler
             throws Exception
     {
         prepareMockBackend(mockTrinoServer, customBackendPort, "default custom response");
-        mockTrinoServer.setDispatcher(new Dispatcher() {
+        mockTrinoServer.setDispatcher(new Dispatcher()
+        {
             @Override
             public MockResponse dispatch(RecordedRequest request)
             {
@@ -131,18 +132,18 @@ final class TestProxyRequestHandler
     {
         // A sample query longer than 200 characters to test against truncation.
         String longQuery = """
-        SELECT
-            c.customer_name,
-            c.customer_region,
-            COUNT(o.order_id) AS total_orders,
-            SUM(o.order_value) AS total_revenue
-        FROM
-            hive.sales_data.customers AS c
-        JOIN
-            hive.sales_data.orders AS o
-                ON c.customer_id = o.customer_id
-        WHERE
-            o.order_date >= date '2023-01-01'""";
+                SELECT
+                    c.customer_name,
+                    c.customer_region,
+                    COUNT(o.order_id) AS total_orders,
+                    SUM(o.order_value) AS total_revenue
+                FROM
+                    hive.sales_data.customers AS c
+                JOIN
+                    hive.sales_data.orders AS o
+                        ON c.customer_id = o.customer_id
+                WHERE
+                    o.order_date >= date '2023-01-01'""";
 
         io.airlift.http.client.Request request = preparePost()
                 .setUri(URI.create("http://localhost:" + routerPort + V1_STATEMENT_PATH))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

`Accept-Encoding` is removed when making POST request so response does not include compression.
Since client(trino-gateway) requests without It compression, trino server would return without compression (Content-Encoding).

It may depend on result, but when it seems compression is done about 51%(722->351), so approx 51% of network/memory could be saved.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

- #749 

### local test

before (add request/response header logging from main branch)
```
2025-09-10T11:28:12.860+0900    INFO    http-worker-80  io.trino.gateway.ha.handler.RoutingTargetHandler        Rerouting [http://[0:0:0:0:0:0:0:1]:8080/v1/statement]--> [http://localhost:8082/v1/statement]
2025-09-10T11:28:12.861+0900    INFO    http-worker-80  io.trino.gateway.proxyserver.ProxyRequestHandler        Request Headers:
2025-09-10T11:28:12.861+0900    INFO    http-worker-80  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [Accept] = [[*/*]]
2025-09-10T11:28:12.861+0900    INFO    http-worker-80  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [Content-Length] = [[480]]
2025-09-10T11:28:12.861+0900    INFO    http-worker-80  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [Content-Type] = [[application/json]]
2025-09-10T11:28:12.861+0900    INFO    http-worker-80  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [User-Agent] = [[curl/8.7.1]]
2025-09-10T11:28:12.861+0900    INFO    http-worker-80  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [Via] = [[HTTP/1.1 TrinoGateway]]
2025-09-10T11:28:12.861+0900    INFO    http-worker-80  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [X-Forwarded-For] = [[[0:0:0:0:0:0:0:1]]]
2025-09-10T11:28:12.861+0900    INFO    http-worker-80  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [X-Forwarded-Host] = [[localhost]]
2025-09-10T11:28:12.861+0900    INFO    http-worker-80  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [X-Forwarded-Port] = [[8080]]
2025-09-10T11:28:12.862+0900    INFO    http-worker-80  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [X-Forwarded-Proto] = [[http]]
2025-09-10T11:28:12.862+0900    INFO    http-worker-80  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [X-Trino-User] = [[lago-hive]]
2025-09-10T11:28:12.885+0900    INFO    http-client-proxy-52    io.trino.gateway.proxyserver.ProxyResponseHandler       Response Headers:
2025-09-10T11:28:12.886+0900    INFO    http-client-proxy-52    io.trino.gateway.proxyserver.ProxyResponseHandler       Header [Date] = [[Wed, 10 Sep 2025 02:28:12 GMT]]
2025-09-10T11:28:12.886+0900    INFO    http-client-proxy-52    io.trino.gateway.proxyserver.ProxyResponseHandler       Header [Vary] = [[Accept-Encoding]]
2025-09-10T11:28:12.886+0900    INFO    http-client-proxy-52    io.trino.gateway.proxyserver.ProxyResponseHandler       Header [Content-Type] = [[application/json]]
2025-09-10T11:28:12.886+0900    INFO    http-client-proxy-52    io.trino.gateway.proxyserver.ProxyResponseHandler       Header [X-Content-Type-Options] = [[nosniff]]
2025-09-10T11:28:12.886+0900    INFO    http-client-proxy-52    io.trino.gateway.proxyserver.ProxyResponseHandler       Header [Content-Length] = [[722]]
```

after
```
2025-09-10T11:20:41.950+0900    INFO    http-worker-81  io.trino.gateway.ha.handler.RoutingTargetHandler        Rerouting [http://[0:0:0:0:0:0:0:1]:8080/v1/statement]--> [http://localhost:8082/v1/statement]
2025-09-10T11:20:41.951+0900    INFO    http-worker-81  io.trino.gateway.proxyserver.ProxyRequestHandler        Request Headers:
2025-09-10T11:20:41.953+0900    INFO    http-worker-81  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [Accept] = [[*/*]]
2025-09-10T11:20:41.953+0900    INFO    http-worker-81  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [Accept-Encoding] = [[gzip, deflate, br]]
2025-09-10T11:20:41.953+0900    INFO    http-worker-81  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [Content-Length] = [[480]]
2025-09-10T11:20:41.953+0900    INFO    http-worker-81  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [Content-Type] = [[application/json]]
2025-09-10T11:20:41.953+0900    INFO    http-worker-81  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [User-Agent] = [[curl/8.7.1]]
2025-09-10T11:20:41.957+0900    INFO    http-worker-81  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [Via] = [[HTTP/1.1 TrinoGateway]]
2025-09-10T11:20:41.957+0900    INFO    http-worker-81  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [X-Forwarded-For] = [[[0:0:0:0:0:0:0:1]]]
2025-09-10T11:20:41.957+0900    INFO    http-worker-81  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [X-Forwarded-Host] = [[localhost]]
2025-09-10T11:20:41.957+0900    INFO    http-worker-81  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [X-Forwarded-Port] = [[8080]]
2025-09-10T11:20:41.957+0900    INFO    http-worker-81  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [X-Forwarded-Proto] = [[http]]
2025-09-10T11:20:41.958+0900    INFO    http-worker-81  io.trino.gateway.proxyserver.ProxyRequestHandler        Header [X-Trino-User] = [[lago-hive]]
2025-09-10T11:20:41.997+0900    INFO    http-client-proxy-52    io.trino.gateway.proxyserver.ProxyResponseHandler       Response Headers:
2025-09-10T11:20:41.998+0900    INFO    http-client-proxy-52    io.trino.gateway.proxyserver.ProxyResponseHandler       Header [Date] = [[Wed, 10 Sep 2025 02:20:41 GMT]]
2025-09-10T11:20:41.998+0900    INFO    http-client-proxy-52    io.trino.gateway.proxyserver.ProxyResponseHandler       Header [Vary] = [[Accept-Encoding]]
2025-09-10T11:20:41.998+0900    INFO    http-client-proxy-52    io.trino.gateway.proxyserver.ProxyResponseHandler       Header [Content-Type] = [[application/json]]
2025-09-10T11:20:41.998+0900    INFO    http-client-proxy-52    io.trino.gateway.proxyserver.ProxyResponseHandler       Header [X-Content-Type-Options] = [[nosniff]]
2025-09-10T11:20:41.998+0900    INFO    http-client-proxy-52    io.trino.gateway.proxyserver.ProxyResponseHandler       Header [Content-Encoding] = [[gzip]]
2025-09-10T11:20:41.998+0900    INFO    http-client-proxy-52    io.trino.gateway.proxyserver.ProxyResponseHandler       Header [Content-Length] = [[351]]

```

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
