### PR TITLE
Fix query history search based on RoutedTo field

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/QueryHistoryRequest.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/QueryHistoryRequest.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @param page page index
  * @param size page size
  * @param user Query histories of specified user. ADMIN role is optional, other roles are mandatory.
- * @param backendUrl Optional, you can query the history based on the backendUrl.
+ * @param externalUrl Optional, you can query the history based on the externalUrl.
  * @param queryId Optional, you can query the query history based on the queryId of Trino.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -30,7 +30,7 @@ public record QueryHistoryRequest(
         @JsonProperty("page") Integer page,
         @JsonProperty("size") Integer size,
         @JsonProperty("user") String user,
-        @JsonProperty("backendUrl") String backendUrl,
+        @JsonProperty("externalUrl") String externalUrl,
         @JsonProperty("queryId") String queryId,
         @JsonProperty("source") String source)
 {

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
@@ -139,7 +139,7 @@ public class GatewayWebAppResource
                     query.page(),
                     query.size(),
                     securityContext.getUserPrincipal().getName(),
-                    query.backendUrl(),
+                    query.externalUrl(),
                     query.queryId(),
                     query.source()));
         }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
@@ -122,8 +122,8 @@ public class HaQueryHistoryManager
         if (!Strings.isNullOrEmpty(query.user())) {
             condition += " and user_name = '" + query.user() + "'";
         }
-        if (!Strings.isNullOrEmpty(query.backendUrl())) {
-            condition += " and backend_url = '" + query.backendUrl() + "'";
+        if (!Strings.isNullOrEmpty(query.externalUrl())) {
+            condition += " and external_url = '" + query.externalUrl() + "'";
         }
         if (!Strings.isNullOrEmpty(query.queryId())) {
             condition += " and query_id = '" + query.queryId() + "'";

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestObjectSerializable.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestObjectSerializable.java
@@ -123,9 +123,9 @@ final class TestObjectSerializable
             throws JsonProcessingException
     {
         assertThat(objectMapper.writeValueAsString(new QueryHistoryRequest(null, null, "user1", "url1", "query_id", "source")))
-                .contains(ImmutableList.of("\"page\":1", "\"size\":10", "user", "backendUrl", "queryId", "source"));
+                .contains(ImmutableList.of("\"page\":1", "\"size\":10", "user", "externalUrl", "queryId", "source"));
         assertThat(objectMapper.writeValueAsString(new QueryHistoryRequest(5, 6, "user1", "url1", "query_id", "source")))
-                .contains(ImmutableList.of("\"page\":5", "\"size\":6", "user", "backendUrl", "queryId", "source"));
+                .contains(ImmutableList.of("\"page\":5", "\"size\":6", "user", "externalUrl", "queryId", "source"));
     }
 
     @Test

--- a/webapp/src/components/history.tsx
+++ b/webapp/src/components/history.tsx
@@ -105,7 +105,7 @@ export function History() {
         <Form labelPosition="left"
           render={() => (
             <>
-              <Form.Select field="backendUrl" label='RoutedTo' style={{ width: 200 }} showClear placeholder={Locale.History.RoutedToTip}>
+              <Form.Select field="externalUrl" label='RoutedTo' style={{ width: 200 }} showClear placeholder={Locale.History.RoutedToTip}>
                 {backendData?.map(b => (
                   <Form.Select.Option key={b.externalUrl} value={b.externalUrl}>
                     <Tag color={'blue'} style={{ marginRight: '5px' }}>{backendMapping[b.externalUrl]}</Tag>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Searching by the routedTo field stopped working after this change - https://github.com/trinodb/trino-gateway/pull/693 
This commit fixes the issue
Form label should be externalUrl instead of backendUrl and search also should happen based on externalUrl


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
