### PR TITLE
Enable health check to use mtls to connect to backends

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -558,3 +558,32 @@ a username and password using `backendState` as with the `JDBC` option.
 #### NOOP
 
 This option disables health checks.
+
+### Enable mTLS for monitor HttpClient (JMX and METRICS)
+
+For JMX and Metrics monitors, you can enable mutual TLS (mTLS) for the monitor HttpClient.
+When enabled, the monitors authenticate to backends with a client certificate and ignore any
+configured `backendState.username` and `backendState.password`.
+
+Enable it with a toggle in `backendState` and provide TLS material for the named `monitor` HttpClient
+under `serverConfig`:
+
+```yaml
+backendState:
+  monitorMtlsEnabled: true
+
+serverConfig:
+  monitor.http-client.key-store-path: /path/to/keystore
+  monitor.http-client.key-store-password: keystore_password
+  monitor.http-client.trust-store-path: /path/to/truststore
+  monitor.http-client.trust-store-password: changeit
+```
+
+Notes:
+
+- The `monitor` client is bound via Airlift's `httpClientBinder`, so properties must use the
+  `monitor.http-client.*` prefix.
+- With `monitorMtlsEnabled: true`:
+    - JMX and Metrics monitors do not send `Authorization` or `X-Trino-User` headers and do not apply Basic Auth.
+    - Authentication relies solely on the configured client certificate.
+- The gateway validates these TLS properties on startup when mTLS is enabled and fails fast if any are missing.

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/BackendStateConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/BackendStateConfiguration.java
@@ -19,6 +19,7 @@ public class BackendStateConfiguration
     private String password = "";
     private Boolean ssl = false;
     private boolean xForwardedProtoHeader;
+    private boolean monitorMtlsEnabled;
 
     public BackendStateConfiguration() {}
 
@@ -60,5 +61,15 @@ public class BackendStateConfiguration
     public void setXForwardedProtoHeader(boolean xForwardedProtoHeader)
     {
         this.xForwardedProtoHeader = xForwardedProtoHeader;
+    }
+
+    public boolean isMonitorMtlsEnabled()
+    {
+        return monitorMtlsEnabled;
+    }
+
+    public void setMonitorMtlsEnabled(boolean monitorMtlsEnabled)
+    {
+        this.monitorMtlsEnabled = monitorMtlsEnabled;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
@@ -70,6 +70,7 @@ import io.trino.gateway.ha.security.util.ChainedAuthFilter;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import org.jdbi.v3.core.Jdbi;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -81,6 +82,11 @@ import static java.util.Objects.requireNonNull;
 public class HaGatewayProviderModule
         extends AbstractModule
 {
+    private static final String MONITOR_HTTP_CLIENT_KEY_STORE_PATH = "monitor.http-client.key-store-path";
+    private static final String MONITOR_HTTP_CLIENT_KEY_STORE_PASSWORD = "monitor.http-client.key-store-password";
+    private static final String MONITOR_HTTP_CLIENT_TRUST_STORE_PATH = "monitor.http-client.trust-store-path";
+    private static final String MONITOR_HTTP_CLIENT_TRUST_STORE_PASSWORD = "monitor.http-client.trust-store-password";
+
     private final LbOAuthManager oauthManager;
     private final LbFormAuthManager formAuthManager;
     private final AuthorizationManager authorizationManager;
@@ -134,12 +140,12 @@ public class HaGatewayProviderModule
     private static void validateMonitorMtlsConfig(Map<String, String> serverConfig)
     {
         String[] requiredKeys = new String[] {
-                "monitor.http-client.key-store-path",
-                "monitor.http-client.key-store-password",
-                "monitor.http-client.trust-store-path",
-                "monitor.http-client.trust-store-password"
+                MONITOR_HTTP_CLIENT_KEY_STORE_PATH,
+                MONITOR_HTTP_CLIENT_KEY_STORE_PASSWORD,
+                MONITOR_HTTP_CLIENT_TRUST_STORE_PATH,
+                MONITOR_HTTP_CLIENT_TRUST_STORE_PASSWORD
         };
-        java.util.List<String> missing = new java.util.ArrayList<>();
+        List<String> missing = new ArrayList<>();
         for (String key : requiredKeys) {
             String value = serverConfig.get(key);
             if (value == null || value.isBlank()) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Today, Trino Gateway’s health monitors authenticate to backend clusters using either:
```
Authorization: Basic header (username/password), or X-Trino-User header (when no password is configured)
```
This creates operational burdens for deployments that must rotate or manage shared credentials, and it exposes unnecessary authentication material in gateway configs.
This PR introduces optional mTLS-based authentication for health checks, allowing deployments to rely solely on client certificates when connecting to backend JMX or metrics endpoints.

`backendState.monitorMtlsEnabled: true/false`
When `monitorMtlsEnabled`=true, the health monitors switch to certificate-based auth and no longer send any identity headers. Startup validation for TLS required configuration is also added.
If `monitorMtlsEnabled` is false (default), existing behavior is unchanged, provides the backward compatibility.

### Test
Build passed.
Tested with local gateway the health check is working as expected.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
NA


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
