### PR TITLE
Enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      # Apply 7 day cooldown to avoid updating dependencies right away. This reduces the opportunity window
+      # when supply chain is compromised.
+      default-days: 7
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    cooldown:
+      # Apply 7 day cooldown to avoid updating dependencies right away. This reduces the opportunity window
+      # when supply chain is compromised. This doesn't apply to the dependencies that we own and release.
+      default-days: 7
+      exclude:
+        - io.airlift:*
+        - io.trino:*
+    ignore:
+      # Airbase and Airlift are best updated together. Update Airbase only when updating Airlift.
+      - dependency-name: "io.airlift:airbase"


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
