### PR TITLE
Migrate from Guava Cache to Caffeine

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -75,6 +75,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.2.3</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Migrate from Guava Cache to Caffeine.

Motivation:
https://github.com/trinodb/trino-gateway/pull/783#discussion_r2608489696


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Removed the call to `setRoutingGroupForQueryId()` and `setExternalUrlForQueryId()` because `cache.get()` already insert the value into the cache if absent.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
