### PR TITLE
Add stale issue processing

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'trinodb/trino-gateway'
     steps:
-      - uses: actions/stale@v10.1.1
+      - uses: actions/stale@v10.2.0
         with:
           # PRs
           stale-pr-message: 'This pull request has gone a while without any activity. Ask for help on #trino-gateway-dev on Trino slack.'


### PR DESCRIPTION
## Description

Add processing for stale issues, note that the `roadmap` issues are ignored. We could add other labels to also ignore if we want but not sure we need that since we can also use the `stale-ignore` label generically.

## Additional context and related issues

Wanted to do this for a while anyway .. this is also a test for doing the same in Trino. For that repo we would have to tweak the start date and see how we can do that for issues only. 

Also see https://github.com/actions/stale

As discussed with @findepi

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
