### PR TITLE
Update airbase to 325 and airlift bom to 372

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -25,9 +25,21 @@
         <dep.flyway.version>11.8.2</dep.flyway.version>
         <dep.jeasy.version>4.1.0</dep.jeasy.version>
         <dep.mockito.version>5.18.0</dep.mockito.version>
-        <dep.okhttp3.version>4.12.0</dep.okhttp3.version>
+        <dep.okhttp3.version>5.3.0</dep.okhttp3.version>
         <dep.trino.version>474</dep.trino.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp-bom</artifactId>
+                <version>${dep.okhttp3.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -88,8 +100,7 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${dep.okhttp3.version}</version>
+            <artifactId>okhttp-jvm</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>277</version>
+        <version>325</version>
     </parent>
 
     <groupId>io.trino.gateway</groupId>
@@ -46,7 +46,7 @@
         <air.modernizer.java-version>8</air.modernizer.java-version>
         <air.release.preparation-goals>clean verify -DskipTests</air.release.preparation-goals>
 
-        <dep.jetty.version>12.0.25</dep.jetty.version>
+        <dep.jetty.version>12.1.3</dep.jetty.version>
     </properties>
 
     <dependencyManagement>
@@ -54,7 +54,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>bom</artifactId>
-                <version>339</version>
+                <version>372</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -96,7 +96,7 @@
             <dependency>
                 <groupId>org.glassfish.jersey.core</groupId>
                 <artifactId>jersey-server</artifactId>
-                <version>3.1.10</version>
+                <version>3.1.11</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

- Updated `airbase` to 325
- Updated `airlift` BOM to 372
- Updated `okhttp3` to 5.3.0
- Added `okhttp3` BOM
- Added `okhttp-jvm` dependency
- Updated `jersey-server` to 3.1.11
- Updated `jetty` to 12.1.3

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes issue #571 by setting configured `max-request-header-size` and `max-response-header-size` parameters on the HttpClient.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required, with the following suggested text:

```markdown
* Set `max-request-header-size` and `max-response-header-size` parameters on the HttpClient to support large HTTP headers.
```
