### PR TITLE
Add db connection pool support

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,6 +55,14 @@ You can also disable query history recording to the database by setting
 `queryHistoryEnabled` to `false`. This can be useful in scenarios where you
 want to reduce database load or don't need query history tracking.
 
+If `maxPoolSize` is configured and greater than 0, Trino Gateway uses a
+connection pool for data store connections, including gateway metadata and
+query history.
+If `maxPoolSize` is not configured, Trino Gateway creates a new JDBC connection
+per request.
+A value of `10` is a reasonable starting point for many deployments, but the
+optimal value depends on the database capacity and expected concurrency.
+
 For example:
 
 ```yaml
@@ -66,6 +74,7 @@ dataStore:
   queryHistoryHoursRetention: 24
   runMigrationsEnabled: false
   queryHistoryEnabled: true  # Set to false to disable query history recording
+  maxPoolSize: 10            # Optional: enables JDBC connection pooling for the data store
 ```
 
 `Flyway` uses a transactional lock in databases that support it such as 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,6 +55,20 @@ You can also disable query history recording to the database by setting
 `queryHistoryEnabled` to `false`. This can be useful in scenarios where you
 want to reduce database load or don't need query history tracking.
 
+If `maxPoolSize` is configured and greater than 0, Trino Gateway uses a
+connection pool for data store connections, including gateway metadata and
+query history.
+If `maxPoolSize` is not configured, Trino Gateway creates a new JDBC connection
+per request.
+A value of `10` is a reasonable starting point for many deployments, but the
+optimal value depends on the database capacity and expected concurrency.
+The optional `keepaliveTime` and `maxLifetime` settings control how frequently
+idle pooled connections are checked and how long a pooled connection can be
+reused. Both accept Airlift-style durations such as `2m` or `30m`. If they are
+not configured, the connection pool defaults are used. Non-zero values must be
+at least `30s`, and `keepaliveTime` must be less than `maxLifetime` when both
+are enabled.
+
 For example:
 
 ```yaml
@@ -66,6 +80,9 @@ dataStore:
   queryHistoryHoursRetention: 24
   runMigrationsEnabled: false
   queryHistoryEnabled: true  # Set to false to disable query history recording
+  maxPoolSize: 10            # Optional: enables JDBC connection pooling for the data store
+  keepaliveTime: 2m          # Optional: interval for checking idle pooled connections
+  maxLifetime: 30m           # Optional: maximum lifetime of a pooled connection
 ```
 
 `Flyway` uses a transactional lock in databases that support it such as 

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -109,6 +109,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>7.0.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>aircompressor-v3</artifactId>
             <version>3.7</version>

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/DataStoreConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/DataStoreConfiguration.java
@@ -22,8 +22,9 @@ public class DataStoreConfiguration
     private boolean queryHistoryEnabled = true;
     private Integer queryHistoryHoursRetention = 4;
     private boolean runMigrationsEnabled = true;
+    private Integer maxPoolSize;
 
-    public DataStoreConfiguration(String jdbcUrl, String user, String password, String driver, boolean queryHistoryEnabled, Integer queryHistoryHoursRetention, boolean runMigrationsEnabled)
+    public DataStoreConfiguration(String jdbcUrl, String user, String password, String driver, boolean queryHistoryEnabled, Integer queryHistoryHoursRetention, boolean runMigrationsEnabled, Integer maxPoolSize)
     {
         this.jdbcUrl = jdbcUrl;
         this.user = user;
@@ -32,6 +33,7 @@ public class DataStoreConfiguration
         this.queryHistoryEnabled = queryHistoryEnabled;
         this.queryHistoryHoursRetention = queryHistoryHoursRetention;
         this.runMigrationsEnabled = runMigrationsEnabled;
+        this.maxPoolSize = maxPoolSize;
     }
 
     public DataStoreConfiguration() {}
