### PR TITLE
Remove unused dep.jeasy.version property

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -23,7 +23,6 @@
 
         <!-- dependency versions -->
         <dep.flyway.version>11.20.1</dep.flyway.version>
-        <dep.jeasy.version>4.1.0</dep.jeasy.version>
         <dep.mockito.version>5.21.0</dep.mockito.version>
         <dep.okhttp3.version>5.3.2</dep.okhttp3.version>
         <dep.trino.version>479</dep.trino.version>


### PR DESCRIPTION
## Description

* Follow-up of https://github.com/trinodb/trino-gateway/pull/540

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
