### PR TITLE
Fix ErrorProne warnings and OAuth test timing issues

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ActiveClusterMonitor.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ActiveClusterMonitor.java
@@ -62,7 +62,8 @@ public class ActiveClusterMonitor
     public void start()
     {
         log.info("Running cluster monitor with connection task delay of %s", taskDelay);
-        scheduledExecutor.scheduleAtFixedRate(() -> {
+        @SuppressWarnings("unused")
+        var unused = scheduledExecutor.scheduleAtFixedRate(() -> {
             try {
                 log.info("Getting stats for all active clusters");
                 List<ProxyBackendConfiguration> activeClusters =

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterMetricsStatsExporter.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterMetricsStatsExporter.java
@@ -61,7 +61,8 @@ public class ClusterMetricsStatsExporter
     public void start()
     {
         log.debug("Running periodic metric refresh with interval of %s", refreshInterval);
-        scheduledExecutor.scheduleAtFixedRate(() -> {
+        @SuppressWarnings("unused")
+        var unused = scheduledExecutor.scheduleAtFixedRate(() -> {
             try {
                 updateClustersMetricRegistry();
             }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterStatsJdbcMonitor.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterStatsJdbcMonitor.java
@@ -21,6 +21,7 @@ import io.trino.gateway.ha.config.MonitorConfiguration;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -69,7 +70,7 @@ public class ClusterStatsJdbcMonitor
         ClusterStats.Builder clusterStats = ClusterStatsMonitor.getClusterStatsBuilder(backend);
         String jdbcUrl;
         try {
-            URL parsedUrl = new URL(url);
+            URL parsedUrl = URI.create(url).toURL();
             jdbcUrl = String
                     .format("jdbc:trino://%s:%s/system",
                             parsedUrl.getHost(),

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterStatsMetricsMonitor.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterStatsMetricsMonitor.java
@@ -13,6 +13,7 @@
  */
 package io.trino.gateway.ha.clustermonitor;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.http.client.HttpClient;
@@ -190,7 +191,7 @@ public class ClusterStatsMetricsMonitor
                 String responseBody = new String(response.getInputStream().readAllBytes(), UTF_8);
                 Map<String, String> metrics = Arrays.stream(responseBody.split("\n"))
                         .filter(line -> !line.startsWith("#"))
-                        .collect(toImmutableMap(s -> s.split(" ")[0], s -> s.split(" ")[1]));
+                        .collect(toImmutableMap(s -> Splitter.on(' ').splitToList(s).get(0), s -> Splitter.on(' ').splitToList(s).get(1)));
                 if (!metrics.keySet().containsAll(requiredKeys)) {
                     throw new UnexpectedResponseException(
                             format("Request is missing required keys: \n%s\nin response: '%s'", String.join("\n", requiredKeys), responseBody),

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/ProxyUtils.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/ProxyUtils.java
@@ -13,6 +13,7 @@
  */
 package io.trino.gateway.ha.handler;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.CharStreams;
 import io.airlift.log.Logger;
@@ -103,15 +104,15 @@ public final class ProxyUtils
         }
         if (matchingStatementPath.isPresent() || path.startsWith(V1_QUERY_PATH)) {
             path = path.replace(matchingStatementPath.orElse(V1_QUERY_PATH), "");
-            String[] tokens = path.split("/");
-            if (tokens.length >= 2) {
-                if (tokens.length >= 3 && QUERY_STATE_PATH.contains(tokens[1])) {
-                    if (tokens.length >= 4 && tokens[2].equals(PARTIAL_CANCEL_PATH)) {
-                        return Optional.of(tokens[3]);
+            List<String> tokens = Splitter.on('/').splitToList(path);
+            if (tokens.size() >= 2) {
+                if (tokens.size() >= 3 && QUERY_STATE_PATH.contains(tokens.get(1))) {
+                    if (tokens.size() >= 4 && tokens.get(2).equals(PARTIAL_CANCEL_PATH)) {
+                        return Optional.of(tokens.get(3));
                     }
-                    return Optional.of(tokens[2]);
+                    return Optional.of(tokens.get(2));
                 }
-                return Optional.of(tokens[1]);
+                return Optional.of(tokens.get(1));
             }
         }
         else if (path.startsWith(TRINO_UI_PATH)) {

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/JdbcConnectionManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/JdbcConnectionManager.java
@@ -104,7 +104,8 @@ public class JdbcConnectionManager
 
     private void startCleanUps()
     {
-        executorService.scheduleWithFixedDelay(
+        @SuppressWarnings("unused")
+        var unused = executorService.scheduleWithFixedDelay(
                 () -> {
                     log.info("Performing query history cleanup task");
                     long created = System.currentTimeMillis() - TimeUnit.HOURS.toMillis(this.configuration.getQueryHistoryHoursRetention());

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
@@ -70,7 +70,7 @@ import static java.util.Objects.requireNonNullElse;
 @Path("/webapp")
 public class GatewayWebAppResource
 {
-    private static final LocalDateTime START_TIME = LocalDateTime.now(ZoneId.systemDefault());
+    private final LocalDateTime startTime = LocalDateTime.now(ZoneId.systemDefault());
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
     private final GatewayBackendManager gatewayBackendManager;
     private final QueryHistoryManager queryHistoryManager;
@@ -167,7 +167,7 @@ public class GatewayWebAppResource
                         state -> state.trinoStatus() == TrinoStatus.HEALTHY,
                         Collectors.collectingAndThen(Collectors.counting(), Long::intValue)));
         Integer latestHour = query.latestHour();
-        Long ts = System.currentTimeMillis() - (latestHour * 60 * 60 * 1000);
+        Long ts = System.currentTimeMillis() - (latestHour * 60 * 60 * 1000L);
         List<DistributionResponse.LineChart> lineChart = queryHistoryManager.findDistribution(ts);
         lineChart.forEach(qh -> qh.setName(urlToNameMap.get(qh.getBackendUrl())));
         Map<String, List<DistributionResponse.LineChart>> lineChartMap = lineChart.stream().collect(Collectors.groupingBy(DistributionResponse.LineChart::getName));
@@ -192,7 +192,7 @@ public class GatewayWebAppResource
         distributionResponse.setTotalQueryCount(totalQueryCount);
         distributionResponse.setAverageQueryCountSecond(totalQueryCount / (latestHour * 60d * 60d));
         distributionResponse.setAverageQueryCountMinute(totalQueryCount / (latestHour * 60d));
-        ZonedDateTime zonedLocalTime = START_TIME.atZone(ZoneId.systemDefault());
+        ZonedDateTime zonedLocalTime = startTime.atZone(ZoneId.systemDefault());
         ZonedDateTime utcTime = zonedLocalTime.withZoneSameInstant(ZoneOffset.UTC);
         distributionResponse.setStartTime(utcTime.format(formatter));
         return Response.ok(Result.ok(distributionResponse)).build();

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/GatewayCookie.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/GatewayCookie.java
@@ -152,7 +152,7 @@ public class GatewayCookie
     public int compareTo(GatewayCookie o)
     {
         int priorityDelta = unsignedGatewayCookie.getPriority() - o.getPriority();
-        return priorityDelta != 0 ? priorityDelta : (int) (unsignedGatewayCookie.getTs() - o.getTs());
+        return priorityDelta != 0 ? priorityDelta : unsignedGatewayCookie.getTs().compareTo(o.getTs());
     }
 
     public Cookie toCookie()

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/StatementUtils.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/StatementUtils.java
@@ -195,8 +195,8 @@ public final class StatementUtils
 
     public static String getResourceGroupQueryType(Statement statement)
     {
-        if (statement instanceof ExplainAnalyze) {
-            return getResourceGroupQueryType(((ExplainAnalyze) statement).getStatement());
+        if (statement instanceof ExplainAnalyze explainAnalyze) {
+            return getResourceGroupQueryType(explainAnalyze.getStatement());
         }
         StatementTypeInfo<? extends Statement> statementTypeInfo = STATEMENT_QUERY_TYPES.get(statement.getClass());
         if (statementTypeInfo != null) {

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/StochasticRoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/StochasticRoutingManager.java
@@ -19,13 +19,11 @@ import io.trino.gateway.ha.config.RoutingConfiguration;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class StochasticRoutingManager
         extends BaseRoutingManager
 {
-    private static final Random RANDOM = new Random();
-
     @Inject
     public StochasticRoutingManager(
             GatewayBackendManager gatewayBackendManager,
@@ -41,7 +39,7 @@ public class StochasticRoutingManager
         if (backends.isEmpty()) {
             return Optional.empty();
         }
-        int backendId = Math.abs(RANDOM.nextInt()) % backends.size();
+        int backendId = ThreadLocalRandom.current().nextInt(backends.size());
         return Optional.of(backends.get(backendId));
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/TrinoQueryProperties.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/TrinoQueryProperties.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -300,13 +301,13 @@ public class TrinoQueryProperties
             return preparedStatementsMapBuilder.build();
         }
         while (headers.hasMoreElements()) {
-            String[] preparedStatementsArray = headers.nextElement().split(",");
+            Iterable<String> preparedStatementsArray = Splitter.on(',').split(headers.nextElement());
             for (String preparedStatement : preparedStatementsArray) {
-                String[] nameValue = preparedStatement.split("=");
-                if (nameValue.length != 2) {
+                List<String> nameValue = Splitter.on('=').splitToList(preparedStatement);
+                if (nameValue.size() != 2) {
                     throw new RequestParsingException(format("preparedStatement must be formatted as name=value, but is %s", preparedStatement));
                 }
-                preparedStatementsMapBuilder.put(URLDecoder.decode(nameValue[0], UTF_8), URLDecoder.decode(decodePreparedStatementFromHeader(nameValue[1]), UTF_8));
+                preparedStatementsMapBuilder.put(URLDecoder.decode(nameValue.get(0), UTF_8), URLDecoder.decode(decodePreparedStatementFromHeader(nameValue.get(1)), UTF_8));
             }
         }
         return preparedStatementsMapBuilder.build();

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbKeyProvider.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbKeyProvider.java
@@ -78,13 +78,13 @@ public class LbKeyProvider
 
     RSAPrivateKey getRsaPrivateKey()
     {
-        return (this.privateKey instanceof RSAPrivateKey)
-                ? (RSAPrivateKey) this.privateKey : null;
+        return (this.privateKey instanceof RSAPrivateKey rSAPrivateKey)
+                ? rSAPrivateKey : null;
     }
 
     RSAPublicKey getRsaPublicKey()
     {
-        return (this.publicKey instanceof RSAPublicKey)
-                ? (RSAPublicKey) this.publicKey : null;
+        return (this.publicKey instanceof RSAPublicKey rSAPublicKey)
+                ? rSAPublicKey : null;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbTokenUtil.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbTokenUtil.java
@@ -47,7 +47,8 @@ public final class LbTokenUtil
 
             audiences.ifPresent(auds -> verification.withAnyOfAudience(auds.toArray(new String[0])));
 
-            verification.build().verify(idToken);
+            // Add clock skew tolerance for containerized environments
+            verification.acceptLeeway(10).build().verify(idToken);
         }
         catch (Exception exc) {
             log.error(exc, "Could not validate token.");

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/clustermonitor/TestClusterMetricsStatsExporter.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/clustermonitor/TestClusterMetricsStatsExporter.java
@@ -48,14 +48,14 @@ final class TestClusterMetricsStatsExporter
             sleepUninterruptibly(2, SECONDS);
 
             verify(statsExporter.exporter()).exportWithGeneratedName(
-                    argThat(stats -> stats instanceof ClusterMetricsStats && ((ClusterMetricsStats) stats).getClusterName().equals(clusterName1)),
+                    argThat(stats -> stats instanceof ClusterMetricsStats clusterMetricsStats && clusterMetricsStats.getClusterName().equals(clusterName1)),
                     eq(ClusterMetricsStats.class), eq(clusterName1));
 
             // Wait for next update where cluster is added
             sleepUninterruptibly(2, SECONDS);
 
             verify(statsExporter.exporter()).exportWithGeneratedName(
-                    argThat(stats -> stats instanceof ClusterMetricsStats && ((ClusterMetricsStats) stats).getClusterName().equals(clusterName2)),
+                    argThat(stats -> stats instanceof ClusterMetricsStats clusterMetricsStats && clusterMetricsStats.getClusterName().equals(clusterName2)),
                     eq(ClusterMetricsStats.class), eq(clusterName2));
         }
     }
@@ -74,7 +74,7 @@ final class TestClusterMetricsStatsExporter
             sleepUninterruptibly(2, SECONDS);
 
             verify(statsExporter.exporter()).exportWithGeneratedName(
-                    argThat(stats -> stats instanceof ClusterMetricsStats && ((ClusterMetricsStats) stats).getClusterName().equals(clusterName)),
+                    argThat(stats -> stats instanceof ClusterMetricsStats clusterMetricsStats && clusterMetricsStats.getClusterName().equals(clusterName)),
                     eq(ClusterMetricsStats.class), eq(clusterName));
 
             // Wait for next update where cluster is removed

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestResourceGroupsManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestResourceGroupsManager.java
@@ -80,7 +80,7 @@ public class TestResourceGroupsManager
         assertThat(resourceGroups.get(0).getName()).isEqualTo("admin");
         assertThat(resourceGroups.get(0).getHardConcurrencyLimit()).isEqualTo(20);
         assertThat(resourceGroups.get(0).getMaxQueued()).isEqualTo(200);
-        assertThat(resourceGroups.get(0).getJmxExport()).isEqualTo(Boolean.TRUE);
+        assertThat(resourceGroups.get(0).getJmxExport()).isEqualTo(true);
         assertThat(resourceGroups.get(0).getSoftMemoryLimit()).isEqualTo("80%");
     }
 
@@ -128,21 +128,21 @@ public class TestResourceGroupsManager
         assertThat(resourceGroups.get(0).getName()).isEqualTo("admin");
         assertThat(resourceGroups.get(0).getHardConcurrencyLimit()).isEqualTo(50);
         assertThat(resourceGroups.get(0).getMaxQueued()).isEqualTo(50);
-        assertThat(resourceGroups.get(0).getJmxExport()).isEqualTo(Boolean.FALSE);
+        assertThat(resourceGroups.get(0).getJmxExport()).isEqualTo(false);
         assertThat(resourceGroups.get(0).getSoftMemoryLimit()).isEqualTo("20%");
 
         assertThat(resourceGroups.get(1).getResourceGroupId()).isEqualTo(2L);
         assertThat(resourceGroups.get(1).getName()).isEqualTo("user");
         assertThat(resourceGroups.get(1).getHardConcurrencyLimit()).isEqualTo(10);
         assertThat(resourceGroups.get(1).getMaxQueued()).isEqualTo(100);
-        assertThat(resourceGroups.get(1).getJmxExport()).isEqualTo(Boolean.TRUE);
+        assertThat(resourceGroups.get(1).getJmxExport()).isEqualTo(true);
         assertThat(resourceGroups.get(1).getSoftMemoryLimit()).isEqualTo("50%");
 
         assertThat(resourceGroups.get(2).getResourceGroupId()).isEqualTo(3L);
         assertThat(resourceGroups.get(2).getName()).isEqualTo("localization-eng");
         assertThat(resourceGroups.get(2).getHardConcurrencyLimit()).isEqualTo(50);
         assertThat(resourceGroups.get(2).getMaxQueued()).isEqualTo(70);
-        assertThat(resourceGroups.get(2).getJmxExport()).isEqualTo(Boolean.TRUE);
+        assertThat(resourceGroups.get(2).getJmxExport()).isEqualTo(true);
         assertThat(resourceGroups.get(2).getSoftMemoryLimit()).isEqualTo("20%");
         assertThat(resourceGroups.get(2).getSoftConcurrencyLimit()).isEqualTo(Integer.valueOf(20));
     }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingRulesManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingRulesManager.java
@@ -128,7 +128,8 @@ final class TestRoutingRulesManager
 
         ExecutorService executorService = Executors.newFixedThreadPool(2);
 
-        executorService.submit(() ->
+        @SuppressWarnings("unused")
+        var unused1 = executorService.submit(() ->
         {
             try {
                 routingRulesManager.updateRoutingRule(routingRule1);
@@ -138,7 +139,8 @@ final class TestRoutingRulesManager
             }
         });
 
-        executorService.submit(() ->
+        @SuppressWarnings("unused")
+        var unused2 = executorService.submit(() ->
         {
             try {
                 routingRulesManager.updateRoutingRule(routingRule2);

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/util/QueryRequestMock.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/util/QueryRequestMock.java
@@ -116,6 +116,13 @@ public class QueryRequestMock
             {
                 return byteArrayInputStream.read();
             }
+
+            @Override
+            public int read(byte[] b, int off, int len)
+                    throws IOException
+            {
+                return byteArrayInputStream.read(b, off, len);
+            }
         });
 
         when(mockRequest.getReader()).thenReturn(new BufferedReader(new StringReader(query)));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fix error messages during mvn build and test timing issues

- Replace deprecated URL(String) constructor with URI.create().toURL()
- Fix FutureReturnValueIgnored warnings by capturing return values with @SuppressWarnings("unused")
- Replace String.split() with Guava Splitter to avoid StringSplitter warnings
- Use pattern-matching instanceof to simplify type checks
- Fix time access in static initializer by moving to instance field
- Fix integer overflow by adding explicit long suffix (1000L)
- Use Long.compareTo() instead of manual subtraction to avoid sign flip
- Replace Math.abs() with ThreadLocalRandom.nextInt() for safer random number generation
- Suppress TestContainers deprecation warnings with @SuppressWarnings("deprecation")
- Replace Boolean.TRUE/FALSE with boolean literals in test assertions
- Add multi-byte read method override to fix InputStreamSlowMultibyteRead warning
- Replace Iterables.get() with Stream API for modernizer compliance
- Add 10-second clock skew tolerance to JWT verification for containerized environments

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Currently, mvn build logs warning
- https://github.com/trinodb/trino-gateway/actions/runs/19052033653/job/54414294473?pr=788#step:4:3530

```
Warning:  /home/runner/work/trino-gateway/trino-gateway/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterStatsJdbcMonitor.java:[72,29] URL(java.lang.String) in java.net.URL has been deprecated
Warning:  /home/runner/work/trino-gateway/trino-gateway/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ActiveClusterMonitor.java:[65,46] [FutureReturnValueIgnored] Return value of methods returning Future must be checked. Ignoring returned Futures suppresses exceptions thrown from the code that completes the Future.
    (see https://errorprone.info/bugpattern/FutureReturnValueIgnored)
  Did you mean 'var unused = scheduledExecutor.scheduleAtFixedRate(() -> {' or to remove this line?
....
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```

## Summary by Sourcery

Address ErrorProne warnings and OAuth test timing issues by refactoring deprecated APIs, adopting safer patterns, suppressing spurious warnings, and adjusting JWT verification tolerance

Bug Fixes:
- Add 10-second clock skew tolerance to JWT verification for containerized environments

Enhancements:
- Replace deprecated URL(String) constructor with URI.create().toURL()
- Capture ignored Future return values and suppress related warnings
- Swap String.split usages for Guava Splitter and Stream API to avoid warnings
- Apply pattern-matching instanceof and use Long.compareTo over subtraction
- Switch from Random to ThreadLocalRandom and add explicit long suffix to time calculations
- Suppress deprecation warnings for TestContainers and scheduled task submissions
- Move webapp start time initialization to instance field to fix timing issues

Tests:
- Consolidate duplicated SSL setup, redirect extraction and HTTP client creation in TestOIDC
- Add multi-byte read override in tests and replace Boolean.TRUE/FALSE with literals