### PR TITLE
Fix eager evaluation of fallback routing in resolveRouting

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
@@ -80,7 +80,7 @@ public class RoutingTargetHandler
             return new RoutingTargetResponse(
                     new RoutingDestination(routingGroup, cluster, buildUriWithNewCluster(cluster, request), externalUrl),
                     request);
-        }).orElse(getRoutingTargetResponse(request));
+        }).orElseGet(() -> getRoutingTargetResponse(request));
 
         logRewrite(routingTargetResponse.routingDestination().clusterHost(), request);
         return routingTargetResponse;

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandler.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandler.java
@@ -29,6 +29,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.WebApplicationException;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -108,13 +109,20 @@ class TestRoutingTargetHandler
         config = provideGatewayConfiguration();
         httpClient = Mockito.mock(HttpClient.class);
         routingManager = Mockito.mock(RoutingManager.class);
-        when(routingManager.provideBackendConfiguration(any(), any())).thenReturn(new ProxyBackendConfiguration());
         request = prepareMockRequest();
 
         // Initialize the handler with the configuration
         handler = new RoutingTargetHandler(
                 routingManager,
                 RoutingGroupSelector.byRoutingExternal(httpClient, config.getRoutingRules().getRulesExternalConfiguration(), config.getRequestAnalyzerConfig()), config);
+    }
+
+    @BeforeEach
+    void resetMocks()
+    {
+        Mockito.reset(routingManager);
+        when(routingManager.provideBackendConfiguration(any(), any())).thenReturn(new ProxyBackendConfiguration());
+        config.getRoutingRules().getRulesExternalConfiguration().setPropagateErrors(false);
     }
 
     @Test
@@ -298,6 +306,35 @@ class TestRoutingTargetHandler
 
         assertThatThrownBy(() -> handler.resolveRouting(request))
                 .isInstanceOf(WebApplicationException.class);
+    }
+
+    @Test // regression test for https://github.com/trinodb/trino-gateway/issues/920
+    void testResolveRoutingWithKnownQueryIdAndFailingFallback()
+    {
+        // Simulate a request to /ui/query.html?queryId where the query ID is known
+        // but the fallback routing (getRoutingTargetResponse) would fail because
+        // there are no backends for the resolved routing group.
+        // This tests that the eagerly-evaluated fallback does not throw when
+        // previousCluster is present.
+        String queryId = "20240101_000000_00001_aaaaa";
+        String backendUrl = "https://trino-backend.example.com";
+
+        HttpServletRequest uiRequest = Mockito.mock(HttpServletRequest.class);
+        when(uiRequest.getMethod()).thenReturn(HttpMethod.GET);
+        when(uiRequest.getRequestURI()).thenReturn("/ui/query.html");
+        when(uiRequest.getQueryString()).thenReturn(queryId);
+
+        // Query ID is known — cache returns the backend
+        when(routingManager.findBackendForQueryId(queryId)).thenReturn(backendUrl);
+        when(routingManager.findRoutingGroupForQueryId(queryId)).thenReturn("test-group");
+        when(routingManager.findExternalUrlForQueryId(queryId)).thenReturn(backendUrl);
+
+        // Fallback routing would throw (no backends for the routing group)
+        when(routingManager.provideBackendConfiguration(any(), any()))
+                .thenThrow(new IllegalStateException("Number of active backends found zero"));
+
+        RoutingTargetResponse response = handler.resolveRouting(uiRequest);
+        assertThat(response.routingDestination().clusterHost()).isEqualTo(backendUrl);
     }
 
     private RoutingTargetHandler createHandlerWithPropagateErrorsTrue()


### PR DESCRIPTION
## Summary

- Change `Optional.orElse()` to `Optional.orElseGet()` in `RoutingTargetHandler.resolveRouting()` to prevent eager evaluation of the fallback path

## Problem

`Optional.orElse(value)` eagerly evaluates `value` , in `resolveRouting()`, this means `getRoutingTargetResponse(request)` is always called, even when the query ID is found in the cache and `previousCluster` is present.

For requests like `GET /ui/query.html?queryId` (e.g. Trino Web UI tracking links via Superset), the request has no routing headers (`X-Trino-Routing-Group`, etc.). When `getRoutingTargetResponse()` runs the routing rules and falls through to `provideBackendConfiguration()`, it throws `IllegalStateException: Number of active backends found zero` if no default backend is configured. This exception propagates before `.orElse()` can return the cached result, causing a 500 error even though the query ID was successfully resolved.

## Fix

Replace `.orElse(getRoutingTargetResponse(request))` with `.orElseGet(() -> getRoutingTargetResponse(request))` so the fallback is only evaluated when `previousCluster` is empty.

## Test plan

- Added `testResolveRoutingWithKnownQueryIdAndFailingFallback` which verifies that when a query ID is found in the cache but the fallback routing would throw, `resolveRouting` still returns the cached backend successfully
- The test fails with `orElse()` and passes with `orElseGet()`

Fixes #920
