### PR TITLE
Use orElseGet for lazy evaluation in RoutingTargetHandler

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
@@ -80,7 +80,7 @@ public class RoutingTargetHandler
             return new RoutingTargetResponse(
                     new RoutingDestination(routingGroup, cluster, buildUriWithNewCluster(cluster, request), externalUrl),
                     request);
-        }).orElse(getRoutingTargetResponse(request));
+        }).orElseGet(() -> getRoutingTargetResponse(request));
 
         logRewrite(routingTargetResponse.routingDestination().clusterHost(), request);
         return routingTargetResponse;


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino-gateway/issues/920

<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
`RoutingTargetHandler.resolveRouting()` uses `Optional.orElse(getRoutingTargetResponse(request))`  which eagerly evaluates the fallback even when the query ID is found in the cache. If getRoutingTargetResponse() throws (e.g. no backends match the routing rules), the exception propagates and the request fails with a 500, despite the query ID being successfully resolved.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required, with the following suggested text:
Fix eager evaluation in RoutingTargetHandler

```markdown
* Fix some things.
```