@@ -104,5 +106,15 @@ public class DataStoreConfiguration
     public void setRunMigrationsEnabled(boolean runMigrationsEnabled)
     {
         this.runMigrationsEnabled = runMigrationsEnabled;
+    }
+
+    public Integer getMaxPoolSize()
+    {
+        return maxPoolSize;
+    }
+
+    public void setMaxPoolSize(Integer maxPoolSize)
+    {
+        this.maxPoolSize = maxPoolSize;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/DataStoreConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/DataStoreConfiguration.java
@@ -13,6 +13,8 @@
  */
 package io.trino.gateway.ha.config;
 
+import io.airlift.units.Duration;
+
 public class DataStoreConfiguration
 {
     private String jdbcUrl;
@@ -22,8 +24,11 @@ public class DataStoreConfiguration
     private boolean queryHistoryEnabled = true;
     private Integer queryHistoryHoursRetention = 4;
     private boolean runMigrationsEnabled = true;
+    private Integer maxPoolSize;
+    private Duration keepaliveTime;
+    private Duration maxLifetime;
 
-    public DataStoreConfiguration(String jdbcUrl, String user, String password, String driver, boolean queryHistoryEnabled, Integer queryHistoryHoursRetention, boolean runMigrationsEnabled)
+    public DataStoreConfiguration(String jdbcUrl, String user, String password, String driver, boolean queryHistoryEnabled, Integer queryHistoryHoursRetention, boolean runMigrationsEnabled, Integer maxPoolSize)
     {
         this.jdbcUrl = jdbcUrl;
         this.user = user;
@@ -32,6 +37,7 @@ public class DataStoreConfiguration
         this.queryHistoryEnabled = queryHistoryEnabled;
         this.queryHistoryHoursRetention = queryHistoryHoursRetention;
         this.runMigrationsEnabled = runMigrationsEnabled;
+        this.maxPoolSize = maxPoolSize;
     }
 
     public DataStoreConfiguration() {}
@@ -104,5 +110,35 @@ public class DataStoreConfiguration
     public void setRunMigrationsEnabled(boolean runMigrationsEnabled)
     {
         this.runMigrationsEnabled = runMigrationsEnabled;
+    }
+
+    public Integer getMaxPoolSize()
+    {
+        return maxPoolSize;
+    }
+
+    public void setMaxPoolSize(Integer maxPoolSize)
+    {
+        this.maxPoolSize = maxPoolSize;
+    }
+
+    public Duration getKeepaliveTime()
+    {
+        return keepaliveTime;
+    }
+
+    public void setKeepaliveTime(Duration keepaliveTime)
+    {
+        this.keepaliveTime = keepaliveTime;
+    }
+
+    public Duration getMaxLifetime()
+    {
+        return maxLifetime;
+    }
+
+    public void setMaxLifetime(Duration maxLifetime)
+    {
+        this.maxLifetime = maxLifetime;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/JdbcConnectionManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/JdbcConnectionManager.java
@@ -15,20 +15,27 @@ package io.trino.gateway.ha.persistence;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import io.airlift.log.Logger;
 import io.trino.gateway.ha.config.DataStoreConfiguration;
 import io.trino.gateway.ha.persistence.dao.QueryHistoryDao;
 import jakarta.annotation.Nullable;
+import jakarta.annotation.PreDestroy;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class JdbcConnectionManager
@@ -39,27 +46,39 @@ public class JdbcConnectionManager
     private final DataStoreConfiguration configuration;
     private final ScheduledExecutorService executorService =
             Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledFuture<?> cleanupTask;
+
+    private final Map<String, HikariDataSource> pools = new ConcurrentHashMap<>();
 
     @Inject
     public JdbcConnectionManager(Jdbi jdbi, DataStoreConfiguration configuration)
     {
         this.jdbi = requireNonNull(jdbi, "jdbi is null");
-        this.configuration = configuration;
-        startCleanUps();
+        this.configuration = requireNonNull(configuration, "configuration is null");
+        cleanupTask = startCleanUps();
     }
 
     public Jdbi getJdbi()
     {
-        return jdbi;
+        return getJdbi(null);
     }
 
     public Jdbi getJdbi(@Nullable String routingGroupDatabase)
     {
-        if (routingGroupDatabase == null) {
+        Jdbi result;
+        Integer maxPoolSize = configuration.getMaxPoolSize();
+        if (maxPoolSize != null) {
+            HikariDataSource dataSource = getOrCreateDataSource(routingGroupDatabase, maxPoolSize);
+            result = Jdbi.create(dataSource);
+        }
+        else if (routingGroupDatabase == null) {
             return jdbi;
         }
+        else {
+            result = Jdbi.create(buildJdbcUrl(routingGroupDatabase), configuration.getUser(), configuration.getPassword());
+        }
 
-        return Jdbi.create(buildJdbcUrl(routingGroupDatabase), configuration.getUser(), configuration.getPassword())
+        return result
                 .installPlugin(new SqlObjectPlugin())
                 .registerRowMapper(new RecordAndAnnotatedConstructorMapper());
     }
@@ -102,16 +121,65 @@ public class JdbcConnectionManager
                 uri.getFragment());
     }
 
-    private void startCleanUps()
+    private ScheduledFuture<?> startCleanUps()
     {
-        executorService.scheduleWithFixedDelay(
+        return executorService.scheduleWithFixedDelay(
                 () -> {
                     log.info("Performing query history cleanup task");
                     long created = System.currentTimeMillis() - TimeUnit.HOURS.toMillis(this.configuration.getQueryHistoryHoursRetention());
-                    jdbi.onDemand(QueryHistoryDao.class).deleteOldHistory(created);
+                    getJdbi().onDemand(QueryHistoryDao.class).deleteOldHistory(created);
                 },
                 1,
                 120,
                 TimeUnit.MINUTES);
+    }
+
+    private HikariDataSource getOrCreateDataSource(@Nullable String routingGroupDatabase, int maxPoolSize)
+    {
+        checkArgument(maxPoolSize > 0, "maxPoolSize must be greater than 0");
+        String jdbcUrl = buildJdbcUrl(routingGroupDatabase);
+        return pools.compute(jdbcUrl, (_, existing) -> {
+            if (existing != null && !existing.isClosed()) {
+                return existing;
+            }
+
+            HikariConfig hikariConfig = new HikariConfig();
+            hikariConfig.setJdbcUrl(jdbcUrl);
+            hikariConfig.setUsername(configuration.getUser());
+            hikariConfig.setPassword(configuration.getPassword());
+            if (configuration.getDriver() != null) {
+                hikariConfig.setDriverClassName(configuration.getDriver());
+            }
+            hikariConfig.setMaximumPoolSize(maxPoolSize);
+            if (configuration.getKeepaliveTime() != null) {
+                hikariConfig.setKeepaliveTime(configuration.getKeepaliveTime().toMillis());
+            }
+            if (configuration.getMaxLifetime() != null) {
+                hikariConfig.setMaxLifetime(configuration.getMaxLifetime().toMillis());
+            }
+            hikariConfig.setPoolName(routingGroupDatabase == null ? "gateway-ha-default" : "gateway-ha-" + routingGroupDatabase);
+
+            return new HikariDataSource(hikariConfig);
+        });
+    }
+
+    @PreDestroy
+    public void close()
+    {
+        cleanupTask.cancel(true);
+        executorService.shutdownNow();
+
+        for (Map.Entry<String, HikariDataSource> entry : pools.entrySet()) {
+            HikariDataSource dataSource = entry.getValue();
+            if (!dataSource.isClosed()) {
+                try {
+                    dataSource.close();
+                }
+                catch (RuntimeException exception) {
+                    log.warn(exception, "Failed to close datasource for key: %s", entry.getKey());
+                }
+            }
+        }
+        pools.clear();
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/JdbcConnectionManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/JdbcConnectionManager.java
@@ -15,20 +15,27 @@ package io.trino.gateway.ha.persistence;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import io.airlift.log.Logger;
 import io.trino.gateway.ha.config.DataStoreConfiguration;
 import io.trino.gateway.ha.persistence.dao.QueryHistoryDao;
 import jakarta.annotation.Nullable;
+import jakarta.annotation.PreDestroy;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class JdbcConnectionManager
@@ -39,27 +46,39 @@ public class JdbcConnectionManager
     private final DataStoreConfiguration configuration;
     private final ScheduledExecutorService executorService =
             Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledFuture<?> cleanupTask;
+
+    private final Map<String, HikariDataSource> pools = new ConcurrentHashMap<>();
 
     @Inject
     public JdbcConnectionManager(Jdbi jdbi, DataStoreConfiguration configuration)
     {
         this.jdbi = requireNonNull(jdbi, "jdbi is null");
-        this.configuration = configuration;
-        startCleanUps();
+        this.configuration = requireNonNull(configuration, "configuration is null");
+        cleanupTask = startCleanUps();
     }
 
     public Jdbi getJdbi()
     {
-        return jdbi;
+        return getJdbi(null);
     }
 
     public Jdbi getJdbi(@Nullable String routingGroupDatabase)
     {
-        if (routingGroupDatabase == null) {
+        Jdbi result;
+        Integer maxPoolSize = configuration.getMaxPoolSize();
+        if (maxPoolSize != null) {
+            HikariDataSource dataSource = getOrCreateDataSource(routingGroupDatabase, maxPoolSize);
+            result = Jdbi.create(dataSource);
+        }
+        else if (routingGroupDatabase == null) {
             return jdbi;
         }
+        else {
+            result = Jdbi.create(buildJdbcUrl(routingGroupDatabase), configuration.getUser(), configuration.getPassword());
+        }
 
-        return Jdbi.create(buildJdbcUrl(routingGroupDatabase), configuration.getUser(), configuration.getPassword())
+        return result
                 .installPlugin(new SqlObjectPlugin())
                 .registerRowMapper(new RecordAndAnnotatedConstructorMapper());
     }
@@ -102,16 +121,59 @@ public class JdbcConnectionManager
                 uri.getFragment());
     }
 
-    private void startCleanUps()
+    private ScheduledFuture<?> startCleanUps()
     {
-        executorService.scheduleWithFixedDelay(
+        return executorService.scheduleWithFixedDelay(
                 () -> {
                     log.info("Performing query history cleanup task");
                     long created = System.currentTimeMillis() - TimeUnit.HOURS.toMillis(this.configuration.getQueryHistoryHoursRetention());
-                    jdbi.onDemand(QueryHistoryDao.class).deleteOldHistory(created);
+                    getJdbi().onDemand(QueryHistoryDao.class).deleteOldHistory(created);
                 },
                 1,
                 120,
                 TimeUnit.MINUTES);
+    }
+
+    private HikariDataSource getOrCreateDataSource(@Nullable String routingGroupDatabase, int maxPoolSize)
+    {
+        checkArgument(maxPoolSize > 0, "maxPoolSize must be greater than 0");
+        String jdbcUrl = buildJdbcUrl(routingGroupDatabase);
+        return pools.compute(jdbcUrl, (_, existing) -> {
+            if (existing != null && !existing.isClosed()) {
+                return existing;
+            }
+
+            HikariConfig hikariConfig = new HikariConfig();
+            hikariConfig.setJdbcUrl(jdbcUrl);
+            hikariConfig.setUsername(configuration.getUser());
+            hikariConfig.setPassword(configuration.getPassword());
+            if (configuration.getDriver() != null) {
+                hikariConfig.setDriverClassName(configuration.getDriver());
+            }
+            hikariConfig.setMaximumPoolSize(maxPoolSize);
+            hikariConfig.setPoolName(routingGroupDatabase == null ? "gateway-ha-default" : "gateway-ha-" + routingGroupDatabase);
+
+            return new HikariDataSource(hikariConfig);
+        });
+    }
+
+    @PreDestroy
+    public void close()
+    {
+        cleanupTask.cancel(true);
+        executorService.shutdownNow();
+
+        for (Map.Entry<String, HikariDataSource> entry : pools.entrySet()) {
+            HikariDataSource dataSource = entry.getValue();
+            if (!dataSource.isClosed()) {
+                try {
+                    dataSource.close();
+                }
+                catch (RuntimeException exception) {
+                    log.warn(exception, "Failed to close datasource for key: %s", entry.getKey());
+                }
+            }
+        }
+        pools.clear();
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaGatewayManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaGatewayManager.java
@@ -24,6 +24,7 @@ import io.airlift.stats.CounterStat;
 import io.trino.gateway.ha.config.DatabaseCacheConfiguration;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 import io.trino.gateway.ha.config.RoutingConfiguration;
+import io.trino.gateway.ha.persistence.JdbcConnectionManager;
 import io.trino.gateway.ha.persistence.dao.GatewayBackend;
 import io.trino.gateway.ha.persistence.dao.GatewayBackendDao;
 import org.jdbi.v3.core.Jdbi;
@@ -51,6 +52,11 @@ public class HaGatewayManager
     private final CounterStat backendLookupFailures = new CounterStat();
 
     @Inject
+    public HaGatewayManager(JdbcConnectionManager connectionManager, RoutingConfiguration routingConfiguration, DatabaseCacheConfiguration databaseCacheConfiguration)
+    {
+        this(requireNonNull(connectionManager, "connectionManager is null").getJdbi(), routingConfiguration, databaseCacheConfiguration);
+    }
+
     public HaGatewayManager(Jdbi jdbi, RoutingConfiguration routingConfiguration, DatabaseCacheConfiguration databaseCacheConfiguration)
     {
         this(jdbi, routingConfiguration, databaseCacheConfiguration, Ticker.systemTicker());

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaQueryHistoryManager.java
@@ -19,6 +19,7 @@ import io.trino.gateway.ha.config.DataStoreConfiguration;
 import io.trino.gateway.ha.domain.TableData;
 import io.trino.gateway.ha.domain.request.QueryHistoryRequest;
 import io.trino.gateway.ha.domain.response.DistributionResponse;
+import io.trino.gateway.ha.persistence.JdbcConnectionManager;
 import io.trino.gateway.ha.persistence.dao.QueryHistory;
 import io.trino.gateway.ha.persistence.dao.QueryHistoryDao;
 import org.jdbi.v3.core.Jdbi;
@@ -42,6 +43,11 @@ public class HaQueryHistoryManager
     private final boolean queryHistoryEnabled;
 
     @Inject
+    public HaQueryHistoryManager(JdbcConnectionManager connectionManager, DataStoreConfiguration configuration)
+    {
+        this(requireNonNull(connectionManager, "connectionManager is null").getJdbi(), configuration);
+    }
+
     public HaQueryHistoryManager(Jdbi jdbi, DataStoreConfiguration configuration)
     {
         dao = requireNonNull(jdbi, "jdbi is null").onDemand(QueryHistoryDao.class);

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestingJdbcConnectionManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestingJdbcConnectionManager.java
@@ -33,7 +33,7 @@ public final class TestingJdbcConnectionManager
         tempH2DbDir.deleteOnExit();
         String jdbcUrl = "jdbc:h2:" + tempH2DbDir.getAbsolutePath() + ";NON_KEYWORDS=NAME,VALUE";
         HaGatewayTestUtils.seedRequiredData(tempH2DbDir.getAbsolutePath());
-        return new DataStoreConfiguration(jdbcUrl, "sa", "sa", "org.h2.Driver", true, 4, false);
+        return new DataStoreConfiguration(jdbcUrl, "sa", "sa", "org.h2.Driver", true, 4, false, null);
     }
 
     public static JdbcConnectionManager createTestingJdbcConnectionManager(DataStoreConfiguration config)

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/config/TestDataStoreConfiguration.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/config/TestDataStoreConfiguration.java
@@ -13,8 +13,10 @@
  */
 package io.trino.gateway.ha.config;
 
+import io.airlift.units.Duration;
 import org.junit.jupiter.api.Test;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class TestDataStoreConfiguration
@@ -28,6 +30,9 @@ final class TestDataStoreConfiguration
         assertThat(dataStoreConfiguration.getPassword()).isNull();
         assertThat(dataStoreConfiguration.getDriver()).isNull();
         assertThat(dataStoreConfiguration.isQueryHistoryEnabled()).isTrue();
+        assertThat(dataStoreConfiguration.getMaxPoolSize()).isNull();
+        assertThat(dataStoreConfiguration.getKeepaliveTime()).isNull();
+        assertThat(dataStoreConfiguration.getMaxLifetime()).isNull();
     }
 
     @Test
@@ -49,5 +54,14 @@ final class TestDataStoreConfiguration
 
         dataStoreConfiguration.setQueryHistoryEnabled(false);
         assertThat(dataStoreConfiguration.isQueryHistoryEnabled()).isFalse();
+
+        dataStoreConfiguration.setMaxPoolSize(10);
+        assertThat(dataStoreConfiguration.getMaxPoolSize()).isEqualTo(10);
+
+        dataStoreConfiguration.setKeepaliveTime(new Duration(2, MINUTES));
+        assertThat(dataStoreConfiguration.getKeepaliveTime()).isEqualTo(new Duration(2, MINUTES));
+
+        dataStoreConfiguration.setMaxLifetime(new Duration(30, MINUTES));
+        assertThat(dataStoreConfiguration.getMaxLifetime()).isEqualTo(new Duration(30, MINUTES));
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/config/TestDataStoreConfiguration.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/config/TestDataStoreConfiguration.java
@@ -28,6 +28,7 @@ final class TestDataStoreConfiguration
         assertThat(dataStoreConfiguration.getPassword()).isNull();
         assertThat(dataStoreConfiguration.getDriver()).isNull();
         assertThat(dataStoreConfiguration.isQueryHistoryEnabled()).isTrue();
+        assertThat(dataStoreConfiguration.getMaxPoolSize()).isNull();
     }
 
     @Test
@@ -49,5 +50,8 @@ final class TestDataStoreConfiguration
 
         dataStoreConfiguration.setQueryHistoryEnabled(false);
         assertThat(dataStoreConfiguration.isQueryHistoryEnabled()).isFalse();
+
+        dataStoreConfiguration.setMaxPoolSize(10);
+        assertThat(dataStoreConfiguration.getMaxPoolSize()).isEqualTo(10);
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/BaseTestDatabaseMigrations.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/BaseTestDatabaseMigrations.java
@@ -132,6 +132,7 @@ public abstract class BaseTestDatabaseMigrations
                 container.getDriverClassName(),
                 true,
                 4,
-                true);
+                true,
+                null);
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestJdbcConnectionManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestJdbcConnectionManager.java
@@ -125,7 +125,7 @@ final class TestJdbcConnectionManager
 
     private static JdbcConnectionManager createConnectionManager(String jdbcUrl)
     {
-        DataStoreConfiguration db = new DataStoreConfiguration(jdbcUrl, "sa", "sa", "", true, 4, true);
+        DataStoreConfiguration db = new DataStoreConfiguration(jdbcUrl, "sa", "sa", "", true, 4, true, null);
         return new JdbcConnectionManager(Jdbi.create(jdbcUrl, "sa", "sa"), db);
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestJdbcConnectionManagerPool.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestJdbcConnectionManagerPool.java
@@ -1,0 +1,301 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.persistence;
+
+import io.trino.gateway.ha.config.DataStoreConfiguration;
+import io.trino.gateway.ha.config.DatabaseCacheConfiguration;
+import io.trino.gateway.ha.config.RoutingConfiguration;
+import io.trino.gateway.ha.router.HaGatewayManager;
+import io.trino.gateway.ha.router.HaQueryHistoryManager;
+import io.trino.gateway.ha.router.QueryHistoryManager;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestJdbcConnectionManagerPool
+{
+    @TempDir
+    private Path temporaryDirectory;
+
+    @Test
+    void testRoutingGroupJdbiReusesPoolAndBlocksWhenExceedingMaxPoolSize()
+            throws Exception
+    {
+        DataStoreConfiguration configuration = createConfiguration("routing-group", 2);
+        JdbcConnectionManager connectionManager = createConnectionManager(configuration);
+
+        try {
+            assertThirdConnectionBlocks(
+                    connectionManager.getJdbi("routing-group-database"),
+                    connectionManager.getJdbi("routing-group-database"));
+        }
+        finally {
+            connectionManager.close();
+        }
+    }
+
+    @Test
+    void testDefaultJdbiReusesPoolAndBlocksWhenExceedingMaxPoolSize()
+            throws Exception
+    {
+        DataStoreConfiguration configuration = createConfiguration("default", 2);
+        JdbcConnectionManager connectionManager = createConnectionManager(configuration);
+
+        try {
+            assertThirdConnectionBlocks(connectionManager.getJdbi(), connectionManager.getJdbi());
+        }
+        finally {
+            connectionManager.close();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    void testRejectsInvalidMaxPoolSize(int maxPoolSize)
+    {
+        DataStoreConfiguration configuration = createConfiguration("invalid-" + maxPoolSize, maxPoolSize);
+        JdbcConnectionManager connectionManager = createConnectionManager(configuration);
+
+        try {
+            assertThatThrownBy(connectionManager::getJdbi)
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("maxPoolSize must be greater than 0");
+        }
+        finally {
+            connectionManager.close();
+        }
+    }
+
+    @Test
+    void testHaQueryHistoryManagerUsesDefaultPool()
+            throws Exception
+    {
+        DataStoreConfiguration configuration = createConfiguration("query-history", 1);
+        JdbcConnectionManager connectionManager = createConnectionManager(configuration);
+        Jdbi jdbi = connectionManager.getJdbi();
+        jdbi.useHandle(handle -> handle.execute(
+                """
+                CREATE TABLE query_history (
+                    query_id VARCHAR NOT NULL,
+                    query_text VARCHAR NOT NULL,
+                    backend_url VARCHAR NOT NULL,
+                    user_name VARCHAR,
+                    source VARCHAR,
+                    created BIGINT,
+                    routing_group VARCHAR,
+                    external_url VARCHAR
+                )
+                """));
+
+        QueryHistoryManager queryHistoryManager = new HaQueryHistoryManager(connectionManager, configuration);
+        try (ExecutorService executorService = Executors.newSingleThreadExecutor();
+                Handle heldHandle = jdbi.open()) {
+            Future<List<QueryHistoryManager.QueryDetail>> queryHistory = executorService.submit(() -> queryHistoryManager.fetchQueryHistory(Optional.empty()));
+
+            assertThatThrownBy(() -> queryHistory.get(200, MILLISECONDS))
+                    .isInstanceOf(TimeoutException.class);
+
+            heldHandle.close();
+            assertThat(queryHistory.get(3, SECONDS)).isEmpty();
+        }
+        finally {
+            connectionManager.close();
+        }
+    }
+
+    @Test
+    void testHaGatewayManagerUsesDefaultPool()
+            throws Exception
+    {
+        DataStoreConfiguration configuration = createConfiguration("gateway-manager", 1);
+        JdbcConnectionManager connectionManager = createConnectionManager(configuration);
+        Jdbi jdbi = connectionManager.getJdbi();
+        jdbi.useHandle(handle -> handle.execute(
+                """
+                CREATE TABLE gateway_backend (
+                    name VARCHAR PRIMARY KEY,
+                    routing_group VARCHAR,
+                    backend_url VARCHAR,
+                    external_url VARCHAR,
+                    active BOOLEAN
+                )
+                """));
+
+        try (ExecutorService executorService = Executors.newSingleThreadExecutor();
+                Handle heldHandle = jdbi.open()) {
+            Future<HaGatewayManager> gatewayManager = executorService.submit(() -> new HaGatewayManager(
+                    connectionManager,
+                    new RoutingConfiguration(),
+                    new DatabaseCacheConfiguration()));
+
+            assertThatThrownBy(() -> gatewayManager.get(200, MILLISECONDS))
+                    .isInstanceOf(TimeoutException.class);
+
+            heldHandle.close();
+            assertThat(gatewayManager.get(3, SECONDS)).isNotNull();
+        }
+        finally {
+            connectionManager.close();
+        }
+    }
+
+    @Test
+    void testDoesNotBlockWhenMaxPoolSizeIsNull()
+            throws Exception
+    {
+        DataStoreConfiguration configuration = createConfiguration("no-pool", null);
+        JdbcConnectionManager connectionManager = createConnectionManager(configuration);
+        Jdbi jdbi = connectionManager.getJdbi();
+
+        try (ExecutorService executorService = Executors.newFixedThreadPool(3)) {
+            List<Future<?>> acquired = new ArrayList<>();
+            CountDownLatch hold = new CountDownLatch(1);
+            CountDownLatch acquiredLatch = new CountDownLatch(2);
+
+            try {
+                for (int attempt = 0; attempt < 2; attempt++) {
+                    acquired.add(executorService.submit(() -> {
+                        try (Handle _ = jdbi.open()) {
+                            acquiredLatch.countDown();
+                            assertThat(hold.await(10, SECONDS)).isTrue();
+                        }
+                        return null;
+                    }));
+                }
+
+                assertThat(acquiredLatch.await(3, SECONDS)).isTrue();
+
+                Future<Boolean> third = executorService.submit(() -> {
+                    try (Handle _ = jdbi.open()) {
+                        return true;
+                    }
+                });
+                assertThat(third.get(3, SECONDS)).isTrue();
+
+                int sessions = jdbi.withHandle(handle ->
+                        handle.createQuery("SELECT COUNT(*) FROM INFORMATION_SCHEMA.SESSIONS")
+                                .mapTo(int.class)
+                                .one());
+                assertThat(sessions).isGreaterThanOrEqualTo(3);
+            }
+            finally {
+                hold.countDown();
+                for (Future<?> future : acquired) {
+                    future.get(3, SECONDS);
+                }
+                connectionManager.close();
+            }
+        }
+    }
+
+    @Test
+    void testCloseClosesPool()
+    {
+        DataStoreConfiguration configuration = createConfiguration("close", 1);
+        JdbcConnectionManager connectionManager = createConnectionManager(configuration);
+        Jdbi jdbi = connectionManager.getJdbi();
+
+        jdbi.useHandle(_ -> {});
+        connectionManager.close();
+
+        assertThatThrownBy(jdbi::open)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("has been closed");
+    }
+
+    private static void assertThirdConnectionBlocks(Jdbi firstJdbi, Jdbi secondJdbi)
+            throws Exception
+    {
+        try (ExecutorService executorService = Executors.newFixedThreadPool(3)) {
+            List<Future<?>> acquired = new ArrayList<>();
+            CountDownLatch hold = new CountDownLatch(1);
+            CountDownLatch acquiredLatch = new CountDownLatch(2);
+
+            try {
+                for (int attempt = 0; attempt < 2; attempt++) {
+                    acquired.add(executorService.submit(() -> {
+                        try (Handle _ = firstJdbi.open()) {
+                            acquiredLatch.countDown();
+                            assertThat(hold.await(10, SECONDS))
+                                    .as("hold latch should be released by the test")
+                                    .isTrue();
+                        }
+                        return null;
+                    }));
+                }
+
+                assertThat(acquiredLatch.await(3, SECONDS))
+                        .as("both connections should be acquired before third attempt")
+                        .isTrue();
+
+                Future<Boolean> third = executorService.submit(() -> {
+                    try (Handle _ = secondJdbi.open()) {
+                        return true;
+                    }
+                });
+
+                assertThatThrownBy(() -> third.get(200, MILLISECONDS))
+                        .isInstanceOf(TimeoutException.class);
+
+                hold.countDown();
+                assertThat(third.get(3, SECONDS)).isTrue();
+            }
+            finally {
+                hold.countDown();
+                for (Future<?> future : acquired) {
+                    future.get(3, SECONDS);
+                }
+            }
+        }
+    }
+
+    private DataStoreConfiguration createConfiguration(String databaseName, Integer maxPoolSize)
+    {
+        String jdbcUrl = "jdbc:h2:" + temporaryDirectory.resolve(databaseName);
+        return new DataStoreConfiguration(
+                jdbcUrl,
+                "sa",
+                "sa",
+                "org.h2.Driver",
+                true,
+                4,
+                true,
+                maxPoolSize);
+    }
+
+    private static JdbcConnectionManager createConnectionManager(DataStoreConfiguration configuration)
+    {
+        return new JdbcConnectionManager(
+                Jdbi.create(configuration.getJdbcUrl(), configuration.getUser(), configuration.getPassword()),
+                configuration);
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/BaseExternalUrlQueryHistoryTest.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/BaseExternalUrlQueryHistoryTest.java
@@ -47,7 +47,8 @@ abstract class BaseExternalUrlQueryHistoryTest
                 container.getDriverClassName(),
                 true,
                 4,
-                true);
+                true,
+                null);
         FlywayMigration.migrate(config);
         JdbcConnectionManager jdbcConnectionManager = createTestingJdbcConnectionManager(config);
         queryHistoryManager = new HaQueryHistoryManager(jdbcConnectionManager.getJdbi(), config);

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/BaseTestQueryHistoryManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/BaseTestQueryHistoryManager.java
@@ -54,7 +54,8 @@ abstract class BaseTestQueryHistoryManager
                 container.getDriverClassName(),
                 true,
                 4,
-                true);
+                true,
+                null);
         FlywayMigration.migrate(config);
         JdbcConnectionManager jdbcConnectionManager = createTestingJdbcConnectionManager(config);
         jdbi = jdbcConnectionManager.getJdbi();


### PR DESCRIPTION
### Summary
This PR introduces optional JDBC connection pooling using HikariCP in `JdbcConnectionManager`, solves issue #377 

### Details
- Added an optional field `maxPoolSize` to `DataStoreConfiguration`.
- When `maxPoolSize` is configured (non-null and > 0):
  - `JdbcConnectionManager` uses a Hikari connection pool for routing-group database connections.
- When `maxPoolSize` is not set (null):
  - Connections are created directly (no pooling).

### Tests
Added `TestJdbcConnectionManagerPool`:
1. **blocksWhenExceedingMaxPoolSize**
   - Verifies that when a pool is enabled, new connections block after the pool limit.
2. **doesNotBlockWhenMaxPoolSizeIsNull**
   - Verifies that when the pool is disabled, connections are created directly and do not block.

### Why
This allows controlling connection usage and improving DB efficiency under load, while keeping the old behavior as the default (no pooling).

## Summary by Sourcery

Introduce optional JDBC connection pooling using HikariCP controlled by a new maxPoolSize setting, while preserving default direct connections, and add tests to verify pooling behavior

New Features:
- Enable JDBC connection pooling via HikariCP when maxPoolSize > 0

Enhancements:
- Add maxPoolSize field with constructors, getter, and setter to DataStoreConfiguration
- Update JdbcConnectionManager#getJdbi to use a HikariCP DataSource when pooling is enabled

Build:
- Add HikariCP dependency to the project

Tests:
- Introduce TestJdbcConnectionManagerPool with tests for pool blocking and no-pool scenarios