### PR TITLE
Implement Strict Routing Semantics for Routing Rules

### DIFF
--- a/docs/routing-rules.md
+++ b/docs/routing-rules.md
@@ -149,6 +149,26 @@ actions:
   - 'result.put("routingGroup", "etl-special")'
 ```
 
+#### Strict routing
+
+By default, if no healthy backend is available for the resolved routing group,
+Trino Gateway falls back to the default routing group. You can override this
+behavior by setting `strictRouting` to `true` on a rule. When strict routing is
+enabled and no healthy backend is available for the routing group, Trino Gateway
+returns a `503 Service Unavailable` error to the client instead of falling back.
+
+```yaml
+---
+name: "airflow"
+description: "if query from airflow, route to etl group with strict routing"
+strictRouting: true
+condition: 'request.getHeader("X-Trino-Source") == "airflow"'
+actions:
+  - 'result.put("routingGroup", "etl")'
+```
+
+The `strictRouting` property defaults to `false` if not specified.
+
 Three objects are available by default. They are
 * `request`, the incoming request as an [HttpServletRequest](https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html)
 * `state`, a `HashMap<String, Object>` that allows passing arbitrary state from one rule evaluation to the next

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/RoutingRule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/RoutingRule.java
@@ -33,7 +33,7 @@ public record RoutingRule(
         String name,
         String description,
         Integer priority,
-        Boolean enforceIsolation,
+        Boolean strictRouting,
         List<String> actions,
         String condition)
 {
@@ -41,7 +41,7 @@ public record RoutingRule(
         requireNonNull(name, "name is null");
         description = requireNonNullElse(description, "");
         priority = requireNonNullElse(priority, 0);
-        enforceIsolation = requireNonNullElse(enforceIsolation, false);
+        strictRouting = requireNonNullElse(strictRouting, false);
         actions = ImmutableList.copyOf(actions);
         requireNonNull(condition, "condition is null");
     }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/RoutingRule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/RoutingRule.java
@@ -33,6 +33,7 @@ public record RoutingRule(
         String name,
         String description,
         Integer priority,
+        Boolean enforceIsolation,
         List<String> actions,
         String condition)
 {
@@ -40,6 +41,7 @@ public record RoutingRule(
         requireNonNull(name, "name is null");
         description = requireNonNullElse(description, "");
         priority = requireNonNullElse(priority, 0);
+        enforceIsolation = requireNonNullElse(enforceIsolation, false);
         actions = ImmutableList.copyOf(actions);
         requireNonNull(condition, "condition is null");
     }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/RoutingRule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/RoutingRule.java
@@ -26,6 +26,7 @@ import static java.util.Objects.requireNonNullElse;
  * @param name name of the routing rule
  * @param description description of the routing rule. Defaults to an empty string if not provided, indicating the user intends it to be blank.
  * @param priority priority of the routing rule. Higher number represents higher priority. If two rules have same priority then order of execution is not guaranteed.
+ * @param strictRouting if true, return 503 instead of falling back to the default backend when no healthy backend is available for the routing group
  * @param actions actions of the routing rule
  * @param condition condition of the routing rule
  */

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
@@ -95,7 +95,7 @@ public class RoutingTargetHandler
         String routingGroup = !isNullOrEmpty(routingDestination.routingGroup())
                 ? routingDestination.routingGroup()
                 : defaultRoutingGroup;
-        ProxyBackendConfiguration backendConfiguration = routingManager.provideBackendConfiguration(routingGroup, user, routingDestination.enforceIsolation());
+        ProxyBackendConfiguration backendConfiguration = routingManager.provideBackendConfiguration(routingGroup, user, routingDestination.strictRouting());
         String clusterHost = backendConfiguration.getProxyTo();
         String externalUrl = backendConfiguration.getExternalUrl();
         // Apply headers from RoutingDestination if there are any

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
@@ -91,11 +91,14 @@ public class RoutingTargetHandler
         RoutingSelectorResponse routingDestination = routingGroupSelector.findRoutingDestination(request);
         String user = request.getHeader(USER_HEADER);
 
-        // This falls back on default routing group backend if there is no cluster found for the routing group.
+        // When no cluster is found:
+        //   - If strictRouting is false, fall back to the default routing group backend.
+        //   - If strictRouting is true, return a 404 response.
         String routingGroup = !isNullOrEmpty(routingDestination.routingGroup())
                 ? routingDestination.routingGroup()
                 : defaultRoutingGroup;
-        ProxyBackendConfiguration backendConfiguration = routingManager.provideBackendConfiguration(routingGroup, user, routingDestination.strictRouting());
+        boolean strictRouting = Optional.ofNullable(routingDestination.strictRouting()).orElse(false);
+        ProxyBackendConfiguration backendConfiguration = routingManager.provideBackendConfiguration(routingGroup, user, strictRouting);
         String clusterHost = backendConfiguration.getProxyTo();
         String externalUrl = backendConfiguration.getExternalUrl();
         // Apply headers from RoutingDestination if there are any

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
@@ -95,7 +95,7 @@ public class RoutingTargetHandler
         String routingGroup = !isNullOrEmpty(routingDestination.routingGroup())
                 ? routingDestination.routingGroup()
                 : defaultRoutingGroup;
-        ProxyBackendConfiguration backendConfiguration = routingManager.provideBackendConfiguration(routingGroup, user);
+        ProxyBackendConfiguration backendConfiguration = routingManager.provideBackendConfiguration(routingGroup, user, routingDestination.enforceIsolation());
         String clusterHost = backendConfiguration.getProxyTo();
         String externalUrl = backendConfiguration.getExternalUrl();
         // Apply headers from RoutingDestination if there are any

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
@@ -40,6 +40,7 @@ import static io.trino.gateway.ha.handler.HttpUtils.USER_HEADER;
 import static io.trino.gateway.ha.handler.ProxyUtils.buildUriWithNewCluster;
 import static io.trino.gateway.ha.handler.ProxyUtils.extractQueryIdIfPresent;
 import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 public class RoutingTargetHandler
 {
@@ -91,13 +92,10 @@ public class RoutingTargetHandler
         RoutingSelectorResponse routingDestination = routingGroupSelector.findRoutingDestination(request);
         String user = request.getHeader(USER_HEADER);
 
-        // When no cluster is found:
-        //   - If strictRouting is false, fall back to the default routing group backend.
-        //   - If strictRouting is true, return a 404 response.
         String routingGroup = !isNullOrEmpty(routingDestination.routingGroup())
                 ? routingDestination.routingGroup()
                 : defaultRoutingGroup;
-        boolean strictRouting = Optional.ofNullable(routingDestination.strictRouting()).orElse(false);
+        boolean strictRouting = requireNonNullElse(routingDestination.strictRouting(), false);
         ProxyBackendConfiguration backendConfiguration = routingManager.provideBackendConfiguration(routingGroup, user, strictRouting);
         String clusterHost = backendConfiguration.getProxyTo();
         String externalUrl = backendConfiguration.getExternalUrl();

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
@@ -112,7 +112,7 @@ public abstract class BaseRoutingManager
         List<ProxyBackendConfiguration> backends = gatewayBackendManager.getActiveBackends(routingGroup).stream()
                 .filter(backEnd -> isBackendHealthy(backEnd.getName()))
                 .toList();
-        if (backends.isEmpty() && strictRouting) {
+        if (strictRouting && backends.isEmpty()) {
             throw new WebApplicationException(
                              Response.status(NOT_FOUND)
                             .entity(String.format("No healthy backends available for routing group '%s' under strict routing for user '%s'", routingGroup, user))

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
@@ -104,15 +104,15 @@ public abstract class BaseRoutingManager
 
     /**
      * Performs routing to a given cluster group. This falls back to a default backend if the target group
-     * has no suitable backend unless {@code enforceIsolation} is true, in which case a 404 is returned.
+     * has no suitable backend unless {@code strictRouting} is true, in which case a 404 is returned.
      */
     @Override
-    public ProxyBackendConfiguration provideBackendConfiguration(String routingGroup, String user, Boolean enforceIsolation)
+    public ProxyBackendConfiguration provideBackendConfiguration(String routingGroup, String user, Boolean strictRouting)
     {
         List<ProxyBackendConfiguration> backends = gatewayBackendManager.getActiveBackends(routingGroup).stream()
                 .filter(backEnd -> isBackendHealthy(backEnd.getName()))
                 .toList();
-        if (backends.isEmpty() && enforceIsolation) {
+        if (backends.isEmpty() && strictRouting) {
             throw new WebApplicationException(
                              Response.status(NOT_FOUND)
                             .entity(String.format("No healthy backends available for routing group '%s' under enforced isolation for user '%s'", routingGroup, user))

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
@@ -107,7 +107,7 @@ public abstract class BaseRoutingManager
      * has no suitable backend unless {@code strictRouting} is true, in which case a 404 is returned.
      */
     @Override
-    public ProxyBackendConfiguration provideBackendConfiguration(String routingGroup, String user, Boolean strictRouting)
+    public ProxyBackendConfiguration provideBackendConfiguration(String routingGroup, String user, boolean strictRouting)
     {
         List<ProxyBackendConfiguration> backends = gatewayBackendManager.getActiveBackends(routingGroup).stream()
                 .filter(backEnd -> isBackendHealthy(backEnd.getName()))

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
@@ -44,7 +44,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
+import static jakarta.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 
 /**
  * This class performs health check, stats counts for each backend and provides a backend given
@@ -104,7 +104,7 @@ public abstract class BaseRoutingManager
 
     /**
      * Performs routing to a given cluster group. This falls back to a default backend if the target group
-     * has no suitable backend unless {@code strictRouting} is true, in which case a 404 is returned.
+     * has no suitable backend unless {@code strictRouting} is true, in which case a 503 is returned.
      */
     @Override
     public ProxyBackendConfiguration provideBackendConfiguration(String routingGroup, String user, boolean strictRouting)
@@ -114,7 +114,7 @@ public abstract class BaseRoutingManager
                 .toList();
         if (strictRouting && backends.isEmpty()) {
             throw new WebApplicationException(
-                             Response.status(NOT_FOUND)
+                             Response.status(SERVICE_UNAVAILABLE)
                             .entity(String.format("No healthy backends available for routing group '%s' under strict routing for user '%s'", routingGroup, user))
                             .build());
         }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
@@ -115,7 +115,7 @@ public abstract class BaseRoutingManager
         if (backends.isEmpty() && strictRouting) {
             throw new WebApplicationException(
                              Response.status(NOT_FOUND)
-                            .entity(String.format("No healthy backends available for routing group '%s' under enforced isolation for user '%s'", routingGroup, user))
+                            .entity(String.format("No healthy backends available for routing group '%s' under strict routing for user '%s'", routingGroup, user))
                             .build());
         }
         return selectBackend(backends, user).orElseGet(() -> provideDefaultBackendConfiguration(user));

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/ExternalRoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/ExternalRoutingGroupSelector.java
@@ -128,7 +128,7 @@ public class ExternalRoutingGroupSelector
                     log.info("External routing service modified headers to: %s", filteredHeaders);
                 }
             }
-            return new RoutingSelectorResponse(response.routingGroup(), filteredHeaders);
+            return new RoutingSelectorResponse(response.routingGroup(), filteredHeaders, response.enforceIsolation());
         }
         catch (Exception e) {
             throwIfInstanceOf(e, WebApplicationException.class);

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/ExternalRoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/ExternalRoutingGroupSelector.java
@@ -128,7 +128,7 @@ public class ExternalRoutingGroupSelector
                     log.info("External routing service modified headers to: %s", filteredHeaders);
                 }
             }
-            return new RoutingSelectorResponse(response.routingGroup(), filteredHeaders, response.enforceIsolation());
+            return new RoutingSelectorResponse(response.routingGroup(), filteredHeaders, response.strictRouting());
         }
         catch (Exception e) {
             throwIfInstanceOf(e, WebApplicationException.class);

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/FileBasedRoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/FileBasedRoutingGroupSelector.java
@@ -73,15 +73,15 @@ public class FileBasedRoutingGroupSelector
             data = ImmutableMap.of("request", request);
         }
 
-        boolean enforceIsolation = false;
+        boolean strictRouting = false;
         for (RoutingRule rule : requireNonNull(rules.get())) {
             if (rule.evaluateCondition(data, state)) {
                 log.debug("%s evaluated to true on request: %s", rule, request);
                 rule.evaluateAction(result, data, state);
-                enforceIsolation = rule.isEnforceIsolation();
+                strictRouting = rule.isStrictRouting();
             }
         }
-        return new RoutingSelectorResponse(result.get(RESULTS_ROUTING_GROUP_KEY), ImmutableMap.of(), enforceIsolation);
+        return new RoutingSelectorResponse(result.get(RESULTS_ROUTING_GROUP_KEY), ImmutableMap.of(), strictRouting);
     }
 
     public List<RoutingRule> readRulesFromPath(Path rulesPath)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/FileBasedRoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/FileBasedRoutingGroupSelector.java
@@ -37,6 +37,7 @@ import static io.trino.gateway.ha.handler.HttpUtils.TRINO_QUERY_PROPERTIES;
 import static io.trino.gateway.ha.handler.HttpUtils.TRINO_REQUEST_USER;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.sort;
+import static java.util.Objects.requireNonNull;
 
 public class FileBasedRoutingGroupSelector
         implements RoutingGroupSelector
@@ -72,13 +73,15 @@ public class FileBasedRoutingGroupSelector
             data = ImmutableMap.of("request", request);
         }
 
-        rules.get().forEach(rule -> {
+        boolean enforceIsolation = false;
+        for (RoutingRule rule : requireNonNull(rules.get())) {
             if (rule.evaluateCondition(data, state)) {
                 log.debug("%s evaluated to true on request: %s", rule, request);
                 rule.evaluateAction(result, data, state);
+                enforceIsolation = rule.isEnforceIsolation();
             }
-        });
-        return new RoutingSelectorResponse(result.get(RESULTS_ROUTING_GROUP_KEY));
+        }
+        return new RoutingSelectorResponse(result.get(RESULTS_ROUTING_GROUP_KEY), ImmutableMap.of(), enforceIsolation);
     }
 
     public List<RoutingRule> readRulesFromPath(Path rulesPath)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/FileBasedRoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/FileBasedRoutingGroupSelector.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.google.common.base.Suppliers.memoizeWithExpiration;
 import static io.trino.gateway.ha.handler.HttpUtils.TRINO_QUERY_PROPERTIES;
@@ -77,8 +78,11 @@ public class FileBasedRoutingGroupSelector
         for (RoutingRule rule : requireNonNull(rules.get())) {
             if (rule.evaluateCondition(data, state)) {
                 log.debug("%s evaluated to true on request: %s", rule, request);
+                String previousRoutingGroup = result.get(RESULTS_ROUTING_GROUP_KEY);
                 rule.evaluateAction(result, data, state);
-                strictRouting = rule.isStrictRouting();
+                if (!Objects.equals(previousRoutingGroup, result.get(RESULTS_ROUTING_GROUP_KEY))) {
+                    strictRouting = rule.isStrictRouting();
+                }
             }
         }
         return new RoutingSelectorResponse(result.get(RESULTS_ROUTING_GROUP_KEY), ImmutableMap.of(), strictRouting);

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/MVELRoutingRule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/MVELRoutingRule.java
@@ -37,7 +37,7 @@ public class MVELRoutingRule
     String name;
     String description;
     Integer priority;
-    boolean enforceIsolation;
+    boolean strictRouting;
     Serializable condition;
     List<Serializable> actions;
     ParserContext parserContext = new ParserContext();
@@ -47,7 +47,7 @@ public class MVELRoutingRule
             @JsonProperty("name") String name,
             @JsonProperty("description") String description,
             @JsonProperty("priority") Integer priority,
-            @JsonProperty("enforceIsolation") Boolean enforceIsolation,
+            @JsonProperty("strictRouting") Boolean strictRouting,
             @JsonProperty("condition") Serializable condition,
             @JsonProperty("actions") List<Serializable> actions)
     {
@@ -56,7 +56,7 @@ public class MVELRoutingRule
         this.name = requireNonNull(name, "name is null");
         this.description = requireNonNullElse(description, "");
         this.priority = requireNonNullElse(priority, 0);
-        this.enforceIsolation = requireNonNullElse(enforceIsolation, false);
+        this.strictRouting = requireNonNullElse(strictRouting, false);
         this.condition = requireNonNull(
                 condition instanceof String stringCondition ? compileExpression(stringCondition, parserContext) : condition,
                 "condition is null");
@@ -101,9 +101,9 @@ public class MVELRoutingRule
     }
 
     @Override
-    public boolean isEnforceIsolation()
+    public boolean isStrictRouting()
     {
-        return enforceIsolation;
+        return strictRouting;
     }
 
     @Override
@@ -141,7 +141,7 @@ public class MVELRoutingRule
                 .add("name", name)
                 .add("description", description)
                 .add("priority", priority)
-                .add("enforceIsolation", enforceIsolation)
+                .add("strictRouting", strictRouting)
                 .add("condition", decompile(condition))
                 .add("actions", String.join(",", actions.stream().map(DebugTools::decompile).toList()))
                 .add("parserContext", parserContext)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/MVELRoutingRule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/MVELRoutingRule.java
@@ -37,6 +37,7 @@ public class MVELRoutingRule
     String name;
     String description;
     Integer priority;
+    boolean enforceIsolation;
     Serializable condition;
     List<Serializable> actions;
     ParserContext parserContext = new ParserContext();
@@ -46,6 +47,7 @@ public class MVELRoutingRule
             @JsonProperty("name") String name,
             @JsonProperty("description") String description,
             @JsonProperty("priority") Integer priority,
+            @JsonProperty("enforceIsolation") Boolean enforceIsolation,
             @JsonProperty("condition") Serializable condition,
             @JsonProperty("actions") List<Serializable> actions)
     {
@@ -54,6 +56,7 @@ public class MVELRoutingRule
         this.name = requireNonNull(name, "name is null");
         this.description = requireNonNullElse(description, "");
         this.priority = requireNonNullElse(priority, 0);
+        this.enforceIsolation = requireNonNullElse(enforceIsolation, false);
         this.condition = requireNonNull(
                 condition instanceof String stringCondition ? compileExpression(stringCondition, parserContext) : condition,
                 "condition is null");
@@ -98,6 +101,12 @@ public class MVELRoutingRule
     }
 
     @Override
+    public boolean isEnforceIsolation()
+    {
+        return enforceIsolation;
+    }
+
+    @Override
     public int compareTo(RoutingRule o)
     {
         if (o == null) {
@@ -132,6 +141,7 @@ public class MVELRoutingRule
                 .add("name", name)
                 .add("description", description)
                 .add("priority", priority)
+                .add("enforceIsolation", enforceIsolation)
                 .add("condition", decompile(condition))
                 .add("actions", String.join(",", actions.stream().map(DebugTools::decompile).toList()))
                 .add("parserContext", parserContext)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
@@ -81,8 +81,8 @@ public interface RoutingManager
      *
      * @param routingGroup the routing group to use for backend selection
      * @param user the user requesting the backend
-     * @param enforceIsolation whether to enforce isolation
+     * @param strictRouting whether to enforce isolation
      * @return the backend configuration for the selected cluster
      */
-    ProxyBackendConfiguration provideBackendConfiguration(String routingGroup, String user, Boolean enforceIsolation);
+    ProxyBackendConfiguration provideBackendConfiguration(String routingGroup, String user, Boolean strictRouting);
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
@@ -81,7 +81,8 @@ public interface RoutingManager
      *
      * @param routingGroup the routing group to use for backend selection
      * @param user the user requesting the backend
+     * @param enforceIsolation whether to enforce isolation
      * @return the backend configuration for the selected cluster
      */
-    ProxyBackendConfiguration provideBackendConfiguration(String routingGroup, String user);
+    ProxyBackendConfiguration provideBackendConfiguration(String routingGroup, String user, Boolean enforceIsolation);
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
@@ -81,8 +81,8 @@ public interface RoutingManager
      *
      * @param routingGroup the routing group to use for backend selection
      * @param user the user requesting the backend
-     * @param strictRouting whether to enforce isolation
+     * @param strictRouting whether to force strict routing
      * @return the backend configuration for the selected cluster
      */
-    ProxyBackendConfiguration provideBackendConfiguration(String routingGroup, String user, Boolean strictRouting);
+    ProxyBackendConfiguration provideBackendConfiguration(String routingGroup, String user, boolean strictRouting);
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingRule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingRule.java
@@ -24,5 +24,5 @@ public interface RoutingRule
 
     Integer getPriority();
 
-    boolean isEnforceIsolation();
+    boolean isStrictRouting();
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingRule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingRule.java
@@ -23,4 +23,6 @@ public interface RoutingRule
     void evaluateAction(Map<String, String> result, Map<String, Object> data, Map<String, Object> state);
 
     Integer getPriority();
+
+    boolean isEnforceIsolation();
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/ExternalRouterResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/ExternalRouterResponse.java
@@ -28,10 +28,12 @@ import java.util.Map;
 public record ExternalRouterResponse(
         @Nullable String routingGroup,
         List<String> errors,
-        @Nullable Map<String, String> externalHeaders)
+        @Nullable Map<String, String> externalHeaders,
+        @Nullable Boolean enforceIsolation)
         implements RoutingGroupResponse
 {
     public ExternalRouterResponse {
         externalHeaders = externalHeaders == null ? ImmutableMap.of() : ImmutableMap.copyOf(externalHeaders);
+        enforceIsolation = enforceIsolation != null && enforceIsolation;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/ExternalRouterResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/ExternalRouterResponse.java
@@ -29,11 +29,11 @@ public record ExternalRouterResponse(
         @Nullable String routingGroup,
         List<String> errors,
         @Nullable Map<String, String> externalHeaders,
-        @Nullable Boolean enforceIsolation)
+        @Nullable Boolean strictRouting)
         implements RoutingGroupResponse
 {
     public ExternalRouterResponse {
         externalHeaders = externalHeaders == null ? ImmutableMap.of() : ImmutableMap.copyOf(externalHeaders);
-        enforceIsolation = enforceIsolation != null && enforceIsolation;
+        strictRouting = strictRouting != null && strictRouting;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/ExternalRouterResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/ExternalRouterResponse.java
@@ -24,6 +24,7 @@ import java.util.Map;
  * - routingGroup: The target routing group for the request (optional)
  * - errors: Any errors that occurred during routing
  * - externalHeaders: Headers that can be set in the request
+ * - strictRouting: If true, a 503 error is returned instead of falling back when no backend is available for the routing group
  */
 public record ExternalRouterResponse(
         @Nullable String routingGroup,

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingGroupResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingGroupResponse.java
@@ -32,5 +32,5 @@ public interface RoutingGroupResponse
 
     Map<String, String> externalHeaders();
 
-    Boolean enforceIsolation();
+    Boolean strictRouting();
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingGroupResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingGroupResponse.java
@@ -31,4 +31,6 @@ public interface RoutingGroupResponse
     @Nullable String routingGroup();
 
     Map<String, String> externalHeaders();
+
+    Boolean enforceIsolation();
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingGroupResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingGroupResponse.java
@@ -25,6 +25,7 @@ import java.util.Map;
  Implementations of this interface are used to:
     * Specify the target routing group for a request
     * Provide additional headers that should be added to the request
+    * Specify whether strict routing should be used
  */
 public interface RoutingGroupResponse
 {
@@ -32,5 +33,5 @@ public interface RoutingGroupResponse
 
     Map<String, String> externalHeaders();
 
-    Boolean strictRouting();
+    @Nullable Boolean strictRouting();
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingSelectorResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingSelectorResponse.java
@@ -22,10 +22,10 @@ import java.util.Map;
  * Response from the routing service that includes:
  * - routingGroup: The target routing group for the request (Optional)
  * - externalHeaders: Headers that can be set in the request (Currently can only be set in ExternalRoutingGroupSelector)
- * - enforceIsolation: If true, the handler must not fall back to default when target group has no available backend;
+ * - strictRouting: If true, the handler must not fall back to default when target group has no available backend;
  *   instead, a 4xx should be returned.
  */
-public record RoutingSelectorResponse(@Nullable String routingGroup, Map<String, String> externalHeaders, Boolean enforceIsolation)
+public record RoutingSelectorResponse(@Nullable String routingGroup, Map<String, String> externalHeaders, Boolean strictRouting)
         implements RoutingGroupResponse
 {
     public RoutingSelectorResponse {

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingSelectorResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingSelectorResponse.java
@@ -22,8 +22,10 @@ import java.util.Map;
  * Response from the routing service that includes:
  * - routingGroup: The target routing group for the request (Optional)
  * - externalHeaders: Headers that can be set in the request (Currently can only be set in ExternalRoutingGroupSelector)
+ * - enforceIsolation: If true, the handler must not fall back to default when target group has no available backend;
+ *   instead, a 4xx should be returned.
  */
-public record RoutingSelectorResponse(@Nullable String routingGroup, Map<String, String> externalHeaders)
+public record RoutingSelectorResponse(@Nullable String routingGroup, Map<String, String> externalHeaders, Boolean enforceIsolation)
         implements RoutingGroupResponse
 {
     public RoutingSelectorResponse {
@@ -32,6 +34,6 @@ public record RoutingSelectorResponse(@Nullable String routingGroup, Map<String,
 
     public RoutingSelectorResponse(String routingGroup)
     {
-        this(routingGroup, ImmutableMap.of());
+        this(routingGroup, ImmutableMap.of(), false);
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingSelectorResponse.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/schema/RoutingSelectorResponse.java
@@ -22,10 +22,10 @@ import java.util.Map;
  * Response from the routing service that includes:
  * - routingGroup: The target routing group for the request (Optional)
  * - externalHeaders: Headers that can be set in the request (Currently can only be set in ExternalRoutingGroupSelector)
- * - strictRouting: If true, the handler must not fall back to default when target group has no available backend;
+ * - strictRouting: If true, the handler must not fall back to default when target group has no available backend (Optional)
  *   instead, a 4xx should be returned.
  */
-public record RoutingSelectorResponse(@Nullable String routingGroup, Map<String, String> externalHeaders, Boolean strictRouting)
+public record RoutingSelectorResponse(@Nullable String routingGroup, Map<String, String> externalHeaders, @Nullable Boolean strictRouting)
         implements RoutingGroupResponse
 {
     public RoutingSelectorResponse {

--- a/gateway-ha/src/main/resources/routing_rules.yml
+++ b/gateway-ha/src/main/resources/routing_rules.yml
@@ -1,0 +1,7 @@
+---
+name: "airflow"
+description: "if query from airflow, route to adhoc"
+priority: 0
+actions:
+- "result.put(\"routingGroup\", \"adhoc\")"
+condition: "request.getHeader(\"X-Trino-Source\") == \"datagrip\""

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandler.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandler.java
@@ -43,6 +43,7 @@ import static io.trino.gateway.ha.handler.HttpUtils.USER_HEADER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -108,7 +109,7 @@ class TestRoutingTargetHandler
         config = provideGatewayConfiguration();
         httpClient = Mockito.mock(HttpClient.class);
         routingManager = Mockito.mock(RoutingManager.class);
-        when(routingManager.provideBackendConfiguration(any(), any())).thenReturn(new ProxyBackendConfiguration());
+        when(routingManager.provideBackendConfiguration(any(), any(), anyBoolean())).thenReturn(new ProxyBackendConfiguration());
         request = prepareMockRequest();
 
         // Initialize the handler with the configuration
@@ -128,7 +129,8 @@ class TestRoutingTargetHandler
         ExternalRouterResponse mockResponse = new ExternalRouterResponse(
                 "test-group",
                 Collections.emptyList(),
-                modifiedHeaders);
+                modifiedHeaders,
+                false);
         when(httpClient.execute(any(), any())).thenReturn(mockResponse);
 
         // Execute
@@ -152,7 +154,8 @@ class TestRoutingTargetHandler
         ExternalRouterResponse mockResponse = new ExternalRouterResponse(
                 "test-group",
                 Collections.emptyList(),
-                modifiedHeaders);
+                modifiedHeaders,
+                false);
         when(httpClient.execute(any(), any())).thenReturn(mockResponse);
 
         // Execute
@@ -173,7 +176,8 @@ class TestRoutingTargetHandler
         ExternalRouterResponse mockResponse = new ExternalRouterResponse(
                 "test-group",
                 Collections.emptyList(),
-                ImmutableMap.of());
+                ImmutableMap.of(),
+                false);
         when(httpClient.execute(any(), any())).thenReturn(mockResponse);
 
         // Execute
@@ -195,7 +199,8 @@ class TestRoutingTargetHandler
         ExternalRouterResponse mockResponse = new ExternalRouterResponse(
                 "test-group",
                 Collections.emptyList(),
-                modifiedHeaders);
+                modifiedHeaders,
+                false);
         when(httpClient.execute(any(), any())).thenReturn(mockResponse);
 
         // Execute
@@ -218,7 +223,8 @@ class TestRoutingTargetHandler
         ExternalRouterResponse mockResponse = new ExternalRouterResponse(
                 "",
                 Collections.emptyList(),
-                modifiedHeaders);
+                modifiedHeaders,
+                false);
         when(httpClient.execute(any(), any())).thenReturn(mockResponse);
 
         // Execute
@@ -233,7 +239,7 @@ class TestRoutingTargetHandler
     @Test
     void testResponsePropertiesNull()
     {
-        ExternalRouterResponse mockResponse = new ExternalRouterResponse(null, null, ImmutableMap.of());
+        ExternalRouterResponse mockResponse = new ExternalRouterResponse(null, null, ImmutableMap.of(), null);
         when(httpClient.execute(any(), any())).thenReturn(mockResponse);
 
         RoutingTargetResponse result = handler.resolveRouting(request);
@@ -245,7 +251,7 @@ class TestRoutingTargetHandler
     void testResponseGroupSetResponseErrorsNull()
     {
         ExternalRouterResponse mockResponse = new ExternalRouterResponse(
-                "test-group", null, ImmutableMap.of());
+                "test-group", null, ImmutableMap.of(), null);
         when(httpClient.execute(any(), any())).thenReturn(mockResponse);
 
         RoutingTargetResponse result = handler.resolveRouting(request);
@@ -256,7 +262,7 @@ class TestRoutingTargetHandler
     @Test
     void testPropagateErrorsFalseResponseGroupNullResponseErrorsSet()
     {
-        ExternalRouterResponse mockResponse = new ExternalRouterResponse(null, List.of("some-error"), ImmutableMap.of());
+        ExternalRouterResponse mockResponse = new ExternalRouterResponse(null, List.of("some-error"), ImmutableMap.of(), null);
         when(httpClient.execute(any(), any())).thenReturn(mockResponse);
 
         RoutingTargetResponse result = handler.resolveRouting(request);
@@ -267,7 +273,7 @@ class TestRoutingTargetHandler
     @Test
     void testPropagateErrorsFalseResponseGroupAndErrorsSet()
     {
-        ExternalRouterResponse mockResponse = new ExternalRouterResponse("test-group", List.of("some-error"), ImmutableMap.of());
+        ExternalRouterResponse mockResponse = new ExternalRouterResponse("test-group", List.of("some-error"), ImmutableMap.of(), null);
         when(httpClient.execute(any(), any())).thenReturn(mockResponse);
 
         RoutingTargetResponse result = handler.resolveRouting(request);
@@ -281,7 +287,7 @@ class TestRoutingTargetHandler
         RoutingTargetHandler handler = createHandlerWithPropagateErrorsTrue();
 
         config.getRoutingRules().getRulesExternalConfiguration().setPropagateErrors(true);
-        ExternalRouterResponse mockResponse = new ExternalRouterResponse(null, List.of("some-error"), ImmutableMap.of());
+        ExternalRouterResponse mockResponse = new ExternalRouterResponse(null, List.of("some-error"), ImmutableMap.of(), null);
         when(httpClient.execute(any(), any())).thenReturn(mockResponse);
 
         assertThatThrownBy(() -> handler.resolveRouting(request))
@@ -293,7 +299,7 @@ class TestRoutingTargetHandler
     {
         RoutingTargetHandler handler = createHandlerWithPropagateErrorsTrue();
 
-        ExternalRouterResponse response = new ExternalRouterResponse("test-group", List.of("some-error"), ImmutableMap.of());
+        ExternalRouterResponse response = new ExternalRouterResponse("test-group", List.of("some-error"), ImmutableMap.of(), null);
         when(httpClient.execute(any(), any())).thenReturn(response);
 
         assertThatThrownBy(() -> handler.resolveRouting(request))

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestExternalRoutingGroupSelector.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestExternalRoutingGroupSelector.java
@@ -94,7 +94,7 @@ final class TestExternalRoutingGroupSelector
         HttpServletRequest mockRequest = prepareMockRequest();
 
         // Create a mock response
-        ExternalRouterResponse mockResponse = new ExternalRouterResponse("test-group", null, ImmutableMap.of());
+        ExternalRouterResponse mockResponse = new ExternalRouterResponse("test-group", null, ImmutableMap.of(), false);
 
         // Create ArgumentCaptor
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
@@ -210,7 +210,8 @@ final class TestExternalRoutingGroupSelector
         ExternalRouterResponse mockResponse = new ExternalRouterResponse(
                 "test-group",
                 ImmutableList.of(),
-                ImmutableMap.of(headerKey, headerValue));
+                ImmutableMap.of(headerKey, headerValue),
+                false);
 
         when(httpClient.execute(any(), any())).thenReturn(mockResponse);
 
@@ -244,7 +245,8 @@ final class TestExternalRoutingGroupSelector
                 ImmutableList.of(),
                 ImmutableMap.of(
                         allowedHeaderKey, allowedHeaderValue,
-                        excludedHeaderKey, excludedHeaderValue));
+                        excludedHeaderKey, excludedHeaderValue),
+                false);
 
         when(httpClient.execute(any(), any())).thenReturn(mockResponse);
 
@@ -272,7 +274,8 @@ final class TestExternalRoutingGroupSelector
         ExternalRouterResponse mockResponse = new ExternalRouterResponse(
                 "test-group",
                 ImmutableList.of("Error occurred"),
-                ImmutableMap.of(headerKey, headerValue));
+                ImmutableMap.of(headerKey, headerValue),
+                false);
 
         when(httpClient.execute(any(), any())).thenReturn(mockResponse);
 
@@ -292,7 +295,7 @@ final class TestExternalRoutingGroupSelector
         HttpServletRequest mockRequest = prepareMockRequest();
         setMockHeaders(mockRequest);
 
-        ExternalRouterResponse mockResponse = new ExternalRouterResponse("test-group", ImmutableList.of(), null);
+        ExternalRouterResponse mockResponse = new ExternalRouterResponse("test-group", ImmutableList.of(), null, false);
 
         when(httpClient.execute(any(), any())).thenReturn(mockResponse);
 
@@ -317,7 +320,8 @@ final class TestExternalRoutingGroupSelector
         ExternalRouterResponse mockResponse = new ExternalRouterResponse(
                 "",
                 ImmutableList.of(),
-                ImmutableMap.of(headerKey, headerValue));
+                ImmutableMap.of(headerKey, headerValue),
+                false);
 
         when(httpClient.execute(any(), any())).thenReturn(mockResponse);
 
@@ -340,7 +344,7 @@ final class TestExternalRoutingGroupSelector
         setMockHeaders(mockRequest);
 
         ExternalRouterResponse mockResponse = new ExternalRouterResponse(
-                "test-group", List.of("some-error"), ImmutableMap.of());
+                "test-group", List.of("some-error"), ImmutableMap.of(), false);
 
         when(httpClient.execute(any(), any())).thenReturn(mockResponse);
 
@@ -363,7 +367,7 @@ final class TestExternalRoutingGroupSelector
         setMockHeaders(mockRequest);
 
         ExternalRouterResponse mockResponse = new ExternalRouterResponse(
-                "test-group", List.of("some-error"), ImmutableMap.of());
+                "test-group", List.of("some-error"), ImmutableMap.of(), false);
 
         when(httpClient.execute(any(), any())).thenReturn(mockResponse);
 

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryCountBasedRouter.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryCountBasedRouter.java
@@ -196,7 +196,7 @@ final class TestQueryCountBasedRouter
     {
         // The user u1 has same number of queries queued on each cluster
         // The query needs to be routed to cluster with least number of queries running
-        ProxyBackendConfiguration proxyConfig = queryCountBasedRouter.provideBackendConfiguration("etl", "u1");
+        ProxyBackendConfiguration proxyConfig = queryCountBasedRouter.provideBackendConfiguration("etl", "u1", false);
         String proxyTo = proxyConfig.getProxyTo();
 
         assertThat(proxyTo).isEqualTo(BACKEND_URL_3);
@@ -212,7 +212,7 @@ final class TestQueryCountBasedRouter
         assertThat(c3Stats.userQueuedCount().getOrDefault("u1", 0))
                 .isEqualTo(6);
 
-        proxyConfig = queryCountBasedRouter.provideBackendConfiguration("etl", "u1");
+        proxyConfig = queryCountBasedRouter.provideBackendConfiguration("etl", "u1", false);
         proxyTo = proxyConfig.getProxyTo();
 
         assertThat(proxyTo).isEqualTo(BACKEND_URL_1);
@@ -224,7 +224,7 @@ final class TestQueryCountBasedRouter
     {
         // The user u2 has different number of queries queued on each cluster
         // The query needs to be routed to cluster with least number of queued for that user
-        ProxyBackendConfiguration proxyConfig = queryCountBasedRouter.provideBackendConfiguration(routingConfiguration.getDefaultRoutingGroup(), "u2");
+        ProxyBackendConfiguration proxyConfig = queryCountBasedRouter.provideBackendConfiguration(routingConfiguration.getDefaultRoutingGroup(), "u2", false);
         String proxyTo = proxyConfig.getProxyTo();
 
         assertThat(BACKEND_URL_2).isEqualTo(proxyTo);
@@ -234,7 +234,7 @@ final class TestQueryCountBasedRouter
     @Test
     void testUserWithDifferentQueueLengthUser2()
     {
-        ProxyBackendConfiguration proxyConfig = queryCountBasedRouter.provideBackendConfiguration(routingConfiguration.getDefaultRoutingGroup(), "u3");
+        ProxyBackendConfiguration proxyConfig = queryCountBasedRouter.provideBackendConfiguration(routingConfiguration.getDefaultRoutingGroup(), "u3", false);
         String proxyTo = proxyConfig.getProxyTo();
 
         assertThat(BACKEND_URL_1).isEqualTo(proxyTo);
@@ -244,7 +244,7 @@ final class TestQueryCountBasedRouter
     @Test
     void testUserWithNoQueuedQueries()
     {
-        ProxyBackendConfiguration proxyConfig = queryCountBasedRouter.provideBackendConfiguration(routingConfiguration.getDefaultRoutingGroup(), "u101");
+        ProxyBackendConfiguration proxyConfig = queryCountBasedRouter.provideBackendConfiguration(routingConfiguration.getDefaultRoutingGroup(), "u101", false);
         String proxyTo = proxyConfig.getProxyTo();
 
         assertThat(BACKEND_URL_3).isEqualTo(proxyTo);
@@ -254,7 +254,7 @@ final class TestQueryCountBasedRouter
     void testAdhocRoutingGroupFailOver()
     {
         // The ETL routing group doesn't exist
-        ProxyBackendConfiguration proxyConfig = queryCountBasedRouter.provideBackendConfiguration("NonExisting", "u1");
+        ProxyBackendConfiguration proxyConfig = queryCountBasedRouter.provideBackendConfiguration("NonExisting", "u1", false);
         String proxyTo = proxyConfig.getProxyTo();
 
         assertThat(BACKEND_URL_3).isEqualTo(proxyTo);
@@ -271,7 +271,7 @@ final class TestQueryCountBasedRouter
                 .build();
         queryCountBasedRouter.updateClusterStats(clusters);
 
-        ProxyBackendConfiguration proxyConfig = queryCountBasedRouter.provideBackendConfiguration("NonExisting", "u1");
+        ProxyBackendConfiguration proxyConfig = queryCountBasedRouter.provideBackendConfiguration("NonExisting", "u1", false);
         String proxyTo = proxyConfig.getProxyTo();
 
         assertThat(BACKEND_URL_4).isEqualTo(proxyTo);
@@ -290,7 +290,7 @@ final class TestQueryCountBasedRouter
 
         queryCountBasedRouter.updateClusterStats(clusters);
 
-        ProxyBackendConfiguration proxyConfig = queryCountBasedRouter.provideBackendConfiguration("NonExisting", "u1");
+        ProxyBackendConfiguration proxyConfig = queryCountBasedRouter.provideBackendConfiguration("NonExisting", "u1", false);
         String proxyTo = proxyConfig.getProxyTo();
 
         assertThat(BACKEND_URL_5).isEqualTo(proxyTo);

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingAPI.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingAPI.java
@@ -102,7 +102,7 @@ final class TestRoutingAPI
             throws Exception
     {
         //Update routing rules with a new rule
-        RoutingRule updatedRoutingRules = new RoutingRule("airflow", "if query from airflow, route to adhoc group", 0, List.of("result.put(\"routingGroup\", \"adhoc\")"), "request.getHeader(\"X-Trino-Source\") == \"JDBC\"");
+        RoutingRule updatedRoutingRules = new RoutingRule("airflow", "if query from airflow, route to adhoc group", 0, false, List.of("result.put(\"routingGroup\", \"adhoc\")"), "request.getHeader(\"X-Trino-Source\") == \"JDBC\"");
         RequestBody requestBody = RequestBody.create(OBJECT_MAPPER.writeValueAsString(updatedRoutingRules), MediaType.parse("application/json; charset=utf-8"));
         Request request = new Request.Builder()
                         .url("http://localhost:" + routerPort + "/webapp/updateRoutingRules")
@@ -136,7 +136,7 @@ final class TestRoutingAPI
         assertThat(routingRules[0].actions()).first().isEqualTo("result.put(\"routingGroup\", \"adhoc\")");
 
         //Revert back to old routing rules to avoid any test failures
-        RoutingRule revertRoutingRules = new RoutingRule("airflow", "if query from airflow, route to etl group", 0, List.of("result.put(\"routingGroup\", \"etl\")"), "request.getHeader(\"X-Trino-Source\") == \"airflow\"");
+        RoutingRule revertRoutingRules = new RoutingRule("airflow", "if query from airflow, route to etl group", 0, false, List.of("result.put(\"routingGroup\", \"etl\")"), "request.getHeader(\"X-Trino-Source\") == \"airflow\"");
         RequestBody requestBody3 = RequestBody.create(OBJECT_MAPPER.writeValueAsString(revertRoutingRules), MediaType.parse("application/json; charset=utf-8"));
         Request request3 = new Request.Builder()
                 .url("http://localhost:" + routerPort + "/webapp/updateRoutingRules")

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingManagerNotFound.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingManagerNotFound.java
@@ -40,7 +40,7 @@ final class TestRoutingManagerNotFound
     void testNonExistentRoutingGroupThrowsNotFoundException()
     {
         // When requesting a non-existent routing group, an IllegalStateException should be thrown
-        assertThatThrownBy(() -> routingManager.provideBackendConfiguration("non_existent_group", "user"))
+        assertThatThrownBy(() -> routingManager.provideBackendConfiguration("non_existent_group", "user", false))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Number of active backends found zero");
     }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingRulesManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingRulesManager.java
@@ -49,12 +49,14 @@ final class TestRoutingRulesManager
                         "airflow",
                         "if query from airflow, route to etl group",
                         null,
+                        null,
                         List.of("result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"etl\")"),
                         "request.getHeader(\"X-Trino-Source\") == \"airflow\" && (request.getHeader(\"X-Trino-Client-Tags\") == null || request.getHeader(\"X-Trino-Client-Tags\").isEmpty())"));
         assertThat(result.get(1)).isEqualTo(
                 new RoutingRule(
                         "airflow special",
                         "if query from airflow with special label, route to etl-special group",
+                        null,
                         null,
                         List.of("result.put(FileBasedRoutingGroupSelector.RESULTS_ROUTING_GROUP_KEY, \"etl-special\")"),
                         "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\") contains \"label=special\""));
@@ -84,13 +86,13 @@ final class TestRoutingRulesManager
         configuration.setRoutingRules(routingRulesConfiguration);
         RoutingRulesManager routingRulesManager = new RoutingRulesManager(configuration);
 
-        RoutingRule routingRules = new RoutingRule("airflow", "if query from airflow, route to etl group", 0, List.of("result.put(\"routingGroup\", \"adhoc\")"), "request.getHeader(\"X-Trino-Source\") == \"JDBC\"");
+        RoutingRule routingRules = new RoutingRule("airflow", "if query from airflow, route to etl group", 0, false, List.of("result.put(\"routingGroup\", \"adhoc\")"), "request.getHeader(\"X-Trino-Source\") == \"JDBC\"");
 
         List<RoutingRule> updatedRoutingRules = routingRulesManager.updateRoutingRule(routingRules);
         assertThat(updatedRoutingRules.getFirst().actions().getFirst()).isEqualTo("result.put(\"routingGroup\", \"adhoc\")");
         assertThat(updatedRoutingRules.getFirst().condition()).isEqualTo("request.getHeader(\"X-Trino-Source\") == \"JDBC\"");
 
-        RoutingRule originalRoutingRules = new RoutingRule("airflow", "if query from airflow, route to etl group", 0, List.of("result.put(\"routingGroup\", \"etl\")"), "request.getHeader(\"X-Trino-Source\") == \"airflow\"");
+        RoutingRule originalRoutingRules = new RoutingRule("airflow", "if query from airflow, route to etl group", 0, false, List.of("result.put(\"routingGroup\", \"etl\")"), "request.getHeader(\"X-Trino-Source\") == \"airflow\"");
         List<RoutingRule> updateRoutingRules = routingRulesManager.updateRoutingRule(originalRoutingRules);
 
         assertThat(updateRoutingRules).hasSize(2);
@@ -107,7 +109,7 @@ final class TestRoutingRulesManager
         routingRulesConfiguration.setRulesConfigPath(rulesConfigPath);
         configuration.setRoutingRules(routingRulesConfiguration);
         RoutingRulesManager routingRulesManager = new RoutingRulesManager(configuration);
-        RoutingRule routingRules = new RoutingRule("airflow", "if query from airflow, route to etl group", 0, List.of("result.put(\"routingGroup\", \"adhoc\")"), "request.getHeader(\"X-Trino-Source\") == \"JDBC\"");
+        RoutingRule routingRules = new RoutingRule("airflow", "if query from airflow, route to etl group", 0, false, List.of("result.put(\"routingGroup\", \"adhoc\")"), "request.getHeader(\"X-Trino-Source\") == \"JDBC\"");
 
         assertThatThrownBy(() -> routingRulesManager.updateRoutingRule(routingRules)).hasRootCauseInstanceOf(NoSuchFileException.class);
     }
@@ -123,8 +125,8 @@ final class TestRoutingRulesManager
         configuration.setRoutingRules(routingRulesConfiguration);
         RoutingRulesManager routingRulesManager = new RoutingRulesManager(configuration);
 
-        RoutingRule routingRule1 = new RoutingRule("airflow", "if query from airflow, route to etl group", 0, List.of("result.put(\"routingGroup\", \"etl\")"), "request.getHeader(\"X-Trino-Source\") == \"airflow\"");
-        RoutingRule routingRule2 = new RoutingRule("airflow", "if query from airflow, route to adhoc group", 0, List.of("result.put(\"routingGroup\", \"adhoc\")"), "request.getHeader(\"X-Trino-Source\") == \"datagrip\"");
+        RoutingRule routingRule1 = new RoutingRule("airflow", "if query from airflow, route to etl group", 0, false, List.of("result.put(\"routingGroup\", \"etl\")"), "request.getHeader(\"X-Trino-Source\") == \"airflow\"");
+        RoutingRule routingRule2 = new RoutingRule("airflow", "if query from airflow, route to adhoc group", 0, false, List.of("result.put(\"routingGroup\", \"adhoc\")"), "request.getHeader(\"X-Trino-Source\") == \"datagrip\"");
 
         ExecutorService executorService = Executors.newFixedThreadPool(2);
 

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
@@ -77,7 +77,7 @@ final class TestStochasticRoutingManager
     }
 
     @Test
-    void testEnforceIsolationException()
+    void testStrictRoutingException()
     {
         ProxyBackendConfiguration inactiveBackend = createBackend(
                 "inactive-backend",

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
@@ -107,7 +107,7 @@ final class TestStochasticRoutingManager
     {
         assertThatThrownBy(() -> haRoutingManager.provideBackendConfiguration(routingGroup, "user", true))
                 .isInstanceOfSatisfying(WebApplicationException.class, exception ->
-                        assertThat(exception.getResponse().getStatus()).isEqualTo(Status.NOT_FOUND.getStatusCode()));
+                        assertThat(exception.getResponse().getStatus()).isEqualTo(Status.SERVICE_UNAVAILABLE.getStatusCode()));
     }
 
     private static ProxyBackendConfiguration createBackend(

--- a/gateway-ha/src/test/resources/rules/routing_rules_concurrent.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_concurrent.yml
@@ -2,6 +2,7 @@
 name: "airflow"
 description: "if query from airflow, route to adhoc group"
 priority: 0
+enforceIsolation: false
 actions:
 - "result.put(\"routingGroup\", \"adhoc\")"
 condition: "request.getHeader(\"X-Trino-Source\") == \"datagrip\""

--- a/gateway-ha/src/test/resources/rules/routing_rules_concurrent.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_concurrent.yml
@@ -2,7 +2,7 @@
 name: "airflow"
 description: "if query from airflow, route to adhoc group"
 priority: 0
-enforceIsolation: false
+strictRouting: false
 actions:
 - "result.put(\"routingGroup\", \"adhoc\")"
 condition: "request.getHeader(\"X-Trino-Source\") == \"datagrip\""

--- a/gateway-ha/src/test/resources/rules/routing_rules_update.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_update.yml
@@ -2,7 +2,7 @@
 name: "airflow"
 description: "if query from airflow, route to etl group"
 priority: 0
-enforceIsolation: false
+strictRouting: false
 actions:
 - "result.put(\"routingGroup\", \"etl\")"
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
@@ -10,7 +10,7 @@ condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
 name: "airflow special"
 description: "if query from airflow with special label, route to etl-special group"
 priority: 1
-enforceIsolation: false
+strictRouting: false
 actions:
 - "result.put(\"routingGroup\", \"etl-special\")"
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"\

--- a/gateway-ha/src/test/resources/rules/routing_rules_update.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_update.yml
@@ -2,6 +2,7 @@
 name: "airflow"
 description: "if query from airflow, route to etl group"
 priority: 0
+enforceIsolation: false
 actions:
 - "result.put(\"routingGroup\", \"etl\")"
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
@@ -9,6 +10,7 @@ condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
 name: "airflow special"
 description: "if query from airflow with special label, route to etl-special group"
 priority: 1
+enforceIsolation: false
 actions:
 - "result.put(\"routingGroup\", \"etl-special\")"
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"\


### PR DESCRIPTION
## Description

This PR adds `strictRouting ` flag for routing as proposed in https://github.com/trinodb/trino-gateway/issues/797.  
Routing rules can now support `strictRouting: True` to force pinning the query to the routing group

When `strictRouting = false (default)`, the routing behavior remains unchanged.
When `strictRouting = true`, the gateway would **not** fall back to default clusters if the pinned backend becomes unavailable. Instead, the query should fail immediately with a 404 error.

## Testing

- [x] `mvn clean install`
- [x] Added new test cases in `TestStochasticRoutingManager`
- [x] Local test to verify the `strictRouting ` flag works

```
trino> select 1;
Error starting query at http://localhost:8080/v1/statement returned an invalid response: JsonResponse{statusCode=404, headers={content-length=[96], content-type=[text/plain], date=[Thu, 04 Dec 2025 03:45:04 GMT], vary=[Accept-Encoding]}, hasValue=false} [Error: No healthy backends available for routing group 'adhoc1' under strict routing for user 'pye']
```