### PR TITLE
Enable multiple authentication methods (External + Basic Auth)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -36,8 +36,8 @@ for more details.
 
 The authentication would happen on https protocol only. Add the
 `authentication:` section in the config file. The default authentication type is
-set using `defaultType: "form"` Following types of the authentications are
-supported.
+set using `defaultTypes: ["form"]`. The first authentication type in `defaultTypes` is prioritized and then falls back to following ones.
+Following types of the authentications are supported.
 
 ### OAuth/OpenIDConnect
 
@@ -45,7 +45,7 @@ It can be configured as below
 
 ```yaml
 authentication:
-  defaultType: "oauth"
+  defaultTypes: ["oauth"]
   oauth:
     issuer:
     clientId:
@@ -81,6 +81,11 @@ Set the `privilegesField` to retrieve privileges from an OAuth claim.
 ```
 - That also means you need to have a cluster with that routing group.
 - It's ok to replicate an existing Trino cluster record with a different name for that purpose.
+- If you want to have all users who are authenticated via SSO and are not in the `presetUsers` list be able to view the dashboard and query history, you can set `defaultPrivilege` in the config file:
+```yaml
+authorization:
+  defaultPrivilege: "USER"
+```
 
 ### Form/Basic authentication
 
@@ -102,7 +107,7 @@ Also provide a random key pair in RSA format.
 
 ```yaml
 authentication:
-  defaultType: "form"
+  defaultTypes: ["form"]
   form:
     selfSignKeyPair:
       privateKeyRsa: <private_key_path>
@@ -115,7 +120,7 @@ LDAP requires both random key pair and config path for LDAP
 
 ```yaml
 authentication:
-  defaultType: "form"
+  defaultTypes: ["form"]
   form:
     ldapConfigPath: <ldap_config_path>
     selfSignKeyPair:

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -323,6 +323,13 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-api</artifactId>
+            <version>3.4.2</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Test deps -->
         <dependency>
             <groupId>com.h2database</groupId>

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/AuthenticationConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/AuthenticationConfiguration.java
@@ -13,29 +13,31 @@
  */
 package io.trino.gateway.ha.config;
 
+import java.util.List;
+
 public class AuthenticationConfiguration
 {
-    private String defaultType;
+    private List<String> defaultTypes;
     private OAuthConfiguration oauth;
     private FormAuthConfiguration form;
 
-    public AuthenticationConfiguration(String defaultType, OAuthConfiguration oauth, FormAuthConfiguration form)
+    public AuthenticationConfiguration(List<String> defaultTypes, OAuthConfiguration oauth, FormAuthConfiguration form)
     {
-        this.defaultType = defaultType;
+        this.defaultTypes = defaultTypes;
         this.oauth = oauth;
         this.form = form;
     }
 
     public AuthenticationConfiguration() {}
 
-    public String getDefaultType()
+    public List<String> getDefaultTypes()
     {
-        return this.defaultType;
+        return this.defaultTypes;
     }
 
-    public void setDefaultType(String defaultType)
+    public void setDefaultTypes(List<String> defaultTypes)
     {
-        this.defaultType = defaultType;
+        this.defaultTypes = defaultTypes;
     }
 
     public OAuthConfiguration getOauth()

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/AuthorizationConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/AuthorizationConfiguration.java
@@ -19,13 +19,15 @@ public class AuthorizationConfiguration
     private String user;
     private String api;
     private String ldapConfigPath;
+    private String defaultPrivilege;
 
-    public AuthorizationConfiguration(String admin, String user, String api, String ldapConfigPath)
+    public AuthorizationConfiguration(String admin, String user, String api, String ldapConfigPath, String defaultPrivilege)
     {
         this.admin = admin;
         this.user = user;
         this.api = api;
         this.ldapConfigPath = ldapConfigPath;
+        this.defaultPrivilege = defaultPrivilege;
     }
 
     public AuthorizationConfiguration() {}
@@ -68,5 +70,15 @@ public class AuthorizationConfiguration
     public void setLdapConfigPath(String ldapConfigPath)
     {
         this.ldapConfigPath = ldapConfigPath;
+    }
+
+    public String getDefaultPrivilege()
+    {
+        return this.defaultPrivilege;
+    }
+
+    public void setDefaultPrivilege(String defaultPrivilege)
+    {
+        this.defaultPrivilege = defaultPrivilege;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/LoginResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/LoginResource.java
@@ -16,6 +16,7 @@ package io.trino.gateway.ha.resource;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
 import io.trino.gateway.ha.domain.Result;
 import io.trino.gateway.ha.domain.request.RestLoginRequest;
 import io.trino.gateway.ha.security.LbFormAuthManager;
@@ -56,10 +57,12 @@ public class LoginResource
 
     private final LbOAuthManager oauthManager;
     private final LbFormAuthManager formAuthManager;
+    private final HaGatewayConfiguration haGatewayConfiguration;
 
     @Inject
-    public LoginResource(@Nullable LbOAuthManager oauthManager, @Nullable LbFormAuthManager formAuthManager)
+    public LoginResource(HaGatewayConfiguration haGatewayConfiguration, @Nullable LbOAuthManager oauthManager, @Nullable LbFormAuthManager formAuthManager)
     {
+        this.haGatewayConfiguration = haGatewayConfiguration;
         this.oauthManager = oauthManager;
         this.formAuthManager = formAuthManager;
     }
@@ -173,16 +176,13 @@ public class LoginResource
     @Produces(MediaType.APPLICATION_JSON)
     public Response loginType()
     {
-        String loginType;
-        if (formAuthManager != null) {
-            loginType = "form";
-        }
-        else if (oauthManager != null) {
-            loginType = "oauth";
+        List<String> loginTypes;
+        if (haGatewayConfiguration.getAuthentication() != null) {
+            loginTypes = haGatewayConfiguration.getAuthentication().getDefaultTypes();
         }
         else {
-            loginType = "none";
+            loginTypes = List.of("none");
         }
-        return Response.ok(Result.ok("Ok", loginType)).build();
+        return Response.ok(Result.ok("Ok", loginTypes)).build();
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/HaGatewayTestUtils.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/HaGatewayTestUtils.java
@@ -18,6 +18,8 @@ import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
 import io.trino.gateway.ha.clustermonitor.ClusterStats;
 import io.trino.gateway.ha.clustermonitor.TrinoStatus;
+import okhttp3.CookieJar;
+import okhttp3.JavaNetCookieJar;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -28,16 +30,34 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
+import org.testcontainers.containers.FixedHostPortGenericContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.Network;
 import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.TrinoContainer;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
+import org.testcontainers.utility.DockerImageName;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Scanner;
 import java.util.concurrent.TimeUnit;
 
@@ -46,16 +66,27 @@ import static com.google.common.net.HttpHeaders.CONTENT_ENCODING;
 import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static io.trino.gateway.ha.util.ConfigurationUtils.replaceEnvironmentVariables;
+import static io.trino.gateway.ha.util.TestcontainersUtils.createPostgreSqlContainer;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
 public class HaGatewayTestUtils
 {
     private static final Logger log = Logger.get(HaGatewayTestUtils.class);
     private static final OkHttpClient httpClient = new OkHttpClient();
+
+    // TODO: TRINO-7103 Set up TMC job to update Trino image version in trino-gateway
+    private static final String TRINO_IMAGE_VERSION = "406.186.12";
+
+    private static final String HYDRA_IMAGE = "oryd/hydra:v1.11.10";
+    private static final String DSN = "mysql://hydra:mysecretpassword@tcp(hydra-db:3306)/hydra?parseTime=true";
+
+    private static final int TTL_ACCESS_TOKEN_IN_SECONDS = 5;
+    private static final int TTL_REFRESH_TOKEN_IN_SECONDS = 15;
 
     private HaGatewayTestUtils() {}
 
@@ -200,5 +231,152 @@ public class HaGatewayTestUtils
             sleepUninterruptibly(1, TimeUnit.SECONDS);
         }
         throw new IllegalStateException("Trino cluster is not healthy");
+    }
+
+    public static TrinoContainer getTrinoContainer()
+    {
+        TrinoContainer trino = new TrinoContainer(DockerImageName.parse("trinodb/trino:" + TRINO_IMAGE_VERSION));
+        trino.withCopyFileToContainer(forClasspathResource("trino_container_init.sh"), "/");
+        trino.withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("bash", "-c", "./trino_container_init.sh"));
+        return trino;
+    }
+
+    public static void setupOidc(int routerPort, String configFile, String scopes)
+                throws Exception
+    {
+        PostgreSQLContainer<?> postgresql = createPostgreSqlContainer();
+        postgresql.start();
+        setupOidcContainers(routerPort, scopes);
+
+        Path localhostJks = Path.of("src", "test", "resources", "auth", "localhost.jks").toAbsolutePath();
+        Map<String, String> additionalVars = ImmutableMap.<String, String>builder()
+                .put("REQUEST_ROUTER_PORT", String.valueOf(routerPort))
+                .put("LOCALHOST_JKS", localhostJks.toString())
+                .putAll(buildPostgresVars(postgresql))
+                .buildOrThrow();
+        File testConfigFile = HaGatewayTestUtils.buildGatewayConfig(configFile, additionalVars);
+        String[] args = {testConfigFile.getAbsolutePath()};
+        HaGatewayLauncher.main(args);
+    }
+
+    public static void setupOidcContainers(int routerPort, String scopes)
+    {
+        Network network = Network.newNetwork();
+        MySQLContainer<?> databaseContainer = new MySQLContainer<>("mysql:8.0.36")
+                .withNetwork(network)
+                .withNetworkAliases("hydra-db")
+                .withUsername("hydra")
+                .withPassword("mysecretpassword")
+                .withDatabaseName("hydra")
+                .waitingFor(Wait.forLogMessage(".*ready to accept connections.*", 1));
+        databaseContainer.start();
+
+        GenericContainer<?> migrationContainer = new GenericContainer<>(HYDRA_IMAGE)
+                .withNetwork(network)
+                .withCommand("migrate", "sql", "--yes", DSN)
+                .dependsOn(databaseContainer)
+                .withStartupCheckStrategy(new OneShotStartupCheckStrategy());
+        migrationContainer.start();
+
+        FixedHostPortGenericContainer<?> hydraConsent = new FixedHostPortGenericContainer<>("python:3.10.1-alpine")
+                .withFixedExposedPort(3000, 3000)
+                .withNetwork(network)
+                .withNetworkAliases("hydra-consent")
+                .withExposedPorts(3000)
+                .withCopyFileToContainer(forClasspathResource("auth/login_and_consent_server.py"), "/")
+                .withCommand("python", "/login_and_consent_server.py")
+                .waitingFor(Wait.forHttp("/healthz").forPort(3000).forStatusCode(200));
+        hydraConsent.start();
+
+        FixedHostPortGenericContainer<?> hydra = new FixedHostPortGenericContainer<>(HYDRA_IMAGE)
+                .withFixedExposedPort(4444, 4444)
+                .withFixedExposedPort(4445, 4445)
+                .withNetwork(network)
+                .withNetworkAliases("hydra")
+                .withEnv("LOG_LEVEL", "debug")
+                .withEnv("LOG_LEAK_SENSITIVE_VALUES", "true")
+                .withEnv("OAUTH2_EXPOSE_INTERNAL_ERRORS", "1")
+                .withEnv("GODEBUG", "http2debug=1")
+                .withEnv("DSN", DSN)
+                .withEnv("URLS_SELF_ISSUER", "http://localhost:4444/")
+                .withEnv("URLS_CONSENT", "http://localhost:3000/consent")
+                .withEnv("URLS_LOGIN", "http://localhost:3000/login")
+                .withEnv("STRATEGIES_ACCESS_TOKEN", "jwt")
+                .withEnv("TTL_ACCESS_TOKEN", TTL_ACCESS_TOKEN_IN_SECONDS + "s")
+                .withEnv("TTL_REFRESH_TOKEN", TTL_REFRESH_TOKEN_IN_SECONDS + "s")
+                .withEnv("OAUTH2_ALLOWED_TOP_LEVEL_CLAIMS", "groups")
+                .withCommand("serve", "all", "--dangerous-force-http")
+                .dependsOn(hydraConsent, migrationContainer)
+                .waitingFor(new WaitAllStrategy()
+                .withStrategy(Wait.forLogMessage(".*Setting up http server on :4444.*", 1))
+                .withStrategy(Wait.forLogMessage(".*Setting up http server on :4445.*", 1)))
+                .withStartupTimeout(java.time.Duration.ofMinutes(3));
+        hydra.start();
+
+        String clientId = "trino_client_id";
+        String clientSecret = "trino_client_secret";
+        String tokenEndpointAuthMethod = "client_secret_basic";
+        String audience = "trino_client_id";
+        String callbackUrl = format("https://localhost:%s/oidc/callback", routerPort);
+        GenericContainer<?> clientCreatingContainer = new GenericContainer<>(HYDRA_IMAGE)
+                .withNetwork(network)
+                .dependsOn(hydra)
+                .withCommand("clients", "create",
+                "--endpoint", "http://hydra:4445",
+                "--skip-tls-verify",
+                "--id", clientId,
+                "--secret", clientSecret,
+                "--audience", audience,
+                "-g", "authorization_code,refresh_token,client_credentials",
+                "-r", "token,code,id_token",
+                "--scope", scopes,
+                "--token-endpoint-auth-method", tokenEndpointAuthMethod,
+                "--callbacks", callbackUrl);
+        clientCreatingContainer.start();
+    }
+
+    public static OkHttpClient createOkHttpClient(Optional<CookieJar> cookieJar)
+            throws Exception
+    {
+        OkHttpClient.Builder httpClientBuilder = new OkHttpClient.Builder()
+                .followRedirects(true)
+                .cookieJar(cookieJar.orElseGet(() -> {
+                    CookieManager cookieManager = new CookieManager();
+                    cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
+                    return new JavaNetCookieJar(cookieManager);
+                }));
+        setupInsecureSsl(httpClientBuilder);
+        return httpClientBuilder.build();
+    }
+
+    private static void setupInsecureSsl(OkHttpClient.Builder clientBuilder)
+            throws Exception
+    {
+        X509TrustManager trustAllCerts = new X509TrustManager()
+        {
+            @Override
+            public void checkClientTrusted(X509Certificate[] chain, String authType)
+            {
+                throw new UnsupportedOperationException("checkClientTrusted should not be called");
+            }
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] chain, String authType)
+            {
+                // skip validation of server certificate
+            }
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers()
+            {
+                return new X509Certificate[0];
+            }
+        };
+
+        SSLContext sslContext = SSLContext.getInstance("SSL");
+        sslContext.init(null, new TrustManager[] {trustAllCerts}, new SecureRandom());
+
+        clientBuilder.sslSocketFactory(sslContext.getSocketFactory(), trustAllCerts);
+        clientBuilder.hostnameVerifier((hostname, session) -> true);
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestAuthenticationFallbacks.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestAuthenticationFallbacks.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.security;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.trino.gateway.ha.HaGatewayTestUtils;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Optional;
+
+import static io.trino.gateway.ha.HaGatewayTestUtils.createOkHttpClient;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TestAuthenticationFallbacks
+{
+    private final int routerPort = 21001 + (int) (Math.random() * 1000);
+
+    @BeforeAll
+    void setup()
+            throws Exception
+    {
+        HaGatewayTestUtils.setupOidc(routerPort, "auth/oauth-and-form-test-config.yml", "openid");
+    }
+
+    @Test
+    void testPrimaryAuth()
+            throws Exception
+    {
+        OkHttpClient httpClient = createOkHttpClient(Optional.empty());
+        try (Response response = httpClient.newCall(uiLoginTypeCall().build()).execute()) {
+            String body = response.body().string();
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode jsonNode = objectMapper.readTree(body);
+            JsonNode dataNode = jsonNode.get("data");
+            assertThat(dataNode.isArray()).isTrue();
+            assertThat(dataNode.size()).isEqualTo(2);
+            assertThat(dataNode.get(0).asText()).isEqualTo("oauth");
+            assertThat(dataNode.get(1).asText()).isEqualTo("form");
+        }
+    }
+
+    @Test
+    void testApiFallbackAuth()
+            throws Exception
+    {
+        OkHttpClient httpClient = createOkHttpClient(Optional.empty());
+        Request request = new Request.Builder()
+                .url(format("https://localhost:%s/webapp/getAllBackends", routerPort))
+                .post(RequestBody.create("{}", MediaType.parse("application/json")))
+                .addHeader("Authorization", "Basic YWRtaW4xOmFkbWluMV9wYXNzd29yZA==") // admin1:admin1_password
+                .build();
+
+        try (Response response = httpClient.newCall(request).execute()) {
+            assertThat(response.isSuccessful()).isTrue();
+            String body = response.body().string();
+            assertThat(body).contains("Successful.");
+        }
+    }
+
+    private Request.Builder uiLoginTypeCall()
+    {
+        return new Request.Builder()
+                .url(format("https://localhost:%s/loginType", routerPort))
+                .post(RequestBody.create("{}", MediaType.parse("application/json")));
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestAuthorizationManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestAuthorizationManager.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.security;
+
+import io.trino.gateway.ha.config.AuthorizationConfiguration;
+import io.trino.gateway.ha.config.UserConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestAuthorizationManager
+{
+    @Test
+    public void testNoDefaultPrivilege()
+    {
+        AuthorizationConfiguration authConfig = new AuthorizationConfiguration();
+        Map<String, UserConfiguration> presetUsers = Collections.emptyMap();
+        AuthorizationManager authManager = new AuthorizationManager(authConfig, presetUsers);
+
+        Optional<String> privileges = authManager.getPrivileges("newUser");
+        assertThat(privileges).isEmpty();
+    }
+
+    @Test
+    public void testCustomDefaultPrivilege()
+    {
+        AuthorizationConfiguration authConfig = new AuthorizationConfiguration();
+        authConfig.setDefaultPrivilege("CUSTOM_DEFAULT");
+        Map<String, UserConfiguration> presetUsers = Collections.emptyMap();
+        AuthorizationManager authManager = new AuthorizationManager(authConfig, presetUsers);
+
+        Optional<String> privileges = authManager.getPrivileges("newUser");
+        assertThat(privileges).isPresent();
+        assertThat(privileges.orElseThrow()).isEqualTo("CUSTOM_DEFAULT");
+    }
+
+    @Test
+    public void testOauthDefaultUserRoleEnabled()
+    {
+        AuthorizationConfiguration authConfig = new AuthorizationConfiguration();
+        authConfig.setDefaultPrivilege("USER");
+        Map<String, UserConfiguration> presetUsers = Collections.emptyMap();
+        AuthorizationManager authManager = new AuthorizationManager(authConfig, presetUsers);
+
+        Optional<String> privileges = authManager.getPrivileges("newUser");
+        assertThat(privileges).isPresent();
+        assertThat(privileges.orElseThrow()).isEqualTo("USER");
+    }
+
+    @Test
+    public void testOauthDefaultUserRoleDisabled()
+    {
+        AuthorizationConfiguration authConfig = new AuthorizationConfiguration();
+        Map<String, UserConfiguration> presetUsers = Collections.emptyMap();
+        AuthorizationManager authManager = new AuthorizationManager(authConfig, presetUsers);
+
+        Optional<String> privileges = authManager.getPrivileges("newUser");
+        assertThat(privileges).isNotPresent();
+    }
+
+    @Test
+    public void testPresetUserRole()
+    {
+        AuthorizationConfiguration authConfig = new AuthorizationConfiguration();
+        UserConfiguration presetUser = new UserConfiguration("ADMIN", "password");
+        Map<String, UserConfiguration> presetUsers = Map.of("adminUser", presetUser);
+        AuthorizationManager authManager = new AuthorizationManager(authConfig, presetUsers);
+
+        Optional<String> privileges = authManager.getPrivileges("adminUser");
+        assertThat(privileges).isPresent();
+        assertThat(privileges.orElseThrow()).isEqualTo("ADMIN");
+    }
+
+    @Test
+    public void testPresetUserWithEmptyPrivileges()
+    {
+        AuthorizationConfiguration authConfig = new AuthorizationConfiguration();
+        UserConfiguration presetUser = new UserConfiguration("", "password"); // Empty privileges
+        Map<String, UserConfiguration> presetUsers = Map.of("emptyPrivUser", presetUser);
+        AuthorizationManager authManager = new AuthorizationManager(authConfig, presetUsers);
+
+        Optional<String> privileges = authManager.getPrivileges("emptyPrivUser");
+        assertThat(privileges).isEmpty();
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestOIDC.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestOIDC.java
@@ -16,8 +16,6 @@ package io.trino.gateway.ha.security;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
-import io.trino.gateway.ha.HaGatewayLauncher;
 import io.trino.gateway.ha.HaGatewayTestUtils;
 import okhttp3.Cookie;
 import okhttp3.CookieJar;
@@ -30,135 +28,27 @@ import okhttp3.Response;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.testcontainers.containers.FixedHostPortGenericContainer;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.Network;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
-
-import java.io.File;
 import java.net.CookieManager;
 import java.net.CookiePolicy;
-import java.net.URL;
-import java.nio.file.Path;
-import java.security.SecureRandom;
-import java.security.cert.X509Certificate;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
-import static io.trino.gateway.ha.HaGatewayTestUtils.buildPostgresVars;
+import static io.trino.gateway.ha.HaGatewayTestUtils.createOkHttpClient;
 import static io.trino.gateway.ha.security.OidcCookie.OIDC_COOKIE;
-import static io.trino.gateway.ha.util.TestcontainersUtils.createPostgreSqlContainer;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 final class TestOIDC
 {
-    private static final int TTL_ACCESS_TOKEN_IN_SECONDS = 5;
-    private static final int TTL_REFRESH_TOKEN_IN_SECONDS = 15;
-
-    private static final String HYDRA_IMAGE = "oryd/hydra:v1.11.10";
-    private static final String DSN = "postgres://hydra:mysecretpassword@hydra-db:5432/hydra?sslmode=disable";
     private static final int ROUTER_PORT = 21001 + (int) (Math.random() * 1000);
 
     @BeforeAll
     void setup()
             throws Exception
     {
-        Network network = Network.newNetwork();
-
-        PostgreSQLContainer<?> databaseContainer = createPostgreSqlContainer()
-                .withNetwork(network)
-                .withNetworkAliases("hydra-db")
-                .withUsername("hydra")
-                .withPassword("mysecretpassword")
-                .withDatabaseName("hydra");
-        databaseContainer.start();
-
-        GenericContainer migrationContainer = new GenericContainer(HYDRA_IMAGE)
-                .withNetwork(network)
-                .withCommand("migrate", "sql", "--yes", DSN)
-                .dependsOn(databaseContainer)
-                .withStartupCheckStrategy(new OneShotStartupCheckStrategy());
-        migrationContainer.start();
-
-        FixedHostPortGenericContainer<?> hydraConsent = new FixedHostPortGenericContainer<>("python:3.10.1-alpine")
-                .withFixedExposedPort(3000, 3000)
-                .withNetwork(network)
-                .withNetworkAliases("hydra-consent")
-                .withExposedPorts(3000)
-                .withCopyFileToContainer(forClasspathResource("auth/login_and_consent_server.py"), "/")
-                .withCommand("python", "/login_and_consent_server.py")
-                .waitingFor(Wait.forHttp("/healthz").forPort(3000).forStatusCode(200));
-        hydraConsent.start();
-
-        FixedHostPortGenericContainer<?> hydra = new FixedHostPortGenericContainer<>(HYDRA_IMAGE)
-                .withFixedExposedPort(4444, 4444)
-                .withFixedExposedPort(4445, 4445)
-                .withNetwork(network)
-                .withNetworkAliases("hydra")
-                .withEnv("LOG_LEVEL", "debug")
-                .withEnv("LOG_LEAK_SENSITIVE_VALUES", "true")
-                .withEnv("OAUTH2_EXPOSE_INTERNAL_ERRORS", "1")
-                .withEnv("GODEBUG", "http2debug=1")
-                .withEnv("DSN", DSN)
-                .withEnv("URLS_SELF_ISSUER", "http://localhost:4444/")
-                .withEnv("URLS_CONSENT", "http://localhost:3000/consent")
-                .withEnv("URLS_LOGIN", "http://localhost:3000/login")
-                .withEnv("STRATEGIES_ACCESS_TOKEN", "jwt")
-                .withEnv("TTL_ACCESS_TOKEN", TTL_ACCESS_TOKEN_IN_SECONDS + "s")
-                .withEnv("TTL_REFRESH_TOKEN", TTL_REFRESH_TOKEN_IN_SECONDS + "s")
-                .withEnv("OAUTH2_ALLOWED_TOP_LEVEL_CLAIMS", "groups")
-                .withCommand("serve", "all", "--dangerous-force-http")
-                .dependsOn(hydraConsent, migrationContainer)
-                .waitingFor(new WaitAllStrategy()
-                        .withStrategy(Wait.forLogMessage(".*Setting up http server on :4444.*", 1))
-                        .withStrategy(Wait.forLogMessage(".*Setting up http server on :4445.*", 1)))
-                .withStartupTimeout(java.time.Duration.ofMinutes(3));
-
-        String clientId = "trino_client_id";
-        String clientSecret = "trino_client_secret";
-        String tokenEndpointAuthMethod = "client_secret_basic";
-        String audience = "trino_client_id";
-        String callbackUrl = format("https://localhost:%s/oidc/callback", ROUTER_PORT);
-        GenericContainer clientCreatingContainer = new GenericContainer(HYDRA_IMAGE)
-                .withNetwork(network)
-                .dependsOn(hydra)
-                .withCommand("clients", "create",
-                        "--endpoint", "http://hydra:4445",
-                        "--skip-tls-verify",
-                        "--id", clientId,
-                        "--secret", clientSecret,
-                        "--audience", audience,
-                        "-g", "authorization_code,refresh_token,client_credentials",
-                        "-r", "token,code,id_token",
-                        "--scope", "openid,offline",
-                        "--token-endpoint-auth-method", tokenEndpointAuthMethod,
-                        "--callbacks", callbackUrl);
-        clientCreatingContainer.start();
-
-        PostgreSQLContainer gatewayBackendDatabase = createPostgreSqlContainer();
-        gatewayBackendDatabase.start();
-
-        URL resource = HaGatewayTestUtils.class.getClassLoader().getResource("auth/localhost.jks");
-        Map<String, String> additionalVars = ImmutableMap.<String, String>builder()
-                .put("REQUEST_ROUTER_PORT", String.valueOf(ROUTER_PORT))
-                .put("LOCALHOST_JKS", Path.of(resource.toURI()).toString())
-                .putAll(buildPostgresVars(gatewayBackendDatabase))
-                .buildOrThrow();
-        File testConfigFile =
-                HaGatewayTestUtils.buildGatewayConfig("auth/oauth-test-config.yml", additionalVars);
-        String[] args = {testConfigFile.getAbsolutePath()};
-        HaGatewayLauncher.main(args);
+        HaGatewayTestUtils.setupOidc(ROUTER_PORT, "auth/oauth-test-config.yml", "openid,offline");
     }
 
     @Test
@@ -216,37 +106,6 @@ final class TestOIDC
                 .post(RequestBody.create("", null));
     }
 
-    public static void setupInsecureSsl(OkHttpClient.Builder clientBuilder)
-            throws Exception
-    {
-        X509TrustManager trustAllCerts = new X509TrustManager()
-        {
-            @Override
-            public void checkClientTrusted(X509Certificate[] chain, String authType)
-            {
-                throw new UnsupportedOperationException("checkClientTrusted should not be called");
-            }
-
-            @Override
-            public void checkServerTrusted(X509Certificate[] chain, String authType)
-            {
-                // skip validation of server certificate
-            }
-
-            @Override
-            public X509Certificate[] getAcceptedIssuers()
-            {
-                return new X509Certificate[0];
-            }
-        };
-
-        SSLContext sslContext = SSLContext.getInstance("SSL");
-        sslContext.init(null, new TrustManager[] {trustAllCerts}, new SecureRandom());
-
-        clientBuilder.sslSocketFactory(sslContext.getSocketFactory(), trustAllCerts);
-        clientBuilder.hostnameVerifier((hostname, session) -> true);
-    }
-
     public static class BadCookieJar
             implements CookieJar
     {
@@ -288,19 +147,5 @@ final class TestOIDC
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode jsonNode = objectMapper.readTree(body);
         return jsonNode.get("data").asText();
-    }
-
-    private static OkHttpClient createOkHttpClient(Optional<CookieJar> cookieJar)
-            throws Exception
-    {
-        OkHttpClient.Builder httpClientBuilder = new OkHttpClient.Builder()
-                .followRedirects(true)
-                .cookieJar(cookieJar.orElseGet(() -> {
-                    CookieManager cookieManager = new CookieManager();
-                    cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
-                    return new JavaNetCookieJar(cookieManager);
-                }));
-        setupInsecureSsl(httpClientBuilder);
-        return httpClientBuilder.build();
     }
 }

--- a/gateway-ha/src/test/resources/auth/auth-test-config.yml
+++ b/gateway-ha/src/test/resources/auth/auth-test-config.yml
@@ -25,7 +25,7 @@ presetUsers:
     privileges: BAR_BAZ
 
 authentication:
-  defaultType: "form"
+  defaultTypes: ["form"]
   form:
     selfSignKeyPair:
       privateKeyRsa: src/test/resources/auth/test_private_key.pem

--- a/gateway-ha/src/test/resources/auth/oauth-and-form-test-config.yml
+++ b/gateway-ha/src/test/resources/auth/oauth-and-form-test-config.yml
@@ -23,9 +23,12 @@ authorization:
 presetUsers:
   foo@bar.com:
     privileges: FOO_BAR
+  admin1:
+    password: admin1_password
+    privileges: FOO_BAR
 
 authentication:
-  defaultTypes: ["oauth"]
+  defaultTypes: ["oauth", "form"]
   oauth:
     issuer: http://localhost:4444/
     clientId: trino_client_id
@@ -38,3 +41,7 @@ authentication:
     userIdField: sub
     scopes:
       - openid
+  form:
+    selfSignKeyPair:
+      privateKeyRsa: src/test/resources/auth/test_private_key.pem
+      publicKeyRsa: src/test/resources/auth/test_public_key.pem

--- a/webapp/src/components/login.tsx
+++ b/webapp/src/components/login.tsx
@@ -10,11 +10,13 @@ export function Login() {
   const access = useAccessStore();
   const [formApi, setFormApi] = useState<FormApi<any>>();
   const [loginBo, setLoginBo] = useState<Record<string, any>>({});
-  const [loginType, setLoginType] = useState<'form' | 'oauth' | 'none'>();
+  const [loginType, setLoginType] = useState<string>();
 
   useEffect(() => {
     loginTypeApi().then(data => {
-      setLoginType(data);
+      if (data && data.length > 0) {
+        setLoginType(data[0]);
+      }
     }).catch(() => { });
   }, [])
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
At LinkedIn, we need to be able to use multiple different authentication mechanisms, similar to the [Trino Server itself](https://trino.io/docs/current/security/authentication-types.html), as we would like to:
1. Enable our internal users to authenticate via SSO
2. Enable some automated system interactions with Trino Gateway which does not have a human-in-the-loop, and thus, would need another method to performing administrative actions such as activating/deactivating Trino clusters on Trino Gateway.

This PR has the following changes:
1. Change `defaultType` authentication to a list, to enable fallback authentications. This change allows for multiple authentication methods similar to trinodb/trino authentication: https://trino.io/docs/current/security/authentication-types.html
2. UI enables only the first authentication in the `defaultType`, even if there are multiple authentication methods set.
3. All users that log in, if they do not exist in `authorization`, and `defaultPrivilege` is set, they will be given the permission of defined in `defaultPrivilege`. This resolves the issue for OAuth authentications for large enterprises using Trino Gateway as they cannot add every single user to have `USER` permissions by default.

This PR is related to : https://github.com/trinodb/trino-gateway/issues/616

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

### Configurations
```
serverConfig:
  [...]

authentication:
  defaultTypes: ["oauth","form"]
  oauth:
    issuer: "[....]"
  form:
    [....]

presetUsers:
  admin:
    password: admin
    privileges: ADMIN_USER_API
  trinoUser:
    password: trinoUserPassword
    privileges: USER

authorization:
  defaultPrivilege: "USER"
  admin: (.*)ADMIN(.*)
  user: (.*)USER(.*)
  api: (.*)API(.*)

```
## UI View with defaultPrivilege
1. Login screen with OAuth
<img width="1667" height="909" alt="489212012-332754a9-7b26-4e40-9b49-df12efdbeeaf" src="https://github.com/user-attachments/assets/4efe370e-0096-490b-bd55-798af2fdc0a8" />

2. As `andjiang` is nto in the presetUsers list, defaults over to `USER` permissions so can only view history
<img width="1707" height="948" alt="489212036-2af810e1-ff81-445d-913e-a475a2dc5722" src="https://github.com/user-attachments/assets/97a595d7-e120-4c48-978f-f1d6452feb61" />

## API Calls with OAuth enabled:
1. Query API endpoing for all backends
<img width="1288" height="872" alt="489212143-9a8720c0-c8b7-4248-bbfa-d1faea27ae19" src="https://github.com/user-attachments/assets/d0a65b61-c9b0-4876-a84c-a2f83bc72f83" />

2. Deactivate one backend with admin account
<img width="1413" height="510" alt="489212155-6ce2a988-8060-49c4-bbc0-70835b199f84" src="https://github.com/user-attachments/assets/a6008569-61d4-4cf7-bad7-ee93c0d49565" />

3. API with deactivate `trino-adhoc1`
<img width="1404" height="925" alt="489212176-0eca1532-0c10-4498-afda-cb6952dd4012" src="https://github.com/user-attachments/assets/252fc0ce-cdf0-46ee-8f66-eed55a52ddeb" />

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( x ) Release notes are required, with the following suggested text:

```markdown
* Trino Gateway now supports multiple authentication mechanisms via fallbacks. The first authentication in the list is rendered on the UI itself.
* Change configuration `defaultType` to `defaultTypes` and changes the type from a `string` to a `List<String>`.
* Add a new configuration of `defaultPrivilege` to enable large enterprise customers to have admins and all remaining accounts logging in via SSO would default to `USER` privilege
```

## Summary by Sourcery

Enable support for multiple authentication methods in Trino Gateway HA by replacing the single defaultType with a prioritized list (defaultTypes), add fallbacks for BasicAuth API calls alongside OAuth/form login, and introduce a defaultPrivilege setting to automatically assign permissions to users not explicitly configured. Centralize OIDC test setup and add new tests for authorization and authentication fallback behaviors.

New Features:
- Support multiple authentication mechanisms via a prioritized defaultTypes list with fallback order
- Introduce defaultPrivilege configuration to grant default permissions to new SSO users
- Expose loginType endpoint returning the ordered list of enabled authentication methods

Enhancements:
- Add BasicAuth filter fallback for API calls under form authentication
- Refactor and centralize OIDC container and HTTP client setup in test utilities

Build:
- Add docker-java-api test dependency for containerized testing

Documentation:
- Update security documentation to use defaultTypes list and describe fallback behavior

Tests:
- Add unit tests for AuthorizationManager defaultPrivilege logic
- Add integration tests for authentication fallback between OAuth and form methods