### PR TITLE
Bump pnpm from 9.14.2 to 10.27.0

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -553,7 +553,7 @@
                         </goals>
                         <configuration>
                             <nodeVersion>v24.12.0</nodeVersion>
-                            <pnpmVersion>9.14.2</pnpmVersion>
+                            <pnpmVersion>10.27.0</pnpmVersion>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
## Description

Upgrade pnpm from version 9.14.2 to 10.27.0 to align with the recent node.js 24 update.

## Additional context and related issues

node.js has been bumped to version 24 and updating pnpm ensures compatibility, access to the latest fixes, and improved stability.