### PR TITLE
Fix UI Query Distribution chart showing zero queries inaccurately

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
@@ -21,6 +21,7 @@ import io.trino.gateway.ha.persistence.dao.QueryHistory;
 import io.trino.gateway.ha.persistence.dao.QueryHistoryDao;
 import org.jdbi.v3.core.Jdbi;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -144,7 +145,7 @@ public class HaQueryHistoryManager
         List<DistributionResponse.LineChart> resList = new ArrayList<>();
         for (Map<String, Object> model : results) {
             DistributionResponse.LineChart lineChart = new DistributionResponse.LineChart();
-            long minute = (long) Float.parseFloat(model.get("minute").toString());
+            long minute = new BigDecimal(model.get("minute").toString()).longValue();
             Instant instant = Instant.ofEpochSecond(minute * 60L);
             LocalDateTime dateTime = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/BaseTestQueryHistoryManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/BaseTestQueryHistoryManager.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
@@ -117,16 +118,17 @@ abstract class BaseTestQueryHistoryManager
     @Test
     void testTimestampParsing()
     {
-        long result = 30338640;
+        // This ensures odd-minute values remain precision when converted from different formats.
+        long expectedMinuteBucket = 30338641;
 
-        // postgres: minute -> {Double@9333} 3.033864E7
-        String postgresTimestamp = "3.033864E7";
-        long parsedLongTimestamp = (long) Float.parseFloat(postgresTimestamp);
-        assertThat(parsedLongTimestamp).isEqualTo(result);
+        // postgres: minute -> {Double@9333} 3.0338641E7
+        String postgresTimestamp = "3.0338641E7";
+        long parsedPostgresMinute = new BigDecimal(postgresTimestamp).longValue();
+        assertThat(parsedPostgresMinute).isEqualTo(expectedMinuteBucket);
 
-        // mysql: minute -> {BigDecimal@9775} "30338640"
-        String mysqlTimestamp = "30338640";
-        long parsedLongTimestamp2 = (long) Float.parseFloat(mysqlTimestamp);
-        assertThat(parsedLongTimestamp2).isEqualTo(result);
+        // mysql: minute -> {BigDecimal@9775} "30338641"
+        String mysqlTimestamp = "30338641";
+        long parsedMysqlMinute = new BigDecimal(mysqlTimestamp).longValue();
+        assertThat(parsedMysqlMinute).isEqualTo(expectedMinuteBucket);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The Trino Gateway UI currently has a bug in the Query Distribution chart: query counts display correctly for even minutes, but always show zero for odd minutes due to the incorrect query count calculation.

<img width="1068" height="579" alt="Screenshot 2025-10-23 at 22 35 23" src="https://github.com/user-attachments/assets/356652b1-6077-474c-96fb-65b2b0a2bacd" />
<img width="1639" height="362" alt="Screenshot 2025-10-23 at 22 35 46" src="https://github.com/user-attachments/assets/0fbb8358-79ad-499a-adda-721c2f3e5305" />

The issue is caused by using `Float.parseFloat` when converting the minute value. Since float has limited precision, the last bit of the value was lost, results wrong minute buckets. This PR replaces `Float.parseFloat` with `BigDecimal longvalue` to ensure full precision and correct query counts for all minutes.

## Testing Done
- [x] `mvn clean install`
- [x] Tested the new query distribution chart

<img width="1067" height="574" alt="Screenshot 2025-10-23 at 22 39 49" src="https://github.com/user-attachments/assets/267105e0-435d-4264-b51a-c5a7a3c75328" />
<img width="1609" height="420" alt="Screenshot 2025-10-23 at 22 40 00" src="https://github.com/user-attachments/assets/e710f55d-dd2a-40e6-bb27-11e6bb12b02d" />

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix UI Query Distribution chart showing zero queries inaccurately.
```

## Summary by Sourcery

Bug Fixes:
- Replace Float.parseFloat with BigDecimal.longValue to avoid precision loss when computing minute buckets in the chart