### PR TITLE
Add cache in HaGatewayManager

### DIFF
--- a/docs/operation.md
+++ b/docs/operation.md
@@ -81,3 +81,33 @@ taking a long time for garbage collection.
 completed initialization and is ready to serve requests. This means the initial
 connection to the database and the first round of health check on Trino clusters
 are completed. Otherwise, status code 503 is returned.
+
+## Database cache configuration
+
+Trino Gateway can cache database queries to improve performance and reduce load
+on the backend database. This also allow gateway to continue routing queries
+when the database is temporarily unavailable. Currently only the list of backend
+Trino clusters used for query routing are being cached.
+The cache can be configured using the `databaseCache` section in the config file.
+
+```yaml
+databaseCache:
+  enabled: true
+  expireAfterWrite: 60m
+  refreshAfterWrite: 5s
+```
+
+Configuration options:
+
+* `enabled` - Enable or disable the database cache. Default is `false`.
+* `expireAfterWrite` - The maximum time a cached entry is kept since it was last
+  loaded or refreshed. This ensures stale data is eventually removed.
+  If cache is not refreshed before expiration, requests will fail once the entry
+  expires (i.e. cache miss will attempt to reload data, but if the database is unavailable,
+  the request fails because there is no stale value to fall back to after
+  expiration).
+* `refreshAfterWrite` - Duration after which cache entries are eligible for
+  asynchronous refresh. When a refresh is triggered, the existing cached value
+  continues to be served while the refresh happens in the background.
+  This helps keep data fresh while serving slightly stale data to avoid blocking requests.
+

--- a/gateway-ha/src/main/java/io/trino/gateway/baseapp/BaseApp.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/baseapp/BaseApp.java
@@ -21,6 +21,7 @@ import io.airlift.log.Logger;
 import io.trino.gateway.ha.clustermonitor.ClusterMetricsStatsExporter;
 import io.trino.gateway.ha.clustermonitor.ForMonitor;
 import io.trino.gateway.ha.config.DataStoreConfiguration;
+import io.trino.gateway.ha.config.DatabaseCacheConfiguration;
 import io.trino.gateway.ha.config.HaGatewayConfiguration;
 import io.trino.gateway.ha.config.MonitorConfiguration;
 import io.trino.gateway.ha.config.RoutingConfiguration;
@@ -126,6 +127,7 @@ public class BaseApp
         binder.bind(RoutingConfiguration.class).toInstance(configuration.getRouting());
         binder.bind(DataStoreConfiguration.class).toInstance(configuration.getDataStore());
         binder.bind(MonitorConfiguration.class).toInstance(configuration.getMonitor());
+        binder.bind(DatabaseCacheConfiguration.class).toInstance(configuration.getDatabaseCache());
         registerAuthFilters(binder);
         registerResources(binder);
         registerProxyResources(binder);

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/DatabaseCacheConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/DatabaseCacheConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.config;
+
+import io.airlift.units.Duration;
+
+import java.util.concurrent.TimeUnit;
+
+public class DatabaseCacheConfiguration
+{
+    private boolean enabled;
+    private Duration expireAfterWrite = Duration.succinctDuration(60, TimeUnit.MINUTES);
+    private Duration refreshAfterWrite = Duration.succinctDuration(5, TimeUnit.SECONDS);
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
+    }
+
+    public Duration getExpireAfterWrite()
+    {
+        return expireAfterWrite;
+    }
+
+    public void setExpireAfterWrite(Duration expireAfterWrite)
+    {
+        this.expireAfterWrite = expireAfterWrite;
+    }
+
+    public Duration getRefreshAfterWrite()
+    {
+        return refreshAfterWrite;
+    }
+
+    public void setRefreshAfterWrite(Duration refreshAfterWrite)
+    {
+        this.refreshAfterWrite = refreshAfterWrite;
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/HaGatewayConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/HaGatewayConfiguration.java
@@ -42,10 +42,9 @@ public class HaGatewayConfiguration
     private List<String> statementPaths = ImmutableList.of(V1_STATEMENT_PATH);
     private boolean includeClusterHostInResponse;
     private ProxyResponseConfiguration proxyResponseConfiguration = new ProxyResponseConfiguration();
-
     private RequestAnalyzerConfig requestAnalyzerConfig = new RequestAnalyzerConfig();
-
     private UIConfiguration uiConfiguration = new UIConfiguration();
+    private DatabaseCacheConfiguration databaseCache = new DatabaseCacheConfiguration();
 
     // List of Modules with FQCN (Fully Qualified Class Name)
     private List<String> modules;
@@ -265,6 +264,16 @@ public class HaGatewayConfiguration
     public void setProxyResponseConfiguration(ProxyResponseConfiguration proxyResponseConfiguration)
     {
         this.proxyResponseConfiguration = proxyResponseConfiguration;
+    }
+
+    public DatabaseCacheConfiguration getDatabaseCache()
+    {
+        return databaseCache;
+    }
+
+    public void setDatabaseCache(DatabaseCacheConfiguration databaseCache)
+    {
+        this.databaseCache = databaseCache;
     }
 
     private void validateStatementPath(String statementPath, List<String> statementPaths)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/GatewayBackendDao.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/GatewayBackendDao.java
@@ -25,24 +25,6 @@ public interface GatewayBackendDao
 
     @SqlQuery("""
             SELECT * FROM gateway_backend
-            WHERE active = true
-            """)
-    List<GatewayBackend> findActiveBackend();
-
-    @SqlQuery("""
-            SELECT * FROM gateway_backend
-            WHERE active = true AND routing_group = :routingGroup
-            """)
-    List<GatewayBackend> findActiveBackendByRoutingGroup(String routingGroup);
-
-    @SqlQuery("""
-            SELECT * FROM gateway_backend
-            WHERE name = :name
-            """)
-    List<GatewayBackend> findByName(String name);
-
-    @SqlQuery("""
-            SELECT * FROM gateway_backend
             WHERE name = :name
             LIMIT 1
             """)

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestingJdbcConnectionManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestingJdbcConnectionManager.java
@@ -19,6 +19,8 @@ import io.trino.gateway.ha.persistence.JdbcConnectionManager;
 import org.jdbi.v3.core.Jdbi;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 public final class TestingJdbcConnectionManager
@@ -38,5 +40,26 @@ public final class TestingJdbcConnectionManager
     {
         Jdbi jdbi = HaGatewayProviderModule.createJdbi(config);
         return new JdbcConnectionManager(jdbi, config);
+    }
+
+    public static void destroyTestingDatabase(DataStoreConfiguration config)
+    {
+        String tempH2DbDirPath = config.getJdbcUrl().replace("jdbc:h2:", "").replace(";NON_KEYWORDS=NAME,VALUE", "");
+        File dbFile = Path.of(tempH2DbDirPath).toFile();
+        File parentDir = dbFile.getParentFile();
+
+        if (parentDir != null && parentDir.exists()) {
+            File[] files = parentDir.listFiles((dir, name) -> name.startsWith(dbFile.getName()));
+            if (files != null) {
+                for (File file : files) {
+                    try {
+                        Files.deleteIfExists(file.toPath());
+                    }
+                    catch (IOException e) {
+                        // Ignore deletion errors in test cleanup
+                    }
+                }
+            }
+        }
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestHaGatewayManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestHaGatewayManager.java
@@ -13,33 +13,47 @@
  */
 package io.trino.gateway.ha.router;
 
+import com.github.benmanes.caffeine.cache.Ticker;
+import io.airlift.units.Duration;
+import io.trino.gateway.ha.config.DataStoreConfiguration;
+import io.trino.gateway.ha.config.DatabaseCacheConfiguration;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 import io.trino.gateway.ha.config.RoutingConfiguration;
 import io.trino.gateway.ha.persistence.JdbcConnectionManager;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.gateway.ha.TestingJdbcConnectionManager.createTestingJdbcConnectionManager;
 import static io.trino.gateway.ha.TestingJdbcConnectionManager.dataStoreConfig;
+import static io.trino.gateway.ha.TestingJdbcConnectionManager.destroyTestingDatabase;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @TestInstance(Lifecycle.PER_CLASS)
 final class TestHaGatewayManager
 {
-    private HaGatewayManager haGatewayManager;
-
-    @BeforeAll
-    void setUp()
+    @Test
+    void testGatewayManagerWithCache()
     {
         JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager(dataStoreConfig());
-        RoutingConfiguration routingConfiguration = new RoutingConfiguration();
-        haGatewayManager = new HaGatewayManager(connectionManager.getJdbi(), routingConfiguration);
+        DatabaseCacheConfiguration cacheConfiguration = new DatabaseCacheConfiguration();
+        cacheConfiguration.setEnabled(true);
+        cacheConfiguration.setRefreshAfterWrite(new Duration(5, TimeUnit.SECONDS));
+        testGatewayManager(new HaGatewayManager(connectionManager.getJdbi(), new RoutingConfiguration(), cacheConfiguration));
     }
 
     @Test
-    void testGatewayManager()
+    void testGatewayManagerWithoutCache()
+    {
+        JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager(dataStoreConfig());
+        testGatewayManager(new HaGatewayManager(connectionManager.getJdbi(), new RoutingConfiguration(), new DatabaseCacheConfiguration()));
+    }
+
+    void testGatewayManager(HaGatewayManager haGatewayManager)
     {
         ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
         backend.setActive(true);
@@ -100,8 +114,47 @@ final class TestHaGatewayManager
     }
 
     @Test
+    void testGatewayManagerCacheExpire()
+    {
+        DataStoreConfiguration dataStoreConfig = dataStoreConfig();
+        JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager(dataStoreConfig);
+        DatabaseCacheConfiguration cacheConfiguration = new DatabaseCacheConfiguration();
+        cacheConfiguration.setEnabled(true);
+        cacheConfiguration.setRefreshAfterWrite(new Duration(3, TimeUnit.SECONDS));
+        cacheConfiguration.setExpireAfterWrite(new Duration(5, TimeUnit.SECONDS));
+        TestingTicker ticker = new TestingTicker();
+        HaGatewayManager haGatewayManager = new HaGatewayManager(connectionManager.getJdbi(), new RoutingConfiguration(), cacheConfiguration, ticker);
+
+        ProxyBackendConfiguration etl = new ProxyBackendConfiguration();
+        etl.setActive(false);
+        etl.setRoutingGroup("etl");
+        etl.setName("new-etl1");
+        etl.setProxyTo("https://etl1.trino.gateway.io:443/");
+        etl.setExternalUrl("https://etl1.trino.gateway.io:443/");
+        haGatewayManager.addBackend(etl);
+
+        // Initial fetch
+        assertThat(haGatewayManager.getBackendByName("new-etl1").map(ProxyBackendConfiguration::getProxyTo).orElseThrow()).isEqualTo("https://etl1.trino.gateway.io:443");
+
+        // Read from cache
+        destroyTestingDatabase(dataStoreConfig);
+        assertThat(haGatewayManager.getBackendByName("new-etl1").map(ProxyBackendConfiguration::getProxyTo).orElseThrow()).isEqualTo("https://etl1.trino.gateway.io:443");
+
+        // Failed to refresh from DB, but still read from cache
+        ticker.increment(4, TimeUnit.SECONDS);
+        assertThat(haGatewayManager.getBackendByName("new-etl1").map(ProxyBackendConfiguration::getProxyTo).orElseThrow()).isEqualTo("https://etl1.trino.gateway.io:443");
+
+        // Expired from cache, failed to read from DB
+        ticker.increment(2, TimeUnit.SECONDS);
+        assertThatThrownBy(() -> haGatewayManager.getBackendByName("new-etl1")).hasMessage("Failed to load backends from database to cache");
+    }
+
+    @Test
     void testRemoveTrailingSlashInUrl()
     {
+        JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager(dataStoreConfig());
+        HaGatewayManager haGatewayManager = new HaGatewayManager(connectionManager.getJdbi(), new RoutingConfiguration(), new DatabaseCacheConfiguration());
+
         ProxyBackendConfiguration etl = new ProxyBackendConfiguration();
         etl.setActive(false);
         etl.setRoutingGroup("etl");
@@ -123,5 +176,23 @@ final class TestHaGatewayManager
 
         assertThat(haGatewayManager.getBackendByName("new-etl1").map(ProxyBackendConfiguration::getProxyTo).orElseThrow()).isEqualTo("https://etl2.trino.gateway.io:443");
         assertThat(haGatewayManager.getBackendByName("new-etl1").map(ProxyBackendConfiguration::getExternalUrl).orElseThrow()).isEqualTo("https://etl2.trino.gateway.io:443");
+    }
+
+    public static class TestingTicker
+            implements Ticker
+    {
+        private long time;
+
+        @Override
+        public synchronized long read()
+        {
+            return this.time;
+        }
+
+        public synchronized void increment(long delta, TimeUnit unit)
+        {
+            checkArgument(delta >= 0L, "delta is negative");
+            this.time += unit.toNanos(delta);
+        }
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryCountBasedRouter.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryCountBasedRouter.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.gateway.ha.clustermonitor.ClusterStats;
 import io.trino.gateway.ha.clustermonitor.TrinoStatus;
 import io.trino.gateway.ha.config.DataStoreConfiguration;
+import io.trino.gateway.ha.config.DatabaseCacheConfiguration;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 import io.trino.gateway.ha.config.RoutingConfiguration;
 import io.trino.gateway.ha.persistence.JdbcConnectionManager;
@@ -177,7 +178,7 @@ final class TestQueryCountBasedRouter
     {
         DataStoreConfiguration dataStoreConfig = dataStoreConfig();
         JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager(dataStoreConfig);
-        backendManager = new HaGatewayManager(connectionManager.getJdbi(), routingConfiguration);
+        backendManager = new HaGatewayManager(connectionManager.getJdbi(), routingConfiguration, new DatabaseCacheConfiguration());
         historyManager = new HaQueryHistoryManager(connectionManager.getJdbi(), dataStoreConfig);
         queryCountBasedRouter = new QueryCountBasedRouter(backendManager, historyManager, routingConfiguration);
         populateData();

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingManagerNotFound.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingManagerNotFound.java
@@ -14,6 +14,7 @@
 package io.trino.gateway.ha.router;
 
 import io.trino.gateway.ha.config.DataStoreConfiguration;
+import io.trino.gateway.ha.config.DatabaseCacheConfiguration;
 import io.trino.gateway.ha.config.RoutingConfiguration;
 import io.trino.gateway.ha.persistence.JdbcConnectionManager;
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,7 @@ final class TestRoutingManagerNotFound
         RoutingConfiguration routingConfiguration = new RoutingConfiguration();
         routingConfiguration.setDefaultRoutingGroup("default");
 
-        GatewayBackendManager backendManager = new HaGatewayManager(connectionManager.getJdbi(), routingConfiguration);
+        GatewayBackendManager backendManager = new HaGatewayManager(connectionManager.getJdbi(), routingConfiguration, new DatabaseCacheConfiguration());
         QueryHistoryManager historyManager = new HaQueryHistoryManager(connectionManager.getJdbi(), dataStoreConfig);
 
         this.routingManager = new StochasticRoutingManager(backendManager, historyManager, routingConfiguration);

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
@@ -15,6 +15,7 @@ package io.trino.gateway.ha.router;
 
 import io.trino.gateway.ha.clustermonitor.TrinoStatus;
 import io.trino.gateway.ha.config.DataStoreConfiguration;
+import io.trino.gateway.ha.config.DatabaseCacheConfiguration;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 import io.trino.gateway.ha.config.RoutingConfiguration;
 import io.trino.gateway.ha.persistence.JdbcConnectionManager;
@@ -40,7 +41,7 @@ final class TestStochasticRoutingManager
         DataStoreConfiguration dataStoreConfig = dataStoreConfig();
         JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager(dataStoreConfig);
         RoutingConfiguration routingConfiguration = new RoutingConfiguration();
-        backendManager = new HaGatewayManager(connectionManager.getJdbi(), routingConfiguration);
+        backendManager = new HaGatewayManager(connectionManager.getJdbi(), routingConfiguration, new DatabaseCacheConfiguration());
         historyManager = new HaQueryHistoryManager(connectionManager.getJdbi(), dataStoreConfig);
         haRoutingManager = new StochasticRoutingManager(backendManager, historyManager, routingConfiguration);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Add cache in HaGatewayManager.
Continue the work in #501 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Set `databaseCacheTTL` to a non-zero [Airlift duration](https://airlift.github.io/airlift/units/) value to enable in-memory caching of backend metadata retrieved from the gateway database. Trino Gateway caches the list of backend clusters for the specified time and refreshes it asynchronously. Use this setting to reduce database load and improve routing performance.

A value of `0s` (the default) disables the cache and queries the database on
every request.



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes
(x) Release notes are required, with the following suggested text:

```markdown
* Allow setting `databaseCacheTTL` to enable in-memory caching of backend metadata retrieved from the gateway database.
```

## Summary by Sourcery

Introduce an optional in-memory cache for gateway backends in HaGatewayManager with configurable TTL and automatic invalidation on data changes.

New Features:
- Add optional Guava LoadingCache for all gateway backends with a databaseCacheTTL setting in RoutingConfiguration
- Expose metrics for cache lookup successes and failures

Enhancements:
- Invalidate and asynchronously refresh the backend cache on startup and whenever backends are added, updated, activated, or deleted
- Replace multiple DAO methods with a single findAll and perform in-memory filtering for active, group-specific, and named backends

Tests:
- Update TestHaGatewayManager to validate behavior with cache enabled and disabled

## Summary by Sourcery

Introduce configurable in-memory caching in HaGatewayManager to reduce database load and improve routing performance by caching backend metadata with TTL, automatic invalidation, and streamlined retrieval, while updating tests and documentation.

New Features:
- Add optional Guava-based in-memory cache for gateway backends with configurable TTL and asynchronous refresh
- Expose metrics for backend cache lookup successes and failures

Enhancements:
- Invalidate and refresh the backend cache automatically on backend additions, updates, activations, or deletions
- Simplify backend retrieval by fetching all backends once and performing in-memory filtering instead of multiple DAO queries

Documentation:
- Update routing rules documentation to include the databaseCacheTTL configuration and caching behavior

Tests:
- Extend TestHaGatewayManager to validate behavior with cache enabled and disabled