### PR TITLE
Show query text in QueryHistory UI

### DIFF
--- a/webapp/src/components/history.tsx
+++ b/webapp/src/components/history.tsx
@@ -87,9 +87,10 @@ export function History() {
       <Typography.Text
          link={{ onClick: () => handleShowModal(text) }}
          underline
-         style={{ cursor: "pointer" }}
+         style={{ cursor: "pointer", width: "300px"}}
+         ellipsis={{ showTooltip: true }}
       >
-         View Query
+         {text}
       </Typography.Text>
     );
 


### PR DESCRIPTION
## Description
In PR-740, the UI was updated to show the query text in the QueryHistory component in a modal component, to account for larger query texts. This makes it more difficult for smaller query texts that would fit otherwise in the page. 
In this PR, we revert back to showing the query text, but also make it a link that's clickable for larger texts.  

Previous to the change, screenshot:
<img width="466" height="449" alt="image" src="https://github.com/user-attachments/assets/d5660f71-57f1-4b05-a05a-8c4f6bff6055" />

After the change screenshot:
<img width="738" height="676" alt="image" src="https://github.com/user-attachments/assets/ab519c9c-fc37-4cbf-8445-79459c29be72" />


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required, with the following suggested text:

```markdown
* Show truncated query text in Query History UI
```
