### PR TITLE
Add support for HEAD request

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
@@ -59,6 +59,7 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.http.client.Request.Builder.prepareDelete;
 import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.Request.Builder.prepareHead;
 import static io.airlift.http.client.Request.Builder.preparePost;
 import static io.airlift.http.client.Request.Builder.preparePut;
 import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
@@ -151,6 +152,15 @@ public class ProxyRequestHandler
     {
         Request.Builder request = preparePut()
                 .setBodyGenerator(createStaticBodyGenerator(statement, UTF_8));
+        performRequest(routingDestination, servletRequest, asyncResponse, request);
+    }
+
+    public void headRequest(
+            HttpServletRequest servletRequest,
+            AsyncResponse asyncResponse,
+            RoutingDestination routingDestination)
+    {
+        Request.Builder request = prepareHead();
         performRequest(routingDestination, servletRequest, asyncResponse, request);
     }
 

--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/RouteToBackendResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/RouteToBackendResource.java
@@ -20,6 +20,7 @@ import io.trino.gateway.ha.handler.schema.RoutingTargetResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HEAD;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
@@ -95,5 +96,14 @@ public class RouteToBackendResource
         MultiReadHttpServletRequest multiReadHttpServletRequest = new MultiReadHttpServletRequest(servletRequest, body);
         RoutingTargetResponse result = routingTargetHandler.resolveRouting(multiReadHttpServletRequest);
         proxyRequestHandler.putRequest(body, result.modifiedRequest(), asyncResponse, result.routingDestination());
+    }
+
+    @HEAD
+    public void headHandler(
+            @Context HttpServletRequest servletRequest,
+            @Suspended AsyncResponse asyncResponse)
+    {
+        RoutingTargetResponse result = routingTargetHandler.resolveRouting(servletRequest);
+        proxyRequestHandler.headRequest(result.modifiedRequest(), asyncResponse, result.routingDestination());
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/proxyserver/TestProxyRequestHandler.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/proxyserver/TestProxyRequestHandler.java
@@ -61,6 +61,7 @@ final class TestProxyRequestHandler
     private static final String OK = "OK";
     private static final int NOT_FOUND = 404;
     private static final MediaType MEDIA_TYPE = MediaType.parse("application/json; charset=utf-8");
+    private static final String HEAD_ENDPOINT = "/v1/query";
 
     private final String customPutEndpoint = "/v1/custom"; // this is enabled in test-config-template.yml
     private final String healthCheckEndpoint = "/v1/info";
@@ -84,6 +85,11 @@ final class TestProxyRequestHandler
                     return new MockResponse().setResponseCode(200)
                             .setHeader(CONTENT_TYPE, JSON_UTF_8)
                             .setBody(OK);
+                }
+
+                if (request.getMethod().equals("HEAD") && request.getPath().equals(HEAD_ENDPOINT)) {
+                    return new MockResponse().setResponseCode(200)
+                            .setHeader(CONTENT_TYPE, JSON_UTF_8);
                 }
 
                 return new MockResponse().setResponseCode(NOT_FOUND);
@@ -122,6 +128,24 @@ final class TestProxyRequestHandler
 
         Request postRequest = new Request.Builder().url(url).post(requestBody).build();
         try (Response response = httpClient.newCall(postRequest).execute()) {
+            assertThat(response.code()).isEqualTo(NOT_FOUND);
+        }
+    }
+
+    @Test
+    void testHeadRequestHandler()
+            throws Exception
+    {
+        String url = "http://localhost:" + routerPort + HEAD_ENDPOINT;
+
+        Request headRequest = new Request.Builder().url(url).head().build();
+        try (Response response = httpClient.newCall(headRequest).execute()) {
+            assertThat(response.code()).isEqualTo(200);
+            assertThat(response.header("Content-Type")).isEqualTo("application/json;charset=utf-8");
+        }
+
+        Request getRequest = new Request.Builder().url(url).get().build();
+        try (Response response = httpClient.newCall(getRequest).execute()) {
             assertThat(response.code()).isEqualTo(NOT_FOUND);
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
We found an issue after we started using Starburst Tableau connector 1.5.1 which seems to set the validateConnection = true by default causing the queries to start failing because Trino Gateway does not support HEAD request.

`Caused by: java.sql.SQLException: Unable to connect to Trino server
	at io.trino.jdbc.TrinoConnection.<init>(TrinoConnection.java:186) ~[?:?]
	at io.trino.jdbc.NonRegisteringTrinoDriver.connect(NonRegisteringTrinoDriver.java:80) ~[?:?]
	at com.tableausoftware.jdbc.JDBCDriverManager.getConnection(JDBCDriverManager.java:308) ~[jdbcserver.jar:20242.0.4]
	... 20 more
Caused by: java.lang.UnsupportedOperationException: Trino server does not support HEAD /v1/statement
	at io.trino.jdbc.TrinoConnection.isConnectionValid(TrinoConnection.java:216) ~[?:?]
	at io.trino.jdbc.TrinoConnection.<init>(TrinoConnection.java:181) ~[?:?]
	at io.trino.jdbc.NonRegisteringTrinoDriver.connect(NonRegisteringTrinoDriver.java:80) ~[?:?]
	at com.tableausoftware.jdbc.JDBCDriverManager.getConnection(JDBCDriverManager.java:308)`

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
