### PR TITLE
Expose Trino backend state via JMX

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
@@ -16,6 +16,7 @@ package io.trino.gateway.ha.module;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import io.airlift.http.client.HttpClient;
 import io.trino.gateway.ha.clustermonitor.ClusterStatsHttpMonitor;
@@ -82,7 +83,6 @@ public class HaGatewayProviderModule
     private final LbOAuthManager oauthManager;
     private final LbFormAuthManager formAuthManager;
     private final AuthorizationManager authorizationManager;
-    private final BackendStateManager backendStateConnectionManager;
     private final ResourceSecurityDynamicFeature resourceSecurityDynamicFeature;
     private final HaGatewayConfiguration configuration;
     private final ResourceGroupsManager resourceGroupsManager;
@@ -96,6 +96,7 @@ public class HaGatewayProviderModule
         binder().bind(ResourceGroupsManager.class).toInstance(resourceGroupsManager);
         binder().bind(GatewayBackendManager.class).toInstance(gatewayBackendManager);
         binder().bind(QueryHistoryManager.class).toInstance(queryHistoryManager);
+        binder().bind(BackendStateManager.class).in(Scopes.SINGLETON);
     }
 
     public HaGatewayProviderModule(HaGatewayConfiguration configuration)
@@ -108,7 +109,6 @@ public class HaGatewayProviderModule
 
         authorizationManager = new AuthorizationManager(configuration.getAuthorization(), presetUsers);
         resourceSecurityDynamicFeature = getAuthFilter(configuration);
-        backendStateConnectionManager = new BackendStateManager();
 
         GatewayCookieConfigurationPropertiesProvider gatewayCookieConfigurationPropertiesProvider = GatewayCookieConfigurationPropertiesProvider.getInstance();
         gatewayCookieConfigurationPropertiesProvider.initialize(configuration.getGatewayCookieConfiguration());
@@ -204,13 +204,6 @@ public class HaGatewayProviderModule
     public AuthorizationManager getAuthorizationManager()
     {
         return this.authorizationManager;
-    }
-
-    @Provides
-    @Singleton
-    public BackendStateManager getBackendStateConnectionManager()
-    {
-        return this.backendStateConnectionManager;
     }
 
     @Provides

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/BackendStateManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/BackendStateManager.java
@@ -13,19 +13,29 @@
  */
 package io.trino.gateway.ha.router;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
 import io.trino.gateway.ha.clustermonitor.ClusterStats;
