### PR TITLE
 Implement support for JWT-based authentication in the Trino Gateway.

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -133,6 +133,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>http-client</artifactId>
         </dependency>
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/AuthenticationConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/AuthenticationConfiguration.java
@@ -18,12 +18,14 @@ public class AuthenticationConfiguration
     private String defaultType;
     private OAuthConfiguration oauth;
     private FormAuthConfiguration form;
+    private JwtConfiguration jwt;
 
-    public AuthenticationConfiguration(String defaultType, OAuthConfiguration oauth, FormAuthConfiguration form)
+    public AuthenticationConfiguration(String defaultType, OAuthConfiguration oauth, FormAuthConfiguration form, JwtConfiguration jwt)
     {
         this.defaultType = defaultType;
         this.oauth = oauth;
         this.form = form;
+        this.jwt = jwt;
     }
 
     public AuthenticationConfiguration() {}
@@ -56,5 +58,15 @@ public class AuthenticationConfiguration
     public void setForm(FormAuthConfiguration form)
     {
         this.form = form;
+    }
+
+    public JwtConfiguration getJwt()
+    {
+        return this.jwt;
+    }
+
+    public void setJwt(JwtConfiguration jwt)
+    {
+        this.jwt = jwt;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/JwtConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/JwtConfiguration.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.config;
+
+import io.airlift.configuration.validation.FileExists;
+
+import java.io.File;
+import java.util.Optional;
+
+public class JwtConfiguration
+{
+    private String keyFile;
+    private String requiredIssuer;
+    private String requiredAudience;
+    private String principalField = "sub";
+    private Optional<String> userMappingPattern = Optional.empty();
+    private Optional<File> userMappingFile = Optional.empty();
+
+    public JwtConfiguration() {}
+
+    public String getKeyFile()
+    {
+        return this.keyFile;
+    }
+
+    public void setKeyFile(String keyFile)
+    {
+        this.keyFile = keyFile;
+    }
+
+    public String getRequiredIssuer()
+    {
+        return this.requiredIssuer;
+    }
+
+    public void setRequiredIssuer(String requiredIssuer)
+    {
+        this.requiredIssuer = requiredIssuer;
+    }
+
+    public String getRequiredAudience()
+    {
+        return this.requiredAudience;
+    }
+
+    public void setRequiredAudience(String requiredAudience)
+    {
+        this.requiredAudience = requiredAudience;
+    }
+
+    public String getPrincipalField()
+    {
+        return this.principalField;
+    }
+
+    public void setPrincipalField(String principalField)
+    {
+        this.principalField = principalField;
+    }
+
+    public Optional<String> getUserMappingPattern()
+    {
+        return this.userMappingPattern;
+    }
+
+    public void setUserMappingPattern(String userMappingPattern)
+    {
+        this.userMappingPattern = Optional.ofNullable(userMappingPattern);
+    }
+
+    public Optional<@FileExists File> getUserMappingFile()
+    {
+        return this.userMappingFile;
+    }
+
+    public void setUserMappingFile(File userMappingFile)
+    {
+        this.userMappingFile = Optional.ofNullable(userMappingFile);
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbJwtAuthenticator.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbJwtAuthenticator.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.security;
+
+import com.auth0.jwt.interfaces.Claim;
+import io.airlift.log.Logger;
+import io.trino.gateway.ha.security.util.AuthenticationException;
+import io.trino.gateway.ha.security.util.IdTokenAuthenticator;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.gateway.ha.security.UserMapping.createUserMapping;
+
+public class LbJwtAuthenticator
+        implements IdTokenAuthenticator
+{
+    private static final Logger log = Logger.get(LbJwtAuthenticator.class);
+
+    private final LbJwtManager jwtManager;
+    private final AuthorizationManager authorizationManager;
+    private final UserMapping userMapping;
+
+    public LbJwtAuthenticator(LbJwtManager jwtManager,
+            AuthorizationManager authorizationManager)
+    {
+        this.jwtManager = jwtManager;
+        this.authorizationManager = authorizationManager;
+        this.userMapping = createUserMapping(jwtManager.getUserMappingPattern(), jwtManager.getUserMappingFile());
+    }
+
+    /**
+     * If the JWT token is valid and has the right claims, it returns the principal,
+     * otherwise is returns an empty optional.
+     *
+     * @param token JWT token
+     * @return an optional principal
+     */
+    @Override
+    public Optional<LbPrincipal> authenticate(String token)
+            throws AuthenticationException
+    {
+        Optional<Map<String, Claim>> claimsOptional = jwtManager.getClaimsFromToken(token);
+        if (claimsOptional.isEmpty()) {
+            log.error("JWT token verification failed");
+            throw new AuthenticationException("JWT token verification failed");
+        }
+
+        Map<String, Claim> claims = claimsOptional.orElseThrow();
+
+        String principalField = jwtManager.getPrincipalField();
+        if (!claims.containsKey(principalField)) {
+            log.error("Required principal field %s not found in JWT token", principalField);
+            throw new AuthenticationException("Principal field does not exist in JWT token");
+        }
+
+        String originalUserId = claims.get(principalField).asString();
+        // Apply user mapping to transform the username if configured
+        String mappedUserId = userMapping.mapUser(originalUserId);
+        if (log.isDebugEnabled()) {
+            log.debug("JWT principal mapping: %s -> %s", originalUserId, mappedUserId);
+        }
+
+        // Get privileges from the authorization manager
+        Optional<String> privileges = authorizationManager.getPrivileges(mappedUserId);
+
+        return Optional.of(new LbPrincipal(mappedUserId, privileges));
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbJwtManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbJwtManager.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.security;
+
+import com.auth0.jwk.JwkException;
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.UrlJwkProvider;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import io.airlift.log.Logger;
+import io.trino.gateway.ha.config.JwtConfiguration;
+import jakarta.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Locale.ENGLISH;
+
+public class LbJwtManager
+{
+    private static final Logger log = Logger.get(LbJwtManager.class);
+
+    private final JwtConfiguration jwtConfig;
+    private final Map<String, String> pagePermissions;
+    private Algorithm algorithm;
+    private JWTVerifier jwtVerifier;
+    private JwkProvider jwkProvider; // For JWKS-based authentication
+
+    public LbJwtManager(JwtConfiguration configuration, Map<String, String> pagePermissions)
+    {
+        this.jwtConfig = configuration;
+        this.pagePermissions = pagePermissions.entrySet().stream()
+                .filter(entry -> entry.getValue() != null)
+                .collect(toImmutableMap(entry -> entry.getKey().toUpperCase(ENGLISH), Map.Entry::getValue));
+
+        initializeAlgorithm();
+        initializeVerifier();
+    }
+
+    private void initializeAlgorithm()
+    {
+        try {
+            if (jwtConfig.getKeyFile() == null) {
+                throw new IllegalArgumentException("keyFile must be provided in JWT configuration (http-server.authentication.jwt.key-file)");
+            }
+
+            String keyFile = jwtConfig.getKeyFile();
+
+            // Check if it's a JWKS URL
+            if (keyFile.startsWith("http://") || keyFile.startsWith("https://")) {
+                log.info("Configuring JWKS provider for URL: %s", keyFile);
+                this.jwkProvider = new UrlJwkProvider(keyFile);
+                // For JWKS, we'll create the algorithm dynamically in verifyToken method
+                // based on the 'kid' (key ID) from the JWT header
+                this.algorithm = null; // Will be resolved per-token
+                log.info("Successfully configured JWKS provider for: %s", keyFile);
+                return;
+            }
+
+            // Try to load as PEM file first
+            try {
+                RSAPublicKey publicKey = loadPublicKey(keyFile);
+                algorithm = Algorithm.RSA256(publicKey, null);
+                log.info("Loaded RSA public key from: %s", keyFile);
+            }
+            catch (Exception e) {
+                // If PEM loading fails, treat it as HMAC secret file
+                log.info("Failed to load as PEM, treating keyFile as HMAC secret file");
+                String hmacSecret = new String(Files.readAllBytes(Path.of(keyFile)), UTF_8).trim();
+                algorithm = Algorithm.HMAC256(hmacSecret);
+                log.info("Loaded HMAC secret from: %s", keyFile);
+            }
+        }
+        catch (Exception e) {
+            log.error(e, "Failed to initialize JWT algorithm");
+            throw new RuntimeException("Failed to initialize JWT algorithm", e);
+        }
+    }
+
+    private void initializeVerifier()
+    {
+        // For JWKS-based authentication, we create the verifier dynamically in verifyToken()
+        // because we need to get the correct key based on the 'kid' from JWT header
+        if (jwkProvider != null) {
+            log.info("Using JWKS-based verification, verifier will be created per-token");
+            this.jwtVerifier = null;
+            return;
+        }
+
+        // For static key files (PEM/HMAC), create the verifier once
+        var verification = JWT.require(algorithm);
+
+        // Add required issuer verification (Trino: http-server.authentication.jwt.required-issuer)
+        if (jwtConfig.getRequiredIssuer() != null) {
+            verification = verification.withIssuer(jwtConfig.getRequiredIssuer());
+        }
+
+        // Add required audience verification (Trino: http-server.authentication.jwt.required-audience)
+        if (jwtConfig.getRequiredAudience() != null) {
+            verification = verification.withAudience(jwtConfig.getRequiredAudience());
+        }
+
+        jwtVerifier = verification.build();
+    }
+
+    private RSAPublicKey loadPublicKey(String publicKeyPath)
+            throws IOException, NoSuchAlgorithmException, InvalidKeySpecException
+    {
+        String publicKeyContent = new String(Files.readAllBytes(Path.of(publicKeyPath)), UTF_8);
+
+        publicKeyContent = publicKeyContent
+                .replace("-----BEGIN PUBLIC KEY-----", "")
+                .replace("-----END PUBLIC KEY-----", "")
+                .replaceAll("\\s", "");
+
+        byte[] publicKeyBytes = Base64.getDecoder().decode(publicKeyContent);
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        X509EncodedKeySpec keySpec = new X509EncodedKeySpec(publicKeyBytes);
+
+        return (RSAPublicKey) keyFactory.generatePublic(keySpec);
+    }
+
+    public String getPrincipalField()
+    {
+        return jwtConfig.getPrincipalField();
+    }
+
+    public Optional<String> getUserMappingPattern()
+    {
+        return jwtConfig.getUserMappingPattern();
+    }
+
+    public Optional<java.io.File> getUserMappingFile()
+    {
+        return jwtConfig.getUserMappingFile();
+    }
+
+    /**
+     * Verifies a JWT token and returns the claims if valid.
+     *
+     * @param token The JWT token to verify
+     * @return Optional map of claims if token is valid, empty optional otherwise
+     */
+    public Optional<Map<String, Claim>> getClaimsFromToken(String token)
+    {
+        try {
+            // Handle JWKS-based verification
+            if (jwkProvider != null) {
+                return verifyTokenWithJwks(token);
+            }
+
+            // Handle static key verification (PEM/HMAC)
+            DecodedJWT verifiedJwt = jwtVerifier.verify(token);
+            return Optional.of(verifiedJwt.getClaims());
+        }
+        catch (JWTVerificationException e) {
+            log.error(e, "JWT verification failed");
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Verifies a JWT token using JWKS (JSON Web Key Set).
+     */
+    private Optional<Map<String, Claim>> verifyTokenWithJwks(String token)
+    {
+        try {
+            // First decode the token without verification to get the key ID (kid)
+            DecodedJWT unverifiedJwt = JWT.decode(token);
+            String keyId = unverifiedJwt.getKeyId();
+            String algorithm = unverifiedJwt.getAlgorithm();
+            String issuer = unverifiedJwt.getIssuer();
+            String subject = unverifiedJwt.getSubject();
+
+            if (log.isDebugEnabled()) {
+                unverifiedJwt.getClaims().forEach(
+                        (key, value) -> log.debug("JWT %s : %s", key, value));
+            }
+
+            if (keyId == null) {
+                log.error("JWT token is missing 'kid' (key ID) in header, required for JWKS verification. " +
+                         "Token algorithm: %s, issuer: %s", algorithm, issuer);
+                return Optional.empty();
+            }
+
+            // Get the public key from JWKS based on key ID
+            RSAPublicKey publicKey = (RSAPublicKey) jwkProvider.get(keyId).getPublicKey();
+
+            Algorithm rsaAlgorithm = Algorithm.RSA256(publicKey, null);
+
+            // Create verifier with the specific key
+            var verification = JWT.require(rsaAlgorithm);
+
+            if (jwtConfig.getRequiredIssuer() != null) {
+                verification = verification.withIssuer(jwtConfig.getRequiredIssuer());
+            }
+
+            if (jwtConfig.getRequiredAudience() != null) {
+                verification = verification.withAudience(jwtConfig.getRequiredAudience());
+            }
+
+            JWTVerifier jwtVerifierLocal = verification.build();
+
+            // Now verify the token with the correct key
+            DecodedJWT verifiedJwt = jwtVerifierLocal.verify(token);
+
+            log.info("Successfully verified JWT token with key ID: %s, subject: %s, issuer: %s",
+                    keyId, subject, issuer);
+
+            return Optional.of(verifiedJwt.getClaims());
+        }
+        catch (JwkException e) {
+            log.error(e, "Failed to get public key from JWKS provider. Key ID might not exist in JWKS or JWKS endpoint might be unreachable");
+            return Optional.empty();
+        }
+        catch (JWTVerificationException e) {
+            log.error(e, "JWT verification failed with JWKS. This could be due to: " +
+                     "1) Token signed with different key than retrieved from JWKS, " +
+                     "2) Token expired or not yet valid, " +
+                     "3) Issuer/audience mismatch, " +
+                     "4) Token signature is invalid");
+            return Optional.empty();
+        }
+        catch (Exception e) {
+            log.error(e, "Unexpected error during JWKS-based JWT verification");
+            return Optional.empty();
+        }
+    }
+
+    public List<String> processPagePermissions(List<String> roles)
+    {
+        for (String role : roles) {
+            String value = pagePermissions.get(role);
+            if (value == null) {
+                return Collections.emptyList();
+            }
+        }
+
+        return roles.stream()
+                .flatMap(role -> Stream.of(pagePermissions.get(role).split("_")))
+                .distinct().toList();
+    }
+
+    public static Response buildUnauthorizedResponse()
+    {
+        return Response.status(UNAUTHORIZED)
+                .build();
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/UserMapping.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/UserMapping.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.security;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.gateway.ha.security.UserMapping.Case.KEEP;
+import static io.trino.gateway.ha.util.JsonUtils.parseJson;
+import static java.lang.Boolean.TRUE;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+public final class UserMapping
+{
+    private final List<Rule> rules;
+
+    public static UserMapping createUserMapping(Optional<String> userMappingPattern, Optional<File> userMappingFile)
+    {
+        if (userMappingPattern.isPresent()) {
+            checkArgument(userMappingFile.isEmpty(), "user mapping pattern and file can not both be set");
+            return new UserMapping(ImmutableList.of(new Rule(userMappingPattern.orElseThrow())));
+        }
+
+        if (userMappingFile.isPresent()) {
+            List<Rule> rules = parseJson(userMappingFile.orElseThrow().toPath(), UserMappingRules.class).getRules();
+            return new UserMapping(rules);
+        }
+
+        return new UserMapping(ImmutableList.of(new Rule("(.*)")));
+    }
+
+    @VisibleForTesting
+    UserMapping(List<Rule> rules)
+    {
+        requireNonNull(rules, "rules is null");
+        checkArgument(!rules.isEmpty(), "rules list is empty");
+        this.rules = ImmutableList.copyOf(rules);
+    }
+
+    public String mapUser(String principal)
+            throws UserMappingException
+    {
+        for (Rule rule : rules) {
+            Optional<String> user = rule.mapUser(principal);
+            if (user.isPresent()) {
+                return user.orElseThrow();
+            }
+        }
+
+        throw new UserMappingException("No user mapping patterns match the principal");
+    }
+
+    public static final class UserMappingRules
+    {
+        private final List<Rule> rules;
+
+        @JsonCreator
+        public UserMappingRules(
+                @JsonProperty("rules") List<Rule> rules)
+        {
+            this.rules = ImmutableList.copyOf(requireNonNull(rules, "rules is null"));
+        }
+
+        public List<Rule> getRules()
+        {
+            return rules;
+        }
+    }
+
+    enum Case
+    {
+        KEEP {
+            @Override
+            public String transform(String value)
+            {
+                return value;
+            }
+        },
+        LOWER {
+            @Override
+            public String transform(String value)
+            {
+                return value.toLowerCase(ENGLISH);
+            }
+        },
+        UPPER {
+            @Override
+            public String transform(String value)
+            {
+                return value.toUpperCase(ENGLISH);
+            }
+        };
+
+        public abstract String transform(String value);
+    }
+
+    public static final class Rule
+    {
+        private final Pattern pattern;
+        private final String user;
+        private final boolean allow;
+        private final Case userCase;
+
+        public Rule(String pattern)
+        {
+            this(pattern, "$1", true, KEEP);
+        }
+
+        @JsonCreator
+        public Rule(
+                @JsonProperty("pattern") String pattern,
+                @JsonProperty("user") Optional<String> user,
+                @JsonProperty("allow") Optional<Boolean> allow,
+                @JsonProperty("case") Optional<Case> userCase)
+        {
+            this(
+                    pattern,
+                    user.orElse("$1"),
+                    allow.orElse(TRUE),
+                    userCase.orElse(KEEP));
+        }
+
+        public Rule(String pattern, String user, boolean allow, Case userCase)
+        {
+            this.pattern = Pattern.compile(requireNonNull(pattern, "pattern is null"));
+            this.user = requireNonNull(user, "user is null");
+            this.allow = allow;
+            this.userCase = requireNonNull(userCase, "userCase is null");
+        }
+
+        public Optional<String> mapUser(String principal)
+                throws UserMappingException
+        {
+            Matcher matcher = pattern.matcher(principal);
+            if (!matcher.matches()) {
+                return Optional.empty();
+            }
+
+            if (!allow) {
+                throw new UserMappingException("Principal is not allowed");
+            }
+
+            String result = matcher.replaceAll(user).trim();
+            if (result.isEmpty()) {
+                throw new UserMappingException("Principal matched, but mapped user is empty");
+            }
+
+            return Optional.of(userCase.transform(result));
+        }
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/UserMappingException.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/UserMappingException.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.security;
+
+import io.trino.gateway.ha.security.util.AuthenticationException;
+
+public class UserMappingException
+        extends AuthenticationException
+{
+    public UserMappingException(String message)
+    {
+        super(message);
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/util/JsonUtils.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/util/JsonUtils.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.util;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.core.StreamWriteFeature;
+import com.fasterxml.jackson.core.util.JsonRecyclerPools;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.airlift.json.ObjectMapperProvider;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+import static java.nio.file.Files.exists;
+import static java.nio.file.Files.isReadable;
+import static java.util.Objects.requireNonNull;
+
+public final class JsonUtils
+{
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapperProvider().get()
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    private JsonUtils() {}
+
+    public static <T> T parseJson(Path path, Class<T> javaType)
+    {
+        if (!path.isAbsolute()) {
+            path = path.toAbsolutePath();
+        }
+
+        checkArgument(exists(path), "File does not exist: %s", path);
+        checkArgument(isReadable(path), "File is not readable: %s", path);
+
+        try {
+            byte[] json = Files.readAllBytes(path);
+            return parseJson(json, javaType);
+        }
+        catch (IOException | RuntimeException e) {
+            throw new IllegalArgumentException(format("Invalid JSON file '%s' for '%s'", path, javaType), e);
+        }
+    }
+
+    public static <T> T parseJson(String json, Class<T> javaType)
+    {
+        return parseJson(OBJECT_MAPPER, json, javaType);
+    }
+
+    public static <T> T parseJson(ObjectMapper mapper, String json, Class<T> javaType)
+    {
+        return parseJson(mapper, ObjectMapper::createParser, json, javaType);
+    }
+
+    public static <T> T parseJson(byte[] jsonBytes, Class<T> javaType)
+    {
+        return parseJson(OBJECT_MAPPER, jsonBytes, javaType);
+    }
+
+    public static <T> T parseJson(ObjectMapper mapper, byte[] jsonBytes, Class<T> javaType)
+    {
+        return parseJson(mapper, ObjectMapper::createParser, jsonBytes, javaType);
+    }
+
+    public static <T> T parseJson(InputStream inputStream, Class<T> javaType)
+    {
+        return parseJson(OBJECT_MAPPER, inputStream, javaType);
+    }
+
+    public static <T> T parseJson(ObjectMapper mapper, InputStream inputStream, Class<T> javaType)
+    {
+        return parseJson(mapper, ObjectMapper::createParser, inputStream, javaType);
+    }
+
+    public static <T> T parseJson(URL url, Class<T> javaType)
+    {
+        return parseJson(OBJECT_MAPPER, url, javaType);
+    }
+
+    public static <T> T parseJson(ObjectMapper mapper, URL url, Class<T> javaType)
+    {
+        return parseJson(mapper, ObjectMapper::createParser, url, javaType);
+    }
+
+    private static <I, T> T parseJson(ObjectMapper mapper, ParserConstructor<I> parserConstructor, I input, Class<T> javaType)
+    {
+        requireNonNull(mapper, "mapper is null");
+        requireNonNull(parserConstructor, "parserConstructor is null");
+        requireNonNull(input, "input is null");
+        requireNonNull(javaType, "javaType is null");
+
+        try (JsonParser parser = parserConstructor.createParser(mapper, input)) {
+            T value = mapper.readValue(parser, javaType);
+            checkArgument(parser.nextToken() == null, "Found characters after the expected end of input");
+            return value;
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Could not parse JSON", e);
+        }
+    }
+
+    public static <T> T jsonTreeToValue(JsonNode treeNode, Class<T> javaType)
+    {
+        try {
+            return OBJECT_MAPPER.treeToValue(treeNode, javaType);
+        }
+        catch (JsonProcessingException e) {
+            throw new UncheckedIOException("Failed to convert JSON tree node", e);
+        }
+    }
+
+    public static <T> T parseJson(String json, String jsonPointer, Class<T> javaType)
+    {
+        JsonNode node = parseJson(json, JsonNode.class);
+        return parseJson(node, jsonPointer, javaType);
+    }
+
+    public static <T> T parseJson(Path path, String jsonPointer, Class<T> javaType)
+    {
+        JsonNode node = parseJson(path, JsonNode.class);
+        return parseJson(node, jsonPointer, javaType);
+    }
+
+    private static <T> T parseJson(JsonNode node, String jsonPointer, Class<T> javaType)
+    {
+        JsonNode mappingsNode = node.at(jsonPointer);
+        return jsonTreeToValue(mappingsNode, javaType);
+    }
+
+    public static JsonFactory jsonFactory()
+    {
+        return jsonFactoryBuilder().build();
+    }
+
+    // JsonFactoryBuilder usage is intentional as we need to disable read constraints
+    // due to the limits introduced by Jackson 2.15
+    public static JsonFactoryBuilder jsonFactoryBuilder()
+    {
+        // https://github.com/FasterXML/jackson-core/issues/1256
+        return new JsonFactoryBuilder()
+                .streamReadConstraints(StreamReadConstraints.builder()
+                        .maxStringLength(Integer.MAX_VALUE)
+                        .maxNestingDepth(Integer.MAX_VALUE)
+                        .maxNumberLength(Integer.MAX_VALUE)
+                        .build())
+                .enable(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER)
+                .enable(StreamReadFeature.USE_FAST_DOUBLE_PARSER)
+                .enable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)
+                .recyclerPool(JsonRecyclerPools.threadLocalPool());
+    }
+
+    private interface ParserConstructor<I>
+    {
+        JsonParser createParser(ObjectMapper mapper, I input)
+                throws IOException;
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbJwtAuthenticator.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbJwtAuthenticator.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.security;
+
+import com.auth0.jwt.interfaces.Claim;
+import com.google.common.collect.ImmutableMap;
+import io.trino.gateway.ha.security.util.AuthenticationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@TestInstance(Lifecycle.PER_CLASS)
+final class TestLbJwtAuthenticator
+{
+    private static final String TEST_USER = "test-user";
+    private static final String TEST_TOKEN = "valid-jwt-token";
+    private static final String PRINCIPAL_FIELD = "sub";
+
+    @Mock
+    private LbJwtManager jwtManager;
+
+    @Mock
+    private AuthorizationManager authorizationManager;
+
+    @Mock
+    private Claim principalClaim;
+
+    private LbJwtAuthenticator authenticator;
+
+    @BeforeEach
+    void setUp()
+    {
+        MockitoAnnotations.openMocks(this);
+
+        // Setup default user mapping behavior (no transformation)
+        when(jwtManager.getUserMappingPattern()).thenReturn(Optional.empty());
+        when(jwtManager.getUserMappingFile()).thenReturn(Optional.empty());
+
+        authenticator = new LbJwtAuthenticator(jwtManager, authorizationManager);
+
+        // Default behavior for principal field
+        when(jwtManager.getPrincipalField()).thenReturn(PRINCIPAL_FIELD);
+        when(principalClaim.asString()).thenReturn(TEST_USER);
+    }
+
+    @Test
+    void testAuthenticateWithValidTokenAndAuthorizationManager()
+            throws AuthenticationException
+    {
+        // Setup JWT claims without roles (since roles are no longer extracted)
+        Map<String, Claim> claims = ImmutableMap.of(PRINCIPAL_FIELD, principalClaim);
+
+        when(jwtManager.getClaimsFromToken(TEST_TOKEN)).thenReturn(Optional.of(claims));
+        when(authorizationManager.getPrivileges(TEST_USER)).thenReturn(Optional.of("admin_user"));
+
+        Optional<LbPrincipal> result = authenticator.authenticate(TEST_TOKEN);
+
+        assertThat(result).isPresent();
+        LbPrincipal principal = result.orElseThrow();
+        assertThat(principal.getName()).isEqualTo(TEST_USER);
+        assertThat(principal.getMemberOf()).isEqualTo(Optional.of("admin_user"));
+    }
+
+    @Test
+    void testAuthenticateWithValidTokenAndAuthorizationManagerDifferentPrivileges()
+            throws AuthenticationException
+    {
+        // Setup JWT claims without roles (since roles are no longer extracted)
+        Map<String, Claim> claims = ImmutableMap.of(PRINCIPAL_FIELD, principalClaim);
+
+        when(jwtManager.getClaimsFromToken(TEST_TOKEN)).thenReturn(Optional.of(claims));
+        when(authorizationManager.getPrivileges(TEST_USER)).thenReturn(Optional.of("developers_qa"));
+
+        Optional<LbPrincipal> result = authenticator.authenticate(TEST_TOKEN);
+
+        assertThat(result).isPresent();
+        LbPrincipal principal = result.orElseThrow();
+        assertThat(principal.getName()).isEqualTo(TEST_USER);
+        assertThat(principal.getMemberOf()).isEqualTo(Optional.of("developers_qa"));
+    }
+
+    @Test
+    void testAuthenticateWithValidTokenAndAuthorizationManagerPermissions()
+            throws AuthenticationException
+    {
+        // Setup JWT claims without roles (since roles are no longer extracted)
+        Map<String, Claim> claims = ImmutableMap.of(PRINCIPAL_FIELD, principalClaim);
+
+        when(jwtManager.getClaimsFromToken(TEST_TOKEN)).thenReturn(Optional.of(claims));
+        when(authorizationManager.getPrivileges(TEST_USER)).thenReturn(Optional.of("READ_PERMISSION_WRITE_PERMISSION"));
+
+        Optional<LbPrincipal> result = authenticator.authenticate(TEST_TOKEN);
+
+        assertThat(result).isPresent();
+        LbPrincipal principal = result.orElseThrow();
+        assertThat(principal.getName()).isEqualTo(TEST_USER);
+        assertThat(principal.getMemberOf()).isEqualTo(Optional.of("READ_PERMISSION_WRITE_PERMISSION"));
+    }
+
+    @Test
+    void testAuthenticateWithValidTokenNoRoles()
+            throws AuthenticationException
+    {
+        // Setup JWT claims without roles
+        Map<String, Claim> claims = ImmutableMap.of(PRINCIPAL_FIELD, principalClaim);
+
+        when(jwtManager.getClaimsFromToken(TEST_TOKEN)).thenReturn(Optional.of(claims));
+        when(authorizationManager.getPrivileges(TEST_USER)).thenReturn(Optional.of("db_privileges"));
+
+        Optional<LbPrincipal> result = authenticator.authenticate(TEST_TOKEN);
+
+        assertThat(result).isPresent();
+        LbPrincipal principal = result.orElseThrow();
+        assertThat(principal.getName()).isEqualTo(TEST_USER);
+        assertThat(principal.getMemberOf()).isEqualTo(Optional.of("db_privileges"));
+    }
+
+    @Test
+    void testAuthenticateWithValidTokenNoRolesNoPrivileges()
+            throws AuthenticationException
+    {
+        // Setup JWT claims without roles and no privileges from authorization manager
+        Map<String, Claim> claims = ImmutableMap.of(PRINCIPAL_FIELD, principalClaim);
+
+        when(jwtManager.getClaimsFromToken(TEST_TOKEN)).thenReturn(Optional.of(claims));
+        when(authorizationManager.getPrivileges(TEST_USER)).thenReturn(Optional.empty());
+
+        Optional<LbPrincipal> result = authenticator.authenticate(TEST_TOKEN);
+
+        assertThat(result).isPresent();
+        LbPrincipal principal = result.orElseThrow();
+        assertThat(principal.getName()).isEqualTo(TEST_USER);
+        assertThat(principal.getMemberOf()).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    void testAuthenticateWithInvalidToken()
+    {
+        when(jwtManager.getClaimsFromToken(TEST_TOKEN)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authenticator.authenticate(TEST_TOKEN))
+                .isInstanceOf(AuthenticationException.class)
+                .hasMessageContaining("JWT token verification failed");
+    }
+
+    @Test
+    void testAuthenticateWithMissingPrincipalField()
+    {
+        // Setup JWT claims without the required principal field
+        Map<String, Claim> claims = ImmutableMap.of("other_field", principalClaim);
+
+        when(jwtManager.getClaimsFromToken(TEST_TOKEN)).thenReturn(Optional.of(claims));
+
+        assertThatThrownBy(() -> authenticator.authenticate(TEST_TOKEN))
+                .isInstanceOf(AuthenticationException.class)
+                .hasMessageContaining("Principal field does not exist in JWT token");
+    }
+
+    @Test
+    void testAuthenticateWithNullPrincipalClaim()
+    {
+        // Setup JWT claims with null principal field value
+        Map<String, Claim> claims = ImmutableMap.of(PRINCIPAL_FIELD, principalClaim);
+
+        when(jwtManager.getClaimsFromToken(TEST_TOKEN)).thenReturn(Optional.of(claims));
+        when(principalClaim.asString()).thenReturn(null);
+
+        assertThatThrownBy(() -> authenticator.authenticate(TEST_TOKEN))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testAuthenticateWithUserMappingPattern()
+            throws AuthenticationException
+    {
+        // Test with custom user mapping pattern to remove domain
+        String originalUser = "john.doe@company.com";
+        String expectedMappedUser = "john.doe";
+
+        // Create authenticator with user mapping pattern
+        when(jwtManager.getUserMappingPattern()).thenReturn(Optional.of("(.*)@.*"));
+        when(jwtManager.getUserMappingFile()).thenReturn(Optional.empty());
+        LbJwtAuthenticator authenticatorWithMapping = new LbJwtAuthenticator(jwtManager, authorizationManager);
+
+        Map<String, Claim> claims = ImmutableMap.of(PRINCIPAL_FIELD, principalClaim);
+
+        when(jwtManager.getClaimsFromToken(TEST_TOKEN)).thenReturn(Optional.of(claims));
+        when(principalClaim.asString()).thenReturn(originalUser);
+        when(authorizationManager.getPrivileges(expectedMappedUser)).thenReturn(Optional.of("user_privileges"));
+
+        Optional<LbPrincipal> result = authenticatorWithMapping.authenticate(TEST_TOKEN);
+
+        assertThat(result).isPresent();
+        LbPrincipal principal = result.orElseThrow();
+        assertThat(principal.getName()).isEqualTo(expectedMappedUser);
+        assertThat(principal.getMemberOf()).isEqualTo(Optional.of("user_privileges"));
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbJwtAuthenticatorIntegration.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbJwtAuthenticatorIntegration.java
@@ -1,0 +1,560 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import io.trino.gateway.ha.config.JwtConfiguration;
+import io.trino.gateway.ha.security.util.AuthenticationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@TestInstance(Lifecycle.PER_CLASS)
+final class TestLbJwtAuthenticatorIntegration
+{
+    private static final String TEST_ISSUER = "trino-gateway-test";
+    private static final String TEST_AUDIENCE = "trino-test";
+    private static final String TEST_SUBJECT = "test-user@company.com";
+    private static final String HMAC_SECRET = "test-secret-key-for-hmac-256";
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    private AuthorizationManager authorizationManager;
+
+    private KeyPair keyPair;
+    private RSAPublicKey publicKey;
+    private RSAPrivateKey privateKey;
+    private Algorithm rsaAlgorithm;
+    private Algorithm hmacAlgorithm;
+
+    @BeforeEach
+    void setUp()
+            throws Exception
+    {
+        MockitoAnnotations.openMocks(this);
+
+        // Generate RSA key pair for testing
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        keyPair = keyPairGenerator.generateKeyPair();
+        publicKey = (RSAPublicKey) keyPair.getPublic();
+        privateKey = (RSAPrivateKey) keyPair.getPrivate();
+
+        rsaAlgorithm = Algorithm.RSA256(publicKey, privateKey);
+        hmacAlgorithm = Algorithm.HMAC256(HMAC_SECRET);
+    }
+
+    @Test
+    void testEndToEndAuthenticationWithRSAAndAuthorizationManager()
+            throws Exception
+    {
+        // Create RSA public key file
+        Path keyFile = createRSAPublicKeyFile();
+
+        // Setup JWT configuration with user mapping pattern
+        JwtConfiguration jwtConfig = createJwtConfiguration(keyFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        jwtConfig.setUserMappingPattern("(.*)@.*"); // Remove domain from email
+        jwtConfig.setPrincipalField("sub");
+
+        // Create JWT manager and authenticator
+        Map<String, String> pagePermissions = new HashMap<>();
+        LbJwtManager jwtManager = new LbJwtManager(jwtConfig, pagePermissions);
+        LbJwtAuthenticator authenticator = new LbJwtAuthenticator(jwtManager, authorizationManager);
+
+        // Create valid JWT token without roles (roles are handled by AuthorizationManager)
+        String token = JWT.create()
+                .withIssuer(TEST_ISSUER)
+                .withAudience(TEST_AUDIENCE)
+                .withSubject(TEST_SUBJECT)
+                .withIssuedAt(Date.from(Instant.now()))
+                .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .sign(rsaAlgorithm);
+
+        when(authorizationManager.getPrivileges("test-user")).thenReturn(Optional.of("admin_user"));
+
+        // Authenticate
+        Optional<LbPrincipal> result = authenticator.authenticate(token);
+
+        // Verify result
+        assertThat(result).isPresent();
+        LbPrincipal principal = result.orElseThrow();
+        assertThat(principal.getName()).isEqualTo("test-user"); // Domain removed by user mapping
+        assertThat(principal.getMemberOf()).isEqualTo(Optional.of("admin_user"));
+    }
+
+    @Test
+    void testEndToEndAuthenticationWithHMACAndAuthorizationFallback()
+            throws Exception
+    {
+        // Create HMAC secret file
+        Path secretFile = createHMACSecretFile();
+
+        // Setup JWT configuration
+        JwtConfiguration jwtConfig = createJwtConfiguration(secretFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        jwtConfig.setPrincipalField("sub");
+
+        // Create JWT manager and authenticator
+        Map<String, String> pagePermissions = new HashMap<>();
+        LbJwtManager jwtManager = new LbJwtManager(jwtConfig, pagePermissions);
+        LbJwtAuthenticator authenticator = new LbJwtAuthenticator(jwtManager, authorizationManager);
+
+        // Setup authorization manager to return privileges
+        when(authorizationManager.getPrivileges(TEST_SUBJECT)).thenReturn(Optional.of("database_access"));
+
+        // Create valid JWT token without roles
+        String token = JWT.create()
+                .withIssuer(TEST_ISSUER)
+                .withAudience(TEST_AUDIENCE)
+                .withSubject(TEST_SUBJECT)
+                .withIssuedAt(Date.from(Instant.now()))
+                .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .sign(hmacAlgorithm);
+
+        // Authenticate
+        Optional<LbPrincipal> result = authenticator.authenticate(token);
+
+        // Verify result
+        assertThat(result).isPresent();
+        LbPrincipal principal = result.orElseThrow();
+        assertThat(principal.getName()).isEqualTo(TEST_SUBJECT);
+        assertThat(principal.getMemberOf()).isEqualTo(Optional.of("database_access"));
+    }
+
+    @Test
+    void testEndToEndAuthenticationWithExpiredToken()
+            throws Exception
+    {
+        // Create RSA public key file
+        Path keyFile = createRSAPublicKeyFile();
+
+        // Setup JWT configuration
+        JwtConfiguration jwtConfig = createJwtConfiguration(keyFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        Map<String, String> pagePermissions = new HashMap<>();
+        LbJwtManager jwtManager = new LbJwtManager(jwtConfig, pagePermissions);
+        LbJwtAuthenticator authenticator = new LbJwtAuthenticator(jwtManager, authorizationManager);
+
+        // Create expired JWT token
+        String expiredToken = JWT.create()
+                .withIssuer(TEST_ISSUER)
+                .withAudience(TEST_AUDIENCE)
+                .withSubject(TEST_SUBJECT)
+                .withIssuedAt(Date.from(Instant.now().minus(2, ChronoUnit.HOURS)))
+                .withExpiresAt(Date.from(Instant.now().minus(1, ChronoUnit.HOURS)))
+                .sign(rsaAlgorithm);
+
+        // Authenticate with expired token should fail
+        assertThatThrownBy(() -> authenticator.authenticate(expiredToken))
+                .isInstanceOf(AuthenticationException.class);
+    }
+
+    @Test
+    void testEndToEndAuthenticationWithWrongIssuer()
+            throws Exception
+    {
+        // Create RSA public key file
+        Path keyFile = createRSAPublicKeyFile();
+
+        // Setup JWT configuration
+        JwtConfiguration jwtConfig = createJwtConfiguration(keyFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        Map<String, String> pagePermissions = new HashMap<>();
+        LbJwtManager jwtManager = new LbJwtManager(jwtConfig, pagePermissions);
+        LbJwtAuthenticator authenticator = new LbJwtAuthenticator(jwtManager, authorizationManager);
+
+        // Create JWT token with wrong issuer
+        String tokenWithWrongIssuer = JWT.create()
+                .withIssuer("wrong-issuer")
+                .withAudience(TEST_AUDIENCE)
+                .withSubject(TEST_SUBJECT)
+                .withIssuedAt(Date.from(Instant.now()))
+                .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .sign(rsaAlgorithm);
+
+        // Authenticate with wrong issuer should fail
+        assertThatThrownBy(() -> authenticator.authenticate(tokenWithWrongIssuer))
+                .isInstanceOf(AuthenticationException.class);
+    }
+
+    @Test
+    void testEndToEndAuthenticationWithUserMappingAndAuthorizationManager()
+            throws Exception
+    {
+        // Create RSA public key file
+        Path keyFile = createRSAPublicKeyFile();
+
+        // Setup JWT configuration with user mapping file
+        Path userMappingFile = createUserMappingFile();
+        JwtConfiguration jwtConfig = createJwtConfiguration(keyFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        jwtConfig.setUserMappingFile(userMappingFile.toFile());
+        jwtConfig.setPrincipalField("sub");
+
+        // Create JWT manager and authenticator
+        Map<String, String> pagePermissions = new HashMap<>();
+        LbJwtManager jwtManager = new LbJwtManager(jwtConfig, pagePermissions);
+        LbJwtAuthenticator authenticator = new LbJwtAuthenticator(jwtManager, authorizationManager);
+
+        // Mock authorization manager to return the expected privileges
+        when(authorizationManager.getPrivileges("service_account")).thenReturn(Optional.of("admin_developer_tester"));
+
+        // Create valid JWT token without roles (privileges come from AuthorizationManager)
+        String token = JWT.create()
+                .withIssuer(TEST_ISSUER)
+                .withAudience(TEST_AUDIENCE)
+                .withSubject("service_account_123")
+                .withIssuedAt(Date.from(Instant.now()))
+                .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .sign(rsaAlgorithm);
+
+        // Authenticate
+        Optional<LbPrincipal> result = authenticator.authenticate(token);
+
+        // Verify result
+        assertThat(result).isPresent();
+        LbPrincipal principal = result.orElseThrow();
+        assertThat(principal.getName()).isEqualTo("service_account"); // Mapped by user mapping rules
+        assertThat(principal.getMemberOf()).isEqualTo(Optional.of("admin_developer_tester"));
+    }
+
+    @Test
+    void testEndToEndAuthenticationWithAuthorizationManagerPrivileges()
+            throws Exception
+    {
+        // Create HMAC secret file
+        Path secretFile = createHMACSecretFile();
+
+        // Setup JWT configuration
+        JwtConfiguration jwtConfig = createJwtConfiguration(secretFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        jwtConfig.setPrincipalField("sub");
+
+        // Create JWT manager and authenticator
+        Map<String, String> pagePermissions = new HashMap<>();
+        LbJwtManager jwtManager = new LbJwtManager(jwtConfig, pagePermissions);
+        LbJwtAuthenticator authenticator = new LbJwtAuthenticator(jwtManager, authorizationManager);
+
+        // Mock authorization manager to return the expected privileges
+        when(authorizationManager.getPrivileges(TEST_SUBJECT)).thenReturn(Optional.of("engineering_data_science"));
+
+        // Create valid JWT token without groups (privileges come from AuthorizationManager)
+        String token = JWT.create()
+                .withIssuer(TEST_ISSUER)
+                .withAudience(TEST_AUDIENCE)
+                .withSubject(TEST_SUBJECT)
+                .withIssuedAt(Date.from(Instant.now()))
+                .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .sign(hmacAlgorithm);
+
+        // Authenticate
+        Optional<LbPrincipal> result = authenticator.authenticate(token);
+
+        // Verify result
+        assertThat(result).isPresent();
+        LbPrincipal principal = result.orElseThrow();
+        assertThat(principal.getName()).isEqualTo(TEST_SUBJECT);
+        assertThat(principal.getMemberOf()).isEqualTo(Optional.of("engineering_data_science"));
+    }
+
+    @Test
+    void testEndToEndAuthenticationWithNoRolesAndNoPrivileges()
+            throws Exception
+    {
+        // Create RSA public key file
+        Path keyFile = createRSAPublicKeyFile();
+
+        // Setup JWT configuration
+        JwtConfiguration jwtConfig = createJwtConfiguration(keyFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        Map<String, String> pagePermissions = new HashMap<>();
+        LbJwtManager jwtManager = new LbJwtManager(jwtConfig, pagePermissions);
+        LbJwtAuthenticator authenticator = new LbJwtAuthenticator(jwtManager, authorizationManager);
+
+        // Setup authorization manager to return no privileges
+        when(authorizationManager.getPrivileges(TEST_SUBJECT)).thenReturn(Optional.empty());
+
+        // Create valid JWT token without roles
+        String token = JWT.create()
+                .withIssuer(TEST_ISSUER)
+                .withAudience(TEST_AUDIENCE)
+                .withSubject(TEST_SUBJECT)
+                .withIssuedAt(Date.from(Instant.now()))
+                .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .sign(rsaAlgorithm);
+
+        // Authenticate
+        Optional<LbPrincipal> result = authenticator.authenticate(token);
+
+        // Verify result
+        assertThat(result).isPresent();
+        LbPrincipal principal = result.orElseThrow();
+        assertThat(principal.getName()).isEqualTo(TEST_SUBJECT);
+        assertThat(principal.getMemberOf()).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    void testEndToEndAuthenticationWithUserMappingPattern()
+            throws Exception
+    {
+        // Create RSA public key file
+        Path keyFile = createRSAPublicKeyFile();
+
+        // Setup JWT configuration with user mapping pattern to extract username before @ symbol
+        JwtConfiguration jwtConfig = createJwtConfiguration(keyFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        jwtConfig.setUserMappingPattern("(.*)@.*"); // Extract username before @ (uses $1 by default)
+        jwtConfig.setPrincipalField("sub");
+
+        // Create JWT manager and authenticator
+        Map<String, String> pagePermissions = new HashMap<>();
+        LbJwtManager jwtManager = new LbJwtManager(jwtConfig, pagePermissions);
+        LbJwtAuthenticator authenticator = new LbJwtAuthenticator(jwtManager, authorizationManager);
+
+        // Mock authorization manager to return privileges for mapped user
+        when(authorizationManager.getPrivileges("john.doe")).thenReturn(Optional.of("user_privileges"));
+
+        // Create valid JWT token with email subject
+        String token = JWT.create()
+                .withIssuer(TEST_ISSUER)
+                .withAudience(TEST_AUDIENCE)
+                .withSubject("john.doe@example.com")
+                .withIssuedAt(Date.from(Instant.now()))
+                .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .sign(rsaAlgorithm);
+
+        // Authenticate
+        Optional<LbPrincipal> result = authenticator.authenticate(token);
+
+        // Verify result
+        assertThat(result).isPresent();
+        LbPrincipal principal = result.orElseThrow();
+        assertThat(principal.getName()).isEqualTo("john.doe"); // Mapped by user mapping pattern (everything before @)
+        assertThat(principal.getMemberOf()).isEqualTo(Optional.of("user_privileges")); // From AuthorizationManager
+    }
+
+    @Test
+    void testEndToEndAuthenticationWithUserMappingPatternWithFileBasedMapping()
+            throws Exception
+    {
+        // Create RSA public key file
+        Path keyFile = createRSAPublicKeyFile();
+
+        // Setup JWT configuration with user mapping file that can handle multiple patterns
+        Path userMappingFile = createUserMappingFile();
+        JwtConfiguration jwtConfig = createJwtConfiguration(keyFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        jwtConfig.setUserMappingFile(userMappingFile.toFile());
+        jwtConfig.setPrincipalField("sub");
+
+        // Create JWT manager and authenticator
+        Map<String, String> pagePermissions = new HashMap<>();
+        LbJwtManager jwtManager = new LbJwtManager(jwtConfig, pagePermissions);
+        LbJwtAuthenticator authenticator = new LbJwtAuthenticator(jwtManager, authorizationManager);
+
+        // Mock authorization manager to return the expected privileges
+        when(authorizationManager.getPrivileges("service_account")).thenReturn(Optional.of("admin_developer_tester"));
+
+        // Create valid JWT token with service account username that matches the pattern
+        String token = JWT.create()
+                .withIssuer(TEST_ISSUER)
+                .withAudience(TEST_AUDIENCE)
+                .withSubject("service_account_123")
+                .withIssuedAt(Date.from(Instant.now()))
+                .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .sign(rsaAlgorithm);
+
+        // Authenticate
+        Optional<LbPrincipal> result = authenticator.authenticate(token);
+
+        // Verify result
+        assertThat(result).isPresent();
+        LbPrincipal principal = result.orElseThrow();
+        assertThat(principal.getName()).isEqualTo("service_account"); // Mapped by user mapping rules
+        assertThat(principal.getMemberOf()).isEqualTo(Optional.of("admin_developer_tester"));
+    }
+
+    @Test
+    void testEndToEndAuthenticationWithUserMappingPatternDefaultFallback()
+            throws Exception
+    {
+        // Create HMAC secret file
+        Path secretFile = createHMACSecretFile();
+
+        // Setup JWT configuration with default user mapping (no pattern specified)
+        JwtConfiguration jwtConfig = createJwtConfiguration(secretFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        jwtConfig.setPrincipalField("sub");
+        // No user mapping pattern set, so it should use default (.*)  which matches anything
+
+        // Create JWT manager and authenticator
+        Map<String, String> pagePermissions = new HashMap<>();
+        LbJwtManager jwtManager = new LbJwtManager(jwtConfig, pagePermissions);
+        LbJwtAuthenticator authenticator = new LbJwtAuthenticator(jwtManager, authorizationManager);
+
+        // Mock authorization manager to return the expected privileges
+        when(authorizationManager.getPrivileges("any.username@domain.com")).thenReturn(Optional.of("microservice_production_critical"));
+
+        // Create valid JWT token with any username format
+        String token = JWT.create()
+                .withIssuer(TEST_ISSUER)
+                .withAudience(TEST_AUDIENCE)
+                .withSubject("any.username@domain.com")
+                .withIssuedAt(Date.from(Instant.now()))
+                .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .sign(hmacAlgorithm);
+
+        // Authenticate
+        Optional<LbPrincipal> result = authenticator.authenticate(token);
+
+        // Verify result
+        assertThat(result).isPresent();
+        LbPrincipal principal = result.orElseThrow();
+        assertThat(principal.getName()).isEqualTo("any.username@domain.com"); // Default mapping preserves full username
+        assertThat(principal.getMemberOf()).isEqualTo(Optional.of("microservice_production_critical")); // Privileges from AuthorizationManager
+    }
+
+    @Test
+    void testEndToEndAuthenticationWithUserMappingFileMultipleGroups()
+            throws Exception
+    {
+        // Create RSA public key file
+        Path keyFile = createRSAPublicKeyFile();
+
+        // Create a user mapping file with multiple capture groups
+        Path complexMappingFile = createComplexUserMappingFile();
+
+        // Setup JWT configuration with user mapping file that supports complex patterns
+        JwtConfiguration jwtConfig = createJwtConfiguration(keyFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        jwtConfig.setUserMappingFile(complexMappingFile.toFile());
+        jwtConfig.setPrincipalField("sub");
+
+        // Create JWT manager and authenticator
+        Map<String, String> pagePermissions = new HashMap<>();
+        LbJwtManager jwtManager = new LbJwtManager(jwtConfig, pagePermissions);
+        LbJwtAuthenticator authenticator = new LbJwtAuthenticator(jwtManager, authorizationManager);
+
+        // Mock authorization manager to return the expected privileges
+        when(authorizationManager.getPrivileges("api-123")).thenReturn(Optional.of("microservice_production"));
+
+        // Create valid JWT token with service account that matches the complex pattern
+        String token = JWT.create()
+                .withIssuer(TEST_ISSUER)
+                .withAudience(TEST_AUDIENCE)
+                .withSubject("svc-api-123")
+                .withIssuedAt(Date.from(Instant.now()))
+                .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .sign(rsaAlgorithm);
+
+        // Authenticate
+        Optional<LbPrincipal> result = authenticator.authenticate(token);
+
+        // Verify result
+        assertThat(result).isPresent();
+        LbPrincipal principal = result.orElseThrow();
+        assertThat(principal.getName()).isEqualTo("api-123"); // Mapped using multiple capture groups
+        assertThat(principal.getMemberOf()).isEqualTo(Optional.of("microservice_production")); // Privileges from AuthorizationManager
+    }
+
+    private Path createRSAPublicKeyFile()
+            throws IOException
+    {
+        Path keyFile = tempDir.resolve("rsa-public.pem");
+        String pemContent = "-----BEGIN PUBLIC KEY-----\n" +
+                Base64.getEncoder().encodeToString(publicKey.getEncoded()) + "\n" +
+                "-----END PUBLIC KEY-----\n";
+        Files.write(keyFile, pemContent.getBytes(UTF_8));
+        return keyFile;
+    }
+
+    private Path createHMACSecretFile()
+            throws IOException
+    {
+        Path secretFile = tempDir.resolve("hmac-secret.txt");
+        Files.write(secretFile, HMAC_SECRET.getBytes(UTF_8));
+        return secretFile;
+    }
+
+    private Path createUserMappingFile()
+            throws IOException
+    {
+        Path mappingFile = tempDir.resolve("user-mapping.json");
+        String mappingContent = "{\n" +
+                "  \"rules\": [\n" +
+                "    {\n" +
+                "      \"pattern\": \"service_account_(\\\\d+)\",\n" +
+                "      \"user\": \"service_account\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"pattern\": \"(.*)@.*\",\n" +
+                "      \"user\": \"$1\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+        Files.write(mappingFile, mappingContent.getBytes(UTF_8));
+        return mappingFile;
+    }
+
+    private Path createComplexUserMappingFile()
+            throws IOException
+    {
+        Path mappingFile = tempDir.resolve("complex-user-mapping.json");
+        String mappingContent = "{\n" +
+                "  \"rules\": [\n" +
+                "    {\n" +
+                "      \"pattern\": \"svc-([a-z]+)-([0-9]+)\",\n" +
+                "      \"user\": \"$1-$2\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"pattern\": \"([a-zA-Z]+)\\\\.([a-zA-Z]+)@.*\",\n" +
+                "      \"user\": \"$1.$2\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"pattern\": \"(.*)@.*\",\n" +
+                "      \"user\": \"$1\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+        Files.write(mappingFile, mappingContent.getBytes(UTF_8));
+        return mappingFile;
+    }
+
+    private JwtConfiguration createJwtConfiguration(String keyFile, String issuer, String audience)
+    {
+        JwtConfiguration config = new JwtConfiguration();
+        config.setKeyFile(keyFile);
+        config.setRequiredIssuer(issuer);
+        config.setRequiredAudience(audience);
+        config.setPrincipalField("sub");
+        return config;
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbJwtManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbJwtManager.java
@@ -1,0 +1,506 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.security;
+
+import com.auth0.jwk.Jwk;
+import com.auth0.jwk.JwkException;
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.Claim;
+import com.google.common.collect.ImmutableMap;
+import io.trino.gateway.ha.config.JwtConfiguration;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@TestInstance(Lifecycle.PER_CLASS)
+final class TestLbJwtManager
+{
+    private static final String TEST_ISSUER = "trino-gateway-test";
+    private static final String TEST_AUDIENCE = "trino-test";
+    private static final String TEST_SUBJECT = "test-user";
+    private static final String TEST_KEY_ID = "test-key-1";
+    private static final String HMAC_SECRET = "test-secret-key-for-hmac-256";
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    private JwkProvider jwkProvider;
+
+    @Mock
+    private Jwk jwk;
+
+    private KeyPair keyPair;
+    private RSAPublicKey publicKey;
+    private RSAPrivateKey privateKey;
+    private Algorithm rsaAlgorithm;
+    private Algorithm hmacAlgorithm;
+
+    @BeforeEach
+    void setUp()
+            throws Exception
+    {
+        MockitoAnnotations.openMocks(this);
+
+        // Generate RSA key pair for testing
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        keyPair = keyPairGenerator.generateKeyPair();
+        publicKey = (RSAPublicKey) keyPair.getPublic();
+        privateKey = (RSAPrivateKey) keyPair.getPrivate();
+
+        rsaAlgorithm = Algorithm.RSA256(publicKey, privateKey);
+        hmacAlgorithm = Algorithm.HMAC256(HMAC_SECRET);
+    }
+
+    @Test
+    void testConstructorWithValidRSAKeyFile()
+            throws IOException
+    {
+        // Create a PEM public key file
+        Path keyFile = createRSAPublicKeyFile();
+
+        JwtConfiguration config = createJwtConfiguration(keyFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        Map<String, String> pagePermissions = ImmutableMap.of("ADMIN", "admin_access", "USER", "user_access");
+
+        LbJwtManager manager = new LbJwtManager(config, pagePermissions);
+
+        assertThat(manager.getPrincipalField()).isEqualTo("sub");
+        assertThat(manager.getUserMappingPattern()).isEqualTo(config.getUserMappingPattern());
+        assertThat(manager.getUserMappingFile()).isEqualTo(config.getUserMappingFile());
+    }
+
+    @Test
+    void testConstructorWithValidHMACSecretFile()
+            throws IOException
+    {
+        // Create HMAC secret file
+        Path secretFile = tempDir.resolve("hmac-secret.txt");
+        Files.write(secretFile, HMAC_SECRET.getBytes(UTF_8));
+
+        JwtConfiguration config = createJwtConfiguration(secretFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        Map<String, String> pagePermissions = new HashMap<>();
+
+        LbJwtManager manager = new LbJwtManager(config, pagePermissions);
+
+        assertThat(manager.getPrincipalField()).isEqualTo("sub");
+        assertThat(manager.getUserMappingPattern()).isEqualTo(config.getUserMappingPattern());
+        assertThat(manager.getUserMappingFile()).isEqualTo(config.getUserMappingFile());
+    }
+
+    @Test
+    void testConstructorWithJWKSUrl()
+            throws IOException
+    {
+        JwtConfiguration config = createJwtConfiguration("https://example.com/.well-known/jwks.json", TEST_ISSUER, TEST_AUDIENCE);
+        Map<String, String> pagePermissions = new HashMap<>();
+
+        LbJwtManager manager = new LbJwtManager(config, pagePermissions);
+
+        assertThat(manager.getPrincipalField()).isEqualTo("sub");
+        assertThat(manager.getUserMappingPattern()).isEqualTo(config.getUserMappingPattern());
+        assertThat(manager.getUserMappingFile()).isEqualTo(config.getUserMappingFile());
+    }
+
+    @Test
+    void testConstructorWithNullKeyFile()
+    {
+        JwtConfiguration config = new JwtConfiguration();
+        config.setRequiredIssuer(TEST_ISSUER);
+        config.setRequiredAudience(TEST_AUDIENCE);
+        // keyFile is null
+
+        Map<String, String> pagePermissions = new HashMap<>();
+
+        assertThatThrownBy(() -> new LbJwtManager(config, pagePermissions))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Failed to initialize JWT algorithm");
+    }
+
+    @Test
+    void testConstructorWithInvalidKeyFile()
+    {
+        JwtConfiguration config = createJwtConfiguration("/non/existent/file.pem", TEST_ISSUER, TEST_AUDIENCE);
+        Map<String, String> pagePermissions = new HashMap<>();
+
+        assertThatThrownBy(() -> new LbJwtManager(config, pagePermissions))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Failed to initialize JWT algorithm");
+    }
+
+    @Test
+    void testVerifyValidRSAToken()
+            throws IOException
+    {
+        Path keyFile = createRSAPublicKeyFile();
+        JwtConfiguration config = createJwtConfiguration(keyFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        LbJwtManager manager = new LbJwtManager(config, new HashMap<>());
+
+        String token = createValidRSAToken();
+        Optional<Map<String, Claim>> result = manager.getClaimsFromToken(token);
+
+        assertThat(result).isPresent();
+        Map<String, Claim> claims = result.orElseThrow();
+        assertThat(claims.get("sub").asString()).isEqualTo(TEST_SUBJECT);
+        assertThat(claims.get("iss").asString()).isEqualTo(TEST_ISSUER);
+
+        Claim audienceClaim = claims.get("aud");
+        assertThat(audienceClaim).isNotNull();
+        // When only one audience is specified, it's stored as a string, not as a list
+        assertThat(audienceClaim.asString()).isEqualTo(TEST_AUDIENCE);
+    }
+
+    @Test
+    void testVerifyValidHMACToken()
+            throws IOException
+    {
+        Path secretFile = tempDir.resolve("hmac-secret.txt");
+        Files.write(secretFile, HMAC_SECRET.getBytes(UTF_8));
+
+        JwtConfiguration config = createJwtConfiguration(secretFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        LbJwtManager manager = new LbJwtManager(config, new HashMap<>());
+
+        String token = createValidHMACToken();
+        Optional<Map<String, Claim>> result = manager.getClaimsFromToken(token);
+
+        assertThat(result).isPresent();
+        assertThat(result.orElseThrow().get("sub").asString()).isEqualTo(TEST_SUBJECT);
+    }
+
+    @Test
+    void testVerifyValidJWKSToken()
+            throws Exception
+    {
+        // Mock JWKS provider
+        when(jwk.getPublicKey()).thenReturn(publicKey);
+        when(jwkProvider.get(TEST_KEY_ID)).thenReturn(jwk);
+
+        JwtConfiguration config = createJwtConfiguration("https://example.com/.well-known/jwks.json", TEST_ISSUER, TEST_AUDIENCE);
+        LbJwtManager manager = new LbJwtManager(config, new HashMap<>());
+
+        // Use reflection to set the jwkProvider (since it's private)
+        java.lang.reflect.Field jwkProviderField = LbJwtManager.class.getDeclaredField("jwkProvider");
+        jwkProviderField.setAccessible(true);
+        jwkProviderField.set(manager, jwkProvider);
+
+        String token = createValidRSATokenWithKeyId();
+        Optional<Map<String, Claim>> result = manager.getClaimsFromToken(token);
+
+        assertThat(result).isPresent();
+        assertThat(result.orElseThrow().get("sub").asString()).isEqualTo(TEST_SUBJECT);
+    }
+
+    @Test
+    void testVerifyInvalidToken()
+            throws IOException
+    {
+        Path keyFile = createRSAPublicKeyFile();
+        JwtConfiguration config = createJwtConfiguration(keyFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        LbJwtManager manager = new LbJwtManager(config, new HashMap<>());
+
+        String invalidToken = "invalid.jwt.token";
+        Optional<Map<String, Claim>> result = manager.getClaimsFromToken(invalidToken);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testVerifyExpiredToken()
+            throws IOException
+    {
+        Path keyFile = createRSAPublicKeyFile();
+        JwtConfiguration config = createJwtConfiguration(keyFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        LbJwtManager manager = new LbJwtManager(config, new HashMap<>());
+
+        String expiredToken = createExpiredRSAToken();
+        Optional<Map<String, Claim>> result = manager.getClaimsFromToken(expiredToken);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testVerifyTokenWithWrongIssuer()
+            throws IOException
+    {
+        Path keyFile = createRSAPublicKeyFile();
+        JwtConfiguration config = createJwtConfiguration(keyFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        LbJwtManager manager = new LbJwtManager(config, new HashMap<>());
+
+        String token = createRSATokenWithWrongIssuer();
+        Optional<Map<String, Claim>> result = manager.getClaimsFromToken(token);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testVerifyTokenWithWrongAudience()
+            throws IOException
+    {
+        Path keyFile = createRSAPublicKeyFile();
+        JwtConfiguration config = createJwtConfiguration(keyFile.toString(), TEST_ISSUER, TEST_AUDIENCE);
+        LbJwtManager manager = new LbJwtManager(config, new HashMap<>());
+
+        String token = createRSATokenWithWrongAudience();
+        Optional<Map<String, Claim>> result = manager.getClaimsFromToken(token);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testVerifyJWKSTokenWithMissingKeyId()
+            throws Exception
+    {
+        JwtConfiguration config = createJwtConfiguration("https://example.com/.well-known/jwks.json", TEST_ISSUER, TEST_AUDIENCE);
+        LbJwtManager manager = new LbJwtManager(config, new HashMap<>());
+
+        // Use reflection to set the jwkProvider
+        java.lang.reflect.Field jwkProviderField = LbJwtManager.class.getDeclaredField("jwkProvider");
+        jwkProviderField.setAccessible(true);
+        jwkProviderField.set(manager, jwkProvider);
+
+        String token = createValidRSAToken(); // Token without keyId
+        Optional<Map<String, Claim>> result = manager.getClaimsFromToken(token);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testVerifyJWKSTokenWithJwkException()
+            throws Exception
+    {
+        // Mock JWKS provider to throw exception
+        when(jwkProvider.get(TEST_KEY_ID)).thenThrow(new JwkException("Key not found"));
+
+        JwtConfiguration config = createJwtConfiguration("https://example.com/.well-known/jwks.json", TEST_ISSUER, TEST_AUDIENCE);
+        LbJwtManager manager = new LbJwtManager(config, new HashMap<>());
+
+        // Use reflection to set the jwkProvider
+        java.lang.reflect.Field jwkProviderField = LbJwtManager.class.getDeclaredField("jwkProvider");
+        jwkProviderField.setAccessible(true);
+        jwkProviderField.set(manager, jwkProvider);
+
+        String token = createValidRSATokenWithKeyId();
+        Optional<Map<String, Claim>> result = manager.getClaimsFromToken(token);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testProcessPagePermissions()
+    {
+        Map<String, String> pagePermissions = ImmutableMap.of(
+                "ADMIN", "admin_access",
+                "USER", "user_access",
+                "API", "api_access");
+
+        JwtConfiguration config = new JwtConfiguration();
+        config.setKeyFile("dummy"); // Will fail initialization, but we're only testing page permissions
+
+        try {
+            new LbJwtManager(config, pagePermissions);
+        }
+        catch (RuntimeException e) {
+            // Expected due to dummy key file, but we can still test the page permissions logic
+        }
+
+        // Test the static logic by creating a manager with valid config
+        Path secretFile;
+        try {
+            secretFile = tempDir.resolve("hmac-secret.txt");
+            Files.write(secretFile, HMAC_SECRET.getBytes(UTF_8));
+            config.setKeyFile(secretFile.toString());
+            LbJwtManager manager = new LbJwtManager(config, pagePermissions);
+
+            List<String> adminRoles = List.of("ADMIN");
+            List<String> result = manager.processPagePermissions(adminRoles);
+            assertThat(result).containsExactly("admin", "access");
+
+            List<String> multipleRoles = List.of("ADMIN", "USER");
+            result = manager.processPagePermissions(multipleRoles);
+            assertThat(result).containsExactlyInAnyOrder("admin", "access", "user");
+
+            List<String> invalidRoles = List.of("INVALID");
+            result = manager.processPagePermissions(invalidRoles);
+            assertThat(result).isEmpty();
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void testBuildUnauthorizedResponse()
+    {
+        Response response = LbJwtManager.buildUnauthorizedResponse();
+        assertThat(response.getStatus()).isEqualTo(Response.Status.UNAUTHORIZED.getStatusCode());
+    }
+
+    @Test
+    void testGetPrincipalFieldDefault()
+    {
+        Path secretFile;
+        try {
+            secretFile = tempDir.resolve("hmac-secret.txt");
+            Files.write(secretFile, HMAC_SECRET.getBytes(UTF_8));
+
+            JwtConfiguration config = new JwtConfiguration();
+            config.setKeyFile(secretFile.toString());
+            // principalField defaults to "sub"
+
+            LbJwtManager manager = new LbJwtManager(config, new HashMap<>());
+            assertThat(manager.getPrincipalField()).isEqualTo("sub");
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void testGetPrincipalFieldCustom()
+    {
+        Path secretFile;
+        try {
+            secretFile = tempDir.resolve("hmac-secret.txt");
+            Files.write(secretFile, HMAC_SECRET.getBytes(UTF_8));
+
+            JwtConfiguration config = new JwtConfiguration();
+            config.setKeyFile(secretFile.toString());
+            config.setPrincipalField("username");
+
+            LbJwtManager manager = new LbJwtManager(config, new HashMap<>());
+            assertThat(manager.getPrincipalField()).isEqualTo("username");
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // Helper methods
+
+    private JwtConfiguration createJwtConfiguration(String keyFile, String issuer, String audience)
+    {
+        JwtConfiguration config = new JwtConfiguration();
+        config.setKeyFile(keyFile);
+        config.setRequiredIssuer(issuer);
+        config.setRequiredAudience(audience);
+        config.setPrincipalField("sub");
+        return config;
+    }
+
+    private Path createRSAPublicKeyFile()
+            throws IOException
+    {
+        Path keyFile = tempDir.resolve("public_key.pem");
+        String pemContent = "-----BEGIN PUBLIC KEY-----\n" +
+                Base64.getEncoder().encodeToString(publicKey.getEncoded()) + "\n" +
+                "-----END PUBLIC KEY-----";
+        Files.write(keyFile, pemContent.getBytes(UTF_8));
+        return keyFile;
+    }
+
+    private String createValidRSAToken()
+    {
+        return JWT.create()
+                .withIssuer(TEST_ISSUER)
+                .withSubject(TEST_SUBJECT)
+                .withAudience(TEST_AUDIENCE)
+                .withIssuedAt(new Date())
+                .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .sign(rsaAlgorithm);
+    }
+
+    private String createValidRSATokenWithKeyId()
+    {
+        return JWT.create()
+                .withKeyId(TEST_KEY_ID)
+                .withIssuer(TEST_ISSUER)
+                .withSubject(TEST_SUBJECT)
+                .withAudience(TEST_AUDIENCE)
+                .withIssuedAt(new Date())
+                .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .sign(rsaAlgorithm);
+    }
+
+    private String createValidHMACToken()
+    {
+        return JWT.create()
+                .withIssuer(TEST_ISSUER)
+                .withSubject(TEST_SUBJECT)
+                .withAudience(TEST_AUDIENCE)
+                .withIssuedAt(new Date())
+                .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .sign(hmacAlgorithm);
+    }
+
+    private String createExpiredRSAToken()
+    {
+        return JWT.create()
+                .withIssuer(TEST_ISSUER)
+                .withSubject(TEST_SUBJECT)
+                .withAudience(TEST_AUDIENCE)
+                .withIssuedAt(Date.from(Instant.now().minus(2, ChronoUnit.HOURS)))
+                .withExpiresAt(Date.from(Instant.now().minus(1, ChronoUnit.HOURS)))
+                .sign(rsaAlgorithm);
+    }
+
+    private String createRSATokenWithWrongIssuer()
+    {
+        return JWT.create()
+                .withIssuer("wrong-issuer")
+                .withSubject(TEST_SUBJECT)
+                .withAudience(TEST_AUDIENCE)
+                .withIssuedAt(new Date())
+                .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .sign(rsaAlgorithm);
+    }
+
+    private String createRSATokenWithWrongAudience()
+    {
+        return JWT.create()
+                .withIssuer(TEST_ISSUER)
+                .withSubject(TEST_SUBJECT)
+                .withAudience("wrong-audience")
+                .withIssuedAt(new Date())
+                .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .sign(rsaAlgorithm);
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbJwtManagerIntegration.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbJwtManagerIntegration.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.gateway.ha.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import io.airlift.log.Logger;
+import io.trino.gateway.ha.HaGatewayLauncher;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Date;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for LbJwtManager that tests JWT authentication
+ * in a running gateway instance.
+ * <p>
+ * This test creates a real JWT token and tests it against a running gateway
+ * to ensure end-to-end JWT authentication works properly.
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+final class TestLbJwtManagerIntegration
+{
+    private static final Logger log = Logger.get(TestLbJwtManagerIntegration.class);
+
+    private static final String TEST_ISSUER = "trino-gateway-integration-test";
+    private static final String TEST_AUDIENCE = "trino-integration";
+    private static final String TEST_SUBJECT = "integration-test-user";
+
+    @TempDir
+    static Path tempDir;
+
+    private final PostgreSQLContainer<?> postgresql = new PostgreSQLContainer<>("postgres:17")
+            .waitingFor(Wait.forLogMessage(".*ready to accept connections.*", 1));
+    private int routerPort = 21002 + (int) (Math.random() * 1000);
+    private OkHttpClient httpClient;
+    private KeyPair keyPair;
+    private RSAPublicKey publicKey;
+    private RSAPrivateKey privateKey;
+    private Algorithm rsaAlgorithm;
+
+    @BeforeAll
+    void setUp()
+            throws Exception
+    {
+        // Start PostgreSQL container and wait for it to be ready
+        postgresql.start();
+
+        // Generate RSA key pair for testing
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        keyPair = keyPairGenerator.generateKeyPair();
+        publicKey = (RSAPublicKey) keyPair.getPublic();
+        privateKey = (RSAPrivateKey) keyPair.getPrivate();
+
+        rsaAlgorithm = Algorithm.RSA256(publicKey, privateKey);
+        httpClient = new OkHttpClient();
+
+        // Create gateway configuration with JWT authentication
+        File testConfigFile = createGatewayConfigFile();
+
+        // Start Gateway
+        String[] args = {testConfigFile.getAbsolutePath()};
+        HaGatewayLauncher.main(args);
+
+        // Wait for the gateway to start
+        Thread.sleep(5000);
+        log.info("Gateway started on port: " + routerPort);
+    }
+
+    @Test
+    void testAuthenticatedRequestWithValidJWT()
+            throws IOException
+    {
+        String validToken = createValidRSAToken();
+        log.info("Testing with valid JWT token");
+
+        Request request = new Request.Builder()
+                .url("http://localhost:" + routerPort + "/gateway")
+                .header("Authorization", "Bearer " + validToken)
+                .build();
+
+        try (Response response = httpClient.newCall(request).execute()) {
+            log.info("Response code for valid JWT: " + response.code());
+            // Should be able to access the endpoint with valid JWT
+            assertThat(response.code()).isEqualTo(200);
+        }
+    }
+
+    @Test
+    void testUnauthenticatedRequestWithoutJWT()
+            throws IOException
+    {
+        log.info("Testing request without JWT token");
+
+        Request request = new Request.Builder()
+                .url("http://localhost:" + routerPort + "/gateway")
+                .build();
+
+        try (Response response = httpClient.newCall(request).execute()) {
+            log.info("Response code without JWT: " + response.code());
+            // Should be forbidden without JWT
+            assertThat(response.code()).isEqualTo(403);
+        }
+    }
+
+    @Test
+    void testAuthenticatedRequestWithInvalidJWT()
+            throws IOException
+    {
+        String invalidToken = "invalid.jwt.token";
+        log.info("Testing with invalid JWT token");
+
+        Request request = new Request.Builder()
+                .url("http://localhost:" + routerPort + "/gateway")
+                .header("Authorization", "Bearer " + invalidToken)
+                .build();
+
+        try (Response response = httpClient.newCall(request).execute()) {
+            log.info("Response code for invalid JWT: " + response.code());
+            // Should be forbidden with invalid JWT
+            assertThat(response.code()).isEqualTo(403);
+        }
+    }
+
+    @Test
+    void testAuthenticatedRequestWithExpiredJWT()
+            throws IOException
+    {
+        String expiredToken = createExpiredRSAToken();
+        log.info("Testing with expired JWT token");
+
+        Request request = new Request.Builder()
+                .url("http://localhost:" + routerPort + "/gateway")
+                .header("Authorization", "Bearer " + expiredToken)
+                .build();
+
+        try (Response response = httpClient.newCall(request).execute()) {
+            log.info("Response code for expired JWT: " + response.code());
+            // Should be forbidden with expired JWT
+            assertThat(response.code()).isEqualTo(403);
+        }
+    }
+
+    // Helper methods
+
+    private File createGatewayConfigFile()
+            throws IOException
+    {
+        Path rsaKeyFile = createRSAPublicKeyFile();
+
+        // Create a minimal gateway configuration for JWT testing
+        String yamlConfig = String.format("""
+                        serverConfig:
+                          http-server.http.port: %d
+                          node.environment: test
+
+                        authentication:
+                          defaultType: jwt
+                          jwt:
+                            keyFile: %s
+                            requiredIssuer: %s
+                            requiredAudience: %s
+                            principalField: sub
+
+                        pagePermissions:
+                          ADMIN: admin_access
+                          USER: user_access
+                          API: api_access
+
+                        dataStore:
+                          jdbcUrl: %s
+                          user: %s
+                          password: %s
+                          driver: org.postgresql.Driver
+
+                        clusterStatsConfiguration:
+                          monitorType: NOOP
+                        """, routerPort, rsaKeyFile.toString(), TEST_ISSUER, TEST_AUDIENCE,
+                postgresql.getJdbcUrl(), postgresql.getUsername(), postgresql.getPassword());
+
+        Path configFile = tempDir.resolve("test-jwt-integration-config.yml");
+        Files.write(configFile, yamlConfig.getBytes(UTF_8));
+        return configFile.toFile();
+    }
+
+    private Path createRSAPublicKeyFile()
+            throws IOException
+    {
+        Path keyFile = tempDir.resolve("integration_public_key.pem");
+        String pemContent = "-----BEGIN PUBLIC KEY-----\n" +
+                Base64.getEncoder().encodeToString(publicKey.getEncoded()) + "\n" +
+                "-----END PUBLIC KEY-----";
+        Files.write(keyFile, pemContent.getBytes(UTF_8));
+        return keyFile;
+    }
+
+    private String createValidRSAToken()
+    {
+        return JWT.create()
+                .withIssuer(TEST_ISSUER)
+                .withSubject(TEST_SUBJECT)
+                .withAudience(TEST_AUDIENCE)
+                .withIssuedAt(new Date())
+                .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .withClaim("role", "API")
+                .sign(rsaAlgorithm);
+    }
+
+    private String createExpiredRSAToken()
+    {
+        return JWT.create()
+                .withIssuer(TEST_ISSUER)
+                .withSubject(TEST_SUBJECT)
+                .withAudience(TEST_AUDIENCE)
+                .withIssuedAt(Date.from(Instant.now().minus(2, ChronoUnit.HOURS)))
+                .withExpiresAt(Date.from(Instant.now().minus(1, ChronoUnit.HOURS)))
+                .withClaim("role", "API")
+                .sign(rsaAlgorithm);
+    }
+}

--- a/webapp/src/api/webapp/login.ts
+++ b/webapp/src/api/webapp/login.ts
@@ -23,3 +23,7 @@ export async function loginTypeApi(): Promise<any> {
 export async function getUIConfiguration(): Promise<any> {
     return api.get('/webapp/getUIConfiguration')
 }
+
+export async function getTokenApi(): Promise<any> {
+  return api.post('/token', {})
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Add JWT (JSON Web Token) authentication support to Trino Gateway, enabling identity propagation from upstream proxies or API gateways.

### Motivation

In many enterprise deployments, Trino Gateway sits behind a reverse proxy or API gateway (e.g., Nginx, Istio, Envoy, Kong, or a custom proxy) that handles user authentication. The proxy authenticates users against an Identity Provider (IdP) such as Azure AD, Okta, or Keycloak, which issues a JWT token. The proxy then forwards requests to Trino Gateway with the token in the `Authorization: Bearer <jwt-token>` header.

Currently, Trino Gateway cannot consume these forwarded JWT tokens for user identification. This PR enables Trino Gateway to:

- **Validate incoming JWT tokens** from upstream proxies
- **Extract user identity** from configurable JWT claims
- **Apply user mapping** to transform principals (e.g., strip email domains)

```
┌────────┐                 ┌──────────────┐
│  User  │                 │   Identity   │
└────┬───┘                 │   Provider   │
     │                     │  (IdP)       │
     │                     └──────┬───────┘
     │                            │ issues JWT
     ▼                            ▼
┌─────────────────────────────────────────┐
│            Proxy / API Gateway          │
│    (authenticates user, obtains JWT)    │
└────────────────┬────────────────────────┘
                 │ Authorization: Bearer <jwt>
                 ▼
┌─────────────────────────────────────────┐
│           Trino Gateway                 │
│  (validates JWT, extracts identity,     │
│   applies user mapping, authorizes)     │
└─────────────────────────────────────────┘
```

### Changes

#### JWT Authentication (`LbJwtAuthenticator`, `LbJwtManager`)

- Validates JWT tokens from the `Authorization: Bearer` header
- Supports three key sources for signature verification:
  - RSA public key files (PEM format)
  - HMAC secret files
  - JWKS URLs (for dynamic key retrieval from identity providers)
- Validates required claims: issuer (`iss`) and audience (`aud`)
- Extracts user identity from a configurable claim field (default: `sub`)

#### User Mapping (`UserMapping`)

Transforms the JWT principal to an internal username before authorization:

- Simple regex pattern: `(.*)@company\.com` extracts username from email
- Rule file support for complex scenarios (allow/deny rules, case transformation)
- Follows the same pattern as [Trino's user mapping](https://trino.io/docs/current/security/user-mapping.html)

#### Configuration

```yaml
authentication:
  defaultType: "jwt"
  jwt:
    keyFile: "/path/to/public-key.pem"  # or JWKS URL
    requiredIssuer: "https://idp.example.com/"
    requiredAudience: "trino-gateway"
    principalField: "sub"  # claim containing user identity
    userMappingPattern: "(.*)@example\\.com"  # optional
```

#### Files Changed

| Category | Files |
|----------|-------|
| Configuration | `JwtConfiguration`, `AuthenticationConfiguration` |
| Authentication | `LbJwtAuthenticator`, `LbJwtManager` |
| User Mapping | `UserMapping`, `UserMappingException` |
| Utilities | `JsonUtils` |
| Integration | `HaGatewayProviderModule`, `LoginResource` |
| Documentation | `docs/security.md` |
| Tests | 4 test classes with unit and integration coverage |

### How It Works

1. Upstream proxy authenticates user against an IdP and obtains a JWT token
2. Proxy forwards request to Trino Gateway with `Authorization: Bearer <jwt>`
3. Trino Gateway validates the JWT signature and claims
4. User identity is extracted from the configured claim (e.g., `sub` or `email`)
5. User mapping transforms the identity if configured (e.g., strip domain)
6. Existing authorization determines user privileges (admin, user, api)

### Testing

- Unit tests for JWT validation, claim extraction, and user mapping rules
- Integration tests for end-to-end authentication flows


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino-gateway/issues/449

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
