### PR TITLE
Bump node.js from 20.17.0 to 24.12.0

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -552,7 +552,7 @@
                             <goal>install-node-and-pnpm</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v20.17.0</nodeVersion>
+                            <nodeVersion>v24.12.0</nodeVersion>
                             <pnpmVersion>9.14.2</pnpmVersion>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## Description

bump node.js from 20 to 24.

## Additional context and related issues

Node.js v20 is maintenance LTS and will reach end of life in April 2026, while v24 is the current active LTS.

Further details:
https://nodejs.org/en/about/previous-releases
https://github.com/nodejs/Release?tab=readme-ov-file#nodejs-release-working-group

**Note**: npm can be upgraded separately or additionally as part of this PR