+import io.trino.gateway.ha.clustermonitor.TrinoStatus;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
+import org.weakref.jmx.MBeanExporter;
+import org.weakref.jmx.Managed;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Objects.requireNonNull;
+
 public class BackendStateManager
 {
-    private final Map<String, ClusterStats> clusterStats;
+    private final MBeanExporter exporter;
+    private final Map<String, ClusterStats> clusterStats = new HashMap<>();
+    private final Map<String, ClusterStatsJMX> clusterStatsJMXs = new HashMap<>();
 
-    public BackendStateManager()
+    @Inject
+    public BackendStateManager(MBeanExporter exporter)
     {
-        this.clusterStats = new HashMap<>();
+        this.exporter = requireNonNull(exporter, "exporter is null");
     }
 
     public ClusterStats getBackendState(ProxyBackendConfiguration backend)
@@ -36,6 +46,83 @@ public class BackendStateManager
 
     public void updateStates(String clusterId, ClusterStats stats)
     {
+        if (!clusterStatsJMXs.containsKey(clusterId)) {
+            ClusterStatsJMX clusterStatsJMX = new ClusterStatsJMX(stats);
+            exporter.exportWithGeneratedName(
+                    clusterStatsJMX,
+                    ClusterStatsJMX.class,
+                    ImmutableMap.<String, String>builder()
+                            .put("name", "ClusterStats")
+                            .put("cluster_id", clusterId)
+                            .build());
+            clusterStatsJMXs.put(clusterId, clusterStatsJMX);
+        }
+        else {
+            clusterStatsJMXs.get(clusterId).updateFrom(stats);
+        }
         clusterStats.put(clusterId, stats);
+    }
+
+    public static class ClusterStatsJMX
+    {
+        private int runningQueryCount;
+        private int queuedQueryCount;
+        private int numWorkerNodes;
+        private TrinoStatus trinoStatus;
+
+        public ClusterStatsJMX(ClusterStats clusterStats)
+        {
+            updateFrom(clusterStats);
+        }
+
+        public void updateFrom(ClusterStats clusterStats)
+        {
+            runningQueryCount = clusterStats.runningQueryCount();
+            queuedQueryCount = clusterStats.queuedQueryCount();
+            numWorkerNodes = clusterStats.numWorkerNodes();
+            trinoStatus = clusterStats.trinoStatus();
+        }
+
+        @Managed
+        public int getRunningQueryCount()
+        {
+            return runningQueryCount;
+        }
+
+        @Managed
+        public int getQueuedQueryCount()
+        {
+            return queuedQueryCount;
+        }
+
+        @Managed
+        public int getNumWorkerNodes()
+        {
+            return numWorkerNodes;
+        }
+
+        @Managed
+        public int getTrinoStatusPending()
+        {
+            return trinoStatus == TrinoStatus.PENDING ? 1 : 0;
+        }
+
+        @Managed
+        public int getTrinoStatusHealthy()
+        {
+            return trinoStatus == TrinoStatus.HEALTHY ? 1 : 0;
+        }
+
+        @Managed
+        public int getTrinoStatusUnhealthy()
+        {
+            return trinoStatus == TrinoStatus.UNHEALTHY ? 1 : 0;
+        }
+
+        @Managed
+        public int getTrinoStatusUnknown()
+        {
+            return trinoStatus == TrinoStatus.UNKNOWN ? 1 : 0;
+        }
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaMultipleBackend.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaMultipleBackend.java
@@ -387,6 +387,20 @@ final class TestGatewayHaMultipleBackend
         throw new IllegalStateException("Trino Gateway health check failed");
     }
 
+    @Test
+    void testClusterStatsJMX()
+            throws Exception
+    {
+        Request request = new Request.Builder()
+                .url("http://localhost:" + routerPort + "/metrics")
+                .get()
+                .build();
+        Response response = httpClient.newCall(request).execute();
+        String body = response.body().string();
+        assertThat(body).contains("trino1_TrinoStatusHealthy");
+        assertThat(body).contains("trino2_TrinoStatusHealthy");
+    }
+
     @AfterAll
     void cleanup()
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Expose Trino backend state via JMX


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
JMX looks like this:
```
# TYPE io_trino_gateway_ha_router_name_ClusterStats_cluster_id_trino1_QueuedQueryCount gauge
io_trino_gateway_ha_router_name_ClusterStats_cluster_id_trino1_QueuedQueryCount 0.0
# TYPE io_trino_gateway_ha_router_name_ClusterStats_cluster_id_trino1_TrinoStatusUnknown gauge
io_trino_gateway_ha_router_name_ClusterStats_cluster_id_trino1_TrinoStatusUnknown 0.0
# TYPE io_trino_gateway_ha_router_name_ClusterStats_cluster_id_trino1_TrinoStatusHealthy gauge
io_trino_gateway_ha_router_name_ClusterStats_cluster_id_trino1_TrinoStatusHealthy 1.0
# TYPE io_trino_gateway_ha_router_name_ClusterStats_cluster_id_trino1_RunningQueryCount gauge
io_trino_gateway_ha_router_name_ClusterStats_cluster_id_trino1_RunningQueryCount 0.0
# TYPE io_trino_gateway_ha_router_name_ClusterStats_cluster_id_trino1_TrinoStatusPending gauge
io_trino_gateway_ha_router_name_ClusterStats_cluster_id_trino1_TrinoStatusPending 0.0
# TYPE io_trino_gateway_ha_router_name_ClusterStats_cluster_id_trino1_TrinoStatusUnhealthy gauge
io_trino_gateway_ha_router_name_ClusterStats_cluster_id_trino1_TrinoStatusUnhealthy 0.0
# TYPE io_trino_gateway_ha_router_name_ClusterStats_cluster_id_trino1_NumWorkerNodes gauge
io_trino_gateway_ha_router_name_ClusterStats_cluster_id_trino1_NumWorkerNodes 0.0
```

I didn't implement unregister logic, because under the current implementation `BackendStateManager.clusterStats` won't delete old Trino cluster. We may need another PR to refactor `BackendStateManager` and `*Observer` classes to support this.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes
(X) Release notes are required, with the following suggested text:

```markdown
* Expose Trino cluster state via JMX.
```

## Summary by Sourcery

Expose Trino backend state via JMX by exporting dynamic ClusterStatsJMX MBeans for each cluster and updating dependency injection to support MBeanExporter

New Features:
- Expose Trino cluster state via JMX MBeans

Enhancements:
- BackendStateManager now injects MBeanExporter and registers a ClusterStatsJMX MBean to expose running queries, queued queries, worker nodes, and status flags
- Update Guice module to bind BackendStateManager as a singleton and support MBeanExporter injection

Tests:
- Add integration test to verify JMX metrics appear on the /metrics endpoint