### PR TITLE
Fix partialCancel statement path redirection

### DIFF
--- a/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestQueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestQueryIdCachingProxyHandler.java
@@ -44,7 +44,13 @@ final class TestQueryIdCachingProxyHandler
             throws IOException
     {
         List<String> statementPaths = ImmutableList.of("/v1/statement", "/custom/api/statement");
+        assertThat(extractQueryIdIfPresent("/v1/statement/queued/20200416_160256_03078_6b4yt/ye6c54db413e65c5de0e99612ab1eaabb8611a8aa/1", null, statementPaths))
+                .hasValue("20200416_160256_03078_6b4yt");
+        assertThat(extractQueryIdIfPresent("/v1/statement/scheduled/20200416_160256_03078_6b4yt/ye6c54db413e65c5de0e99612ab1eaabb8611a8aa/1", null, statementPaths))
+                .hasValue("20200416_160256_03078_6b4yt");
         assertThat(extractQueryIdIfPresent("/v1/statement/executing/20200416_160256_03078_6b4yt/ya7e884929c67cdf86207a80e7a77ab2166fa2e7b/1368", null, statementPaths))
+                .hasValue("20200416_160256_03078_6b4yt");
+        assertThat(extractQueryIdIfPresent("/v1/statement/executing/partialCancel/20200416_160256_03078_6b4yt/0/yce0e0e038758e454d22d7270de30395e19a28eb6/1", null, statementPaths))
                 .hasValue("20200416_160256_03078_6b4yt");
         assertThat(extractQueryIdIfPresent("/custom/api/statement/executing/20200416_160256_03078_6b4yt/ya7e884929c67cdf86207a80e7a77ab2166fa2e7b/1368", null, statementPaths))
                 .hasValue("20200416_160256_03078_6b4yt");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Partial cancel url path is of form `/v1/statement/executing/partialCancel/<query_id>/...`
Ref - https://github.com/trinodb/trino/blob/master/core/trino-main/src/main/java/io/trino/server/protocol/Query.java#L726

But in the code we are considering it to be of form - `/v1/statement/partialCancel/<query_id>/...` without the `executing` prefix which causes failures while extracting query id. Fixed it with some minor refactoring. 

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required, with the following suggested text:


```markdown
* bug fix: Fix partialCancel statement path redirection
```
