### PR TITLE
Fix schema parsing fallthrough

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/TrinoQueryProperties.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/TrinoQueryProperties.java
@@ -95,26 +95,27 @@ import static java.util.Objects.requireNonNullElse;
 
 public class TrinoQueryProperties
 {
+    public static final String TRINO_CATALOG_HEADER_NAME = "X-Trino-Catalog";
+    public static final String TRINO_SCHEMA_HEADER_NAME = "X-Trino-Schema";
+    public static final String TRINO_PREPARED_STATEMENT_HEADER_NAME = "X-Trino-Prepared-Statement";
+
     private final Logger log = Logger.get(TrinoQueryProperties.class);
     private final boolean isClientsUseV2Format;
     private final int maxBodySize;
+    private final Optional<String> defaultCatalog;
+    private final Optional<String> defaultSchema;
+    private final ZstdDecompressor decompressor = ZstdDecompressor.create();
+
     private String body = "";
     private String queryType = "";
     private String resourceGroupQueryType = "";
     private Set<QualifiedName> tables = ImmutableSet.of();
-    private final Optional<String> defaultCatalog;
-    private final Optional<String> defaultSchema;
     private Set<String> catalogs = ImmutableSet.of();
     private Set<String> schemas = ImmutableSet.of();
     private Set<String> catalogSchemas = ImmutableSet.of();
     private boolean isNewQuerySubmission;
     private Optional<String> errorMessage = Optional.empty();
     private Optional<String> queryId = Optional.empty();
-    private final ZstdDecompressor decompressor = ZstdDecompressor.create();
-
-    public static final String TRINO_CATALOG_HEADER_NAME = "X-Trino-Catalog";
-    public static final String TRINO_SCHEMA_HEADER_NAME = "X-Trino-Schema";
-    public static final String TRINO_PREPARED_STATEMENT_HEADER_NAME = "X-Trino-Prepared-Statement";
 
     @JsonCreator
     public TrinoQueryProperties(
@@ -487,8 +488,7 @@ public class TrinoQueryProperties
     {
         List<String> nameParts = name.getParts();
         return switch (nameParts.size()) {
-            case 1 ->
-                    QualifiedName.of(defaultCatalog.orElseThrow(this::unsetDefaultExceptionSupplier), defaultSchema.orElseThrow(this::unsetDefaultExceptionSupplier), nameParts.getFirst());
+            case 1 -> QualifiedName.of(defaultCatalog.orElseThrow(this::unsetDefaultExceptionSupplier), defaultSchema.orElseThrow(this::unsetDefaultExceptionSupplier), nameParts.getFirst());
             case 2 -> QualifiedName.of(defaultCatalog.orElseThrow(this::unsetDefaultExceptionSupplier), nameParts.getFirst(), nameParts.get(1));
             case 3 -> QualifiedName.of(nameParts.getFirst(), nameParts.get(1), nameParts.get(2));
             default -> throw new RequestParsingException("Unexpected qualified name: " + name.getParts());

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestTrinoQueryProperties.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestTrinoQueryProperties.java
@@ -16,11 +16,24 @@ package io.trino.gateway.ha.router;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.json.JsonCodec;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
+import static io.trino.gateway.ha.router.TrinoQueryProperties.TRINO_CATALOG_HEADER_NAME;
+import static io.trino.gateway.ha.router.TrinoQueryProperties.TRINO_SCHEMA_HEADER_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 final class TestTrinoQueryProperties
 {
@@ -90,5 +103,400 @@ final class TestTrinoQueryProperties
         assertThat(deserializedTrinoQueryProperties.isNewQuerySubmission()).isEqualTo(trinoQueryProperties.isNewQuerySubmission());
         assertThat(deserializedTrinoQueryProperties.isQueryParsingSuccessful()).isEqualTo(trinoQueryProperties.isQueryParsingSuccessful());
         assertThat(deserializedTrinoQueryProperties.getErrorMessage()).isEqualTo(trinoQueryProperties.getErrorMessage());
+    }
+
+    @Test
+    void testCreateSchemaSinglePart()
+            throws IOException
+    {
+        String query = "CREATE SCHEMA myschema";
+        ContainerRequestContext mockRequest = prepareMockRequest(query);
+        when(mockRequest.getHeaderString(TRINO_CATALOG_HEADER_NAME)).thenReturn("default_catalog");
+        when(mockRequest.getHeaderString(TRINO_SCHEMA_HEADER_NAME)).thenReturn("default_schema");
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // Single part schema should use the default catalog
+        assertThat(trinoQueryProperties.getCatalogs()).isEqualTo(ImmutableSet.of("default_catalog"));
+        assertThat(trinoQueryProperties.getSchemas()).isEqualTo(ImmutableSet.of("myschema"));
+        assertThat(trinoQueryProperties.getCatalogSchemas()).isEqualTo(ImmutableSet.of("default_catalog.myschema"));
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testCreateSchemaTwoPart()
+            throws IOException
+    {
+        String query = "CREATE SCHEMA mycatalog.myschema";
+        ContainerRequestContext mockRequest = prepareMockRequest(query);
+        when(mockRequest.getHeaderString(TRINO_CATALOG_HEADER_NAME)).thenReturn("default_catalog");
+        when(mockRequest.getHeaderString(TRINO_SCHEMA_HEADER_NAME)).thenReturn("default_schema");
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // Two-part schema should use a specified catalog
+        assertThat(trinoQueryProperties.getCatalogs()).isEqualTo(ImmutableSet.of("mycatalog"));
+        assertThat(trinoQueryProperties.getSchemas()).isEqualTo(ImmutableSet.of("myschema"));
+        assertThat(trinoQueryProperties.getCatalogSchemas()).isEqualTo(ImmutableSet.of("mycatalog.myschema"));
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testDropSchemaSinglePart()
+            throws IOException
+    {
+        String query = "DROP SCHEMA testschema";
+        ContainerRequestContext mockRequest = prepareMockRequest(query);
+        when(mockRequest.getHeaderString(TRINO_CATALOG_HEADER_NAME)).thenReturn("test_catalog");
+        when(mockRequest.getHeaderString(TRINO_SCHEMA_HEADER_NAME)).thenReturn("test_schema");
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // Single part schema should use the default catalog
+        assertThat(trinoQueryProperties.getCatalogs()).isEqualTo(ImmutableSet.of("test_catalog"));
+        assertThat(trinoQueryProperties.getSchemas()).isEqualTo(ImmutableSet.of("testschema"));
+        assertThat(trinoQueryProperties.getCatalogSchemas()).isEqualTo(ImmutableSet.of("test_catalog.testschema"));
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testDropSchemaTwoPart()
+            throws IOException
+    {
+        String query = "DROP SCHEMA testcatalog.testschema";
+        ContainerRequestContext mockRequest = prepareMockRequest(query);
+        when(mockRequest.getHeaderString(TRINO_CATALOG_HEADER_NAME)).thenReturn("test_catalog");
+        when(mockRequest.getHeaderString(TRINO_SCHEMA_HEADER_NAME)).thenReturn("test_schema");
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // Two-part schema should use a specified catalog
+        assertThat(trinoQueryProperties.getCatalogs()).isEqualTo(ImmutableSet.of("testcatalog"));
+        assertThat(trinoQueryProperties.getSchemas()).isEqualTo(ImmutableSet.of("testschema"));
+        assertThat(trinoQueryProperties.getCatalogSchemas()).isEqualTo(ImmutableSet.of("testcatalog.testschema"));
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testShowTablesSinglePart()
+            throws IOException
+    {
+        String query = "SHOW TABLES FROM myschema";
+        ContainerRequestContext mockRequest = prepareMockRequest(query);
+        when(mockRequest.getHeaderString(TRINO_CATALOG_HEADER_NAME)).thenReturn("default_catalog");
+        when(mockRequest.getHeaderString(TRINO_SCHEMA_HEADER_NAME)).thenReturn("default_schema");
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // Single part schema should use the default catalog
+        assertThat(trinoQueryProperties.getCatalogs()).isEqualTo(ImmutableSet.of("default_catalog"));
+        assertThat(trinoQueryProperties.getSchemas()).isEqualTo(ImmutableSet.of("myschema"));
+        assertThat(trinoQueryProperties.getCatalogSchemas()).isEqualTo(ImmutableSet.of("default_catalog.myschema"));
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testShowTablesTwoPart()
+            throws IOException
+    {
+        String query = "SHOW TABLES FROM mycatalog.myschema";
+        ContainerRequestContext mockRequest = prepareMockRequest(query);
+        when(mockRequest.getHeaderString(TRINO_CATALOG_HEADER_NAME)).thenReturn("default_catalog");
+        when(mockRequest.getHeaderString(TRINO_SCHEMA_HEADER_NAME)).thenReturn("default_schema");
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // Two-part schema should use a specified catalog
+        assertThat(trinoQueryProperties.getCatalogs()).isEqualTo(ImmutableSet.of("mycatalog"));
+        assertThat(trinoQueryProperties.getSchemas()).isEqualTo(ImmutableSet.of("myschema"));
+        assertThat(trinoQueryProperties.getCatalogSchemas()).isEqualTo(ImmutableSet.of("mycatalog.myschema"));
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testSchemaQualifiedNameWithoutDefaults()
+            throws IOException
+    {
+        String query = "CREATE SCHEMA myschema";
+        ContainerRequestContext mockRequest = prepareMockRequest(query);
+        // Don't set default catalog or schema headers
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // The exception is caught and stored in errorMessage, not re-thrown
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isFalse();
+        assertThat(trinoQueryProperties.getErrorMessage()).isPresent();
+        assertThat(trinoQueryProperties.getErrorMessage().get()).contains("Name not fully qualified");
+    }
+
+    @Test
+    void testSchemaQualifiedNameWithEmptyDefaults()
+            throws IOException
+    {
+        String query = "SHOW TABLES"; // This will use empty schema optional
+        ContainerRequestContext mockRequest = prepareMockRequest(query);
+        when(mockRequest.getHeaderString(TRINO_CATALOG_HEADER_NAME)).thenReturn("test_catalog");
+        when(mockRequest.getHeaderString(TRINO_SCHEMA_HEADER_NAME)).thenReturn("test_schema");
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // When schema optional is empty, it should use defaults
+        assertThat(trinoQueryProperties.getCatalogs()).contains("test_catalog");
+        assertThat(trinoQueryProperties.getSchemas()).contains("test_schema");
+        assertThat(trinoQueryProperties.getCatalogSchemas()).contains("test_catalog.test_schema");
+    }
+
+    @Test
+    void testSchemaQualifiedNameWithInvalidParts()
+            throws IOException
+    {
+        // Note: This test demonstrates that the default case in the switch statement is
+        // reached for schemas with >2 parts, which will log an error but continue processing.
+        // Since we cannot easily mock the SQL parser to create a QualifiedName with >2 parts
+        // from a valid SQL statement, this test documents the expected behavior.
+
+        // Test that a valid two-part schema name works correctly (boundary case)
+        String query = "CREATE SCHEMA catalog.schema";
+        ContainerRequestContext mockRequest = prepareMockRequest(query);
+        when(mockRequest.getHeaderString(TRINO_CATALOG_HEADER_NAME)).thenReturn("default_catalog");
+        when(mockRequest.getHeaderString(TRINO_SCHEMA_HEADER_NAME)).thenReturn("default_schema");
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // Verify the two-part case works and doesn't fall through to default
+        assertThat(trinoQueryProperties.getCatalogs()).containsExactly("catalog");
+        assertThat(trinoQueryProperties.getSchemas()).containsExactly("schema");
+        assertThat(trinoQueryProperties.getCatalogSchemas()).containsExactly("catalog.schema");
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testSimpleJoinWithDifferentCatalogs()
+            throws IOException
+    {
+        String query = "SELECT * FROM catalog1.schema1.table1 t1 JOIN catalog2.schema2.table2 t2 ON t1.id = t2.id";
+        ContainerRequestContext mockRequest = prepareMockRequest(query);
+        when(mockRequest.getHeaderString(TRINO_CATALOG_HEADER_NAME)).thenReturn("default_catalog");
+        when(mockRequest.getHeaderString(TRINO_SCHEMA_HEADER_NAME)).thenReturn("default_schema");
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // Should extract both catalogs and schemas
+        assertThat(trinoQueryProperties.getCatalogs()).containsExactlyInAnyOrder("catalog1", "catalog2");
+        assertThat(trinoQueryProperties.getSchemas()).containsExactlyInAnyOrder("schema1", "schema2");
+        assertThat(trinoQueryProperties.getCatalogSchemas()).containsExactlyInAnyOrder("catalog1.schema1", "catalog2.schema2");
+        assertThat(trinoQueryProperties.getTables()).hasSize(2);
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testComplexJoinWithMultipleCatalogs()
+            throws IOException
+    {
+        String query = """
+                SELECT t1.name, t2.value, t3.description, t4.status
+                FROM catalog1.sales.customers t1
+                JOIN catalog1.sales.orders t2 ON t1.id = t2.customer_id
+                LEFT JOIN catalog2.inventory.products t3 ON t2.product_id = t3.id
+                RIGHT JOIN catalog3.analytics.metrics t4 ON t3.category = t4.category
+                """;
+        ContainerRequestContext mockRequest = prepareMockRequest(query);
+        when(mockRequest.getHeaderString(TRINO_CATALOG_HEADER_NAME)).thenReturn("default_catalog");
+        when(mockRequest.getHeaderString(TRINO_SCHEMA_HEADER_NAME)).thenReturn("default_schema");
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // Should extract all three catalogs and their respective schemas
+        assertThat(trinoQueryProperties.getCatalogs()).containsExactlyInAnyOrder("catalog1", "catalog2", "catalog3");
+        assertThat(trinoQueryProperties.getSchemas()).containsExactlyInAnyOrder("sales", "inventory", "analytics");
+        assertThat(trinoQueryProperties.getCatalogSchemas()).containsExactlyInAnyOrder(
+                "catalog1.sales", "catalog2.inventory", "catalog3.analytics");
+        assertThat(trinoQueryProperties.getTables()).hasSize(4);
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testMixedQualifiedNamesInJoin()
+            throws IOException
+    {
+        String query = """
+                SELECT *
+                FROM catalog1.schema1.table1 t1
+                JOIN schema2.table2 t2 ON t1.id = t2.id
+                JOIN table3 t3 ON t2.ref = t3.ref
+                """;
+        ContainerRequestContext mockRequest = prepareMockRequest(query);
+        when(mockRequest.getHeaderString(TRINO_CATALOG_HEADER_NAME)).thenReturn("default_catalog");
+        when(mockRequest.getHeaderString(TRINO_SCHEMA_HEADER_NAME)).thenReturn("default_schema");
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // Should handle mix of fully qualified, schema qualified, and unqualified names
+        assertThat(trinoQueryProperties.getCatalogs()).containsExactlyInAnyOrder("catalog1", "default_catalog");
+        assertThat(trinoQueryProperties.getSchemas()).containsExactlyInAnyOrder("schema1", "schema2", "default_schema");
+        assertThat(trinoQueryProperties.getCatalogSchemas()).containsExactlyInAnyOrder(
+                "catalog1.schema1", "default_catalog.schema2", "default_catalog.default_schema");
+        assertThat(trinoQueryProperties.getTables()).hasSize(3);
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testSubqueryJoinWithMultipleCatalogs()
+            throws IOException
+    {
+        String query = """
+                SELECT main.id, sub.total
+                FROM catalog1.sales.orders main
+                JOIN (
+                    SELECT customer_id, SUM(amount) as total
+                    FROM catalog2.billing.payments
+                    WHERE status = 'completed'
+                    GROUP BY customer_id
+                ) sub ON main.customer_id = sub.customer_id
+                WHERE main.order_date >= '2023-01-01'
+                """;
+        ContainerRequestContext mockRequest = prepareMockRequest(query);
+        when(mockRequest.getHeaderString(TRINO_CATALOG_HEADER_NAME)).thenReturn("default_catalog");
+        when(mockRequest.getHeaderString(TRINO_SCHEMA_HEADER_NAME)).thenReturn("default_schema");
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // Should extract catalogs and schemas from both main query and subquery
+        assertThat(trinoQueryProperties.getCatalogs()).containsExactlyInAnyOrder("catalog1", "catalog2");
+        assertThat(trinoQueryProperties.getSchemas()).containsExactlyInAnyOrder("sales", "billing");
+        assertThat(trinoQueryProperties.getCatalogSchemas()).containsExactlyInAnyOrder("catalog1.sales", "catalog2.billing");
+        assertThat(trinoQueryProperties.getTables()).hasSize(2);
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testUnionWithMultipleCatalogs()
+            throws IOException
+    {
+        String query = """
+                SELECT name, 'active' as status FROM catalog1.users.active_users
+                UNION ALL
+                SELECT name, 'inactive' as status FROM catalog2.users.inactive_users
+                UNION ALL
+                SELECT name, 'pending' as status FROM catalog3.admin.pending_users
+                """;
+        ContainerRequestContext mockRequest = prepareMockRequest(query);
+        when(mockRequest.getHeaderString(TRINO_CATALOG_HEADER_NAME)).thenReturn("default_catalog");
+        when(mockRequest.getHeaderString(TRINO_SCHEMA_HEADER_NAME)).thenReturn("default_schema");
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // Should extract all catalogs and schemas from UNION query
+        assertThat(trinoQueryProperties.getCatalogs()).containsExactlyInAnyOrder("catalog1", "catalog2", "catalog3");
+        assertThat(trinoQueryProperties.getSchemas()).containsExactlyInAnyOrder("users", "admin");
+        assertThat(trinoQueryProperties.getCatalogSchemas()).containsExactlyInAnyOrder(
+                "catalog1.users", "catalog2.users", "catalog3.admin");
+        assertThat(trinoQueryProperties.getTables()).hasSize(3);
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testCTEWithMultipleCatalogs()
+            throws IOException
+    {
+        String query = """
+                WITH sales_summary AS (
+                    SELECT customer_id, SUM(amount) as total_sales
+                    FROM catalog1.sales.transactions
+                    GROUP BY customer_id
+                ),
+                customer_info AS (
+                    SELECT id, name, region
+                    FROM catalog2.crm.customers
+                    WHERE active = true
+                )
+                SELECT c.name, c.region, s.total_sales
+                FROM customer_info c
+                JOIN sales_summary s ON c.id = s.customer_id
+                JOIN catalog3.geo.regions r ON c.region = r.code
+                """;
+        ContainerRequestContext mockRequest = prepareMockRequest(query);
+        when(mockRequest.getHeaderString(TRINO_CATALOG_HEADER_NAME)).thenReturn("default_catalog");
+        when(mockRequest.getHeaderString(TRINO_SCHEMA_HEADER_NAME)).thenReturn("default_schema");
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // Should extract catalogs and schemas from CTE and main query, ignoring temporary tables
+        assertThat(trinoQueryProperties.getCatalogs()).containsExactlyInAnyOrder("catalog1", "catalog2", "catalog3");
+        assertThat(trinoQueryProperties.getSchemas()).containsExactlyInAnyOrder("sales", "crm", "geo");
+        assertThat(trinoQueryProperties.getCatalogSchemas()).containsExactlyInAnyOrder(
+                "catalog1.sales", "catalog2.crm", "catalog3.geo");
+        assertThat(trinoQueryProperties.getTables()).hasSize(3); // Should not include CTE tables
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testInsertSelectWithMultipleCatalogs()
+            throws IOException
+    {
+        String query = """
+                INSERT INTO catalog1.warehouse.inventory (product_id, quantity, location)
+                SELECT p.id, s.available_qty, w.default_location
+                FROM catalog2.products.items p
+                JOIN catalog2.stock.availability s ON p.id = s.product_id
+                JOIN catalog3.locations.warehouses w ON s.warehouse_id = w.id
+                WHERE s.available_qty > 0
+                """;
+        ContainerRequestContext mockRequest = prepareMockRequest(query);
+        when(mockRequest.getHeaderString(TRINO_CATALOG_HEADER_NAME)).thenReturn("default_catalog");
+        when(mockRequest.getHeaderString(TRINO_SCHEMA_HEADER_NAME)).thenReturn("default_schema");
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // Should extract catalogs and schemas from both INSERT target and SELECT source
+        assertThat(trinoQueryProperties.getCatalogs()).containsExactlyInAnyOrder("catalog1", "catalog2", "catalog3");
+        assertThat(trinoQueryProperties.getSchemas()).containsExactlyInAnyOrder("warehouse", "products", "stock", "locations");
+        assertThat(trinoQueryProperties.getCatalogSchemas()).containsExactlyInAnyOrder(
+                "catalog1.warehouse", "catalog2.products", "catalog2.stock", "catalog3.locations");
+        assertThat(trinoQueryProperties.getTables()).hasSize(4);
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testSameCatalogDifferentSchemas()
+            throws IOException
+    {
+        String query = """
+                SELECT o.order_id, c.name, p.price
+                FROM catalog1.sales.orders o
+                JOIN catalog1.customers.profiles c ON o.customer_id = c.id
+                JOIN catalog1.products.items p ON o.product_id = p.id
+                """;
+        ContainerRequestContext mockRequest = prepareMockRequest(query);
+        when(mockRequest.getHeaderString(TRINO_CATALOG_HEADER_NAME)).thenReturn("default_catalog");
+        when(mockRequest.getHeaderString(TRINO_SCHEMA_HEADER_NAME)).thenReturn("default_schema");
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // Should have one catalog but multiple schemas
+        assertThat(trinoQueryProperties.getCatalogs()).containsExactly("catalog1");
+        assertThat(trinoQueryProperties.getSchemas()).containsExactlyInAnyOrder("sales", "customers", "products");
+        assertThat(trinoQueryProperties.getCatalogSchemas()).containsExactlyInAnyOrder(
+                "catalog1.sales", "catalog1.customers", "catalog1.products");
+        assertThat(trinoQueryProperties.getTables()).hasSize(3);
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    private ContainerRequestContext prepareMockRequest(String query)
+    {
+        ContainerRequestContext mockRequest = mock(ContainerRequestContext.class);
+        when(mockRequest.getMethod()).thenReturn(HttpMethod.POST);
+        when(mockRequest.hasEntity()).thenReturn(true);
+
+        MediaType mediaType = MediaType.valueOf("application/json; charset=UTF-8");
+        when(mockRequest.getMediaType()).thenReturn(mediaType);
+
+        InputStream entityStream = new ByteArrayInputStream(query.getBytes(StandardCharsets.UTF_8));
+        when(mockRequest.getEntityStream()).thenReturn(entityStream);
+
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        when(mockRequest.getHeaders()).thenReturn(headers);
+
+        return mockRequest;
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fixes bug where there is fallthrough when parsing schema

You can test via

```
SHOW CREATE SCHEMA information_schema
SHOW TABLES IN {db}
```

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Error log
```
java.lang.IndexOutOfBoundsException: index (1) must be less than size (1)
	at com.google.common.base.Preconditions.checkElementIndex(Preconditions.java:1372)
	at com.google.common.base.Preconditions.checkElementIndex(Preconditions.java:1354)
	at com.google.common.collect.SingletonImmutableList.get(SingletonImmutableList.java:46)
	at io.trino.gateway.ha.router.TrinoQueryProperties.setCatalogAndSchemaNameFromSchemaQualifiedName(TrinoQueryProperties.java:380)
	at io.trino.gateway.ha.router.TrinoQueryProperties.getNames(TrinoQueryProperties.java:340)
	at io.trino.gateway.ha.router.TrinoQueryProperties.processRequestBody(TrinoQueryProperties.java:201)
	at io.trino.gateway.ha.router.TrinoQueryProperties.<init>(TrinoQueryProperties.java:144)
	at io.trino.gateway.ha.router.ExternalRoutingGroupSelector.createRequestBody(ExternalRoutingGroupSelector.java:130)
	at io.trino.gateway.ha.router.ExternalRoutingGroupSelector.findRoutingGroup(ExternalRoutingGroupSelector.java:96)
	at io.trino.gateway.ha.handler.RoutingTargetHandler.getBackendFromRoutingGroup(RoutingTargetHandler.java:86)
	at io.trino.gateway.ha.handler.RoutingTargetHandler.lambda$getRoutingDestination$0(RoutingTargetHandler.java:66)
	at java.base/java.util.Optional.orElseGet(Optional.java:364)
	at io.trino.gateway.ha.handler.RoutingTargetHandler.getRoutingDestination(RoutingTargetHandler.java:66)
	at io.trino.gateway.proxyserver.RouteToBackendResource.postHandler(RouteToBackendResource.java:67)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:146)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:189)
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$VoidOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:159)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:93)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:478)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:400)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:81)
	at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:274)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)

```

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
