### PR TITLE
Add API specific endpoints for routing rules

### DIFF
--- a/docs/gateway-api.md
+++ b/docs/gateway-api.md
@@ -124,20 +124,25 @@ curl -X POST http://localhost:8080/gateway/backend/activate/trino-2
 
 ## Update routing rules
 
-This endpoint is part of the `/webapp` endpoint family and requires the
-`ADMIN` role.
-
 The API can be used to programmatically update the routing rules. Rule are
 updated based on the rule name. Storage of the rules must use a writeable file
-and the configuration 'rulesType: FILE'.
+and the configuration `rulesType: FILE`.
 
 For this feature to work with multiple replicas of the Trino Gateway, you must
 provide a shared storage that supports file locking for the routing rules file.
 If multiple replicas are used with local storage, then rules get out of
 sync when updated.
 
+Get all routing rules:
+
 ```shell
-curl -X POST http://localhost:8080/webapp/updateRoutingRules \
+curl -X GET http://localhost:8080/gateway/routing-rules/all
+```
+
+Update a routing rule:
+
+```shell
+curl -X POST http://localhost:8080/gateway/routing-rules/modify/update \
  -H 'Content-Type: application/json' \
  -d '{  "name": "trino-rule",
         "description": "updated rule description",

--- a/gateway-ha/src/main/java/io/trino/gateway/baseapp/BaseApp.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/baseapp/BaseApp.java
@@ -35,6 +35,7 @@ import io.trino.gateway.ha.resource.GatewayWebAppResource;
 import io.trino.gateway.ha.resource.HaGatewayResource;
 import io.trino.gateway.ha.resource.LoginResource;
 import io.trino.gateway.ha.resource.PublicResource;
+import io.trino.gateway.ha.resource.RoutingRulesResourceHandler;
 import io.trino.gateway.ha.resource.TrinoResource;
 import io.trino.gateway.ha.router.ForRouter;
 import io.trino.gateway.ha.router.RoutingManager;
@@ -137,6 +138,7 @@ public class BaseApp
         binder.bind(ProxyHandlerStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(ProxyHandlerStats.class).withGeneratedName();
         binder.bind(RoutingRulesManager.class);
+        binder.bind(RoutingRulesResourceHandler.class);
         binder.bind(ClusterMetricsStatsExporter.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, RoutingManager.class)
                 .setDefault()

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayResource.java
@@ -15,8 +15,10 @@ package io.trino.gateway.ha.resource;
 
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
+import io.trino.gateway.ha.domain.RoutingRule;
 import io.trino.gateway.ha.router.GatewayBackendManager;
 import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -26,6 +28,8 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Request;
 import jakarta.ws.rs.core.Response;
+
+import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
@@ -37,11 +41,13 @@ public class GatewayResource
     private static final Logger log = Logger.get(GatewayResource.class);
 
     private final GatewayBackendManager gatewayBackendManager;
+    private final RoutingRulesResourceHandler routingRulesResourceHandler;
 
     @Inject
-    public GatewayResource(GatewayBackendManager gatewayBackendManager)
+    public GatewayResource(GatewayBackendManager gatewayBackendManager, RoutingRulesResourceHandler routingRulesResourceHandler)
     {
         this.gatewayBackendManager = requireNonNull(gatewayBackendManager, "gatewayBackendManager is null");
+        this.routingRulesResourceHandler = requireNonNull(routingRulesResourceHandler, "routingRulesResourceHandler is null");
     }
 
     @GET
@@ -90,6 +96,23 @@ public class GatewayResource
             return throwError(e);
         }
         return Response.ok().build();
+    }
+
+    @GET
+    @Path("/routing-rules/all")
+    public Response getRoutingRules()
+            throws IOException
+    {
+        return routingRulesResourceHandler.getRoutingRules();
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/routing-rules/modify/update")
+    public Response updateRoutingRules(RoutingRule routingRule)
+            throws IOException
+    {
+        return routingRulesResourceHandler.updateRoutingRules(routingRule);
     }
 
     private Response throwError(Exception e)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/RoutingRulesResourceHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/RoutingRulesResourceHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.resource;
+
+import com.google.inject.Inject;
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.config.RoutingRulesConfiguration;
+import io.trino.gateway.ha.config.RulesType;
+import io.trino.gateway.ha.domain.Result;
+import io.trino.gateway.ha.domain.RoutingRule;
+import io.trino.gateway.ha.router.RoutingRulesManager;
+import jakarta.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class RoutingRulesResourceHandler
+{
+    private final RoutingRulesManager routingRulesManager;
+    private final boolean isRulesEngineEnabled;
+    private final RulesType rulesType;
+
+    @Inject
+    public RoutingRulesResourceHandler(RoutingRulesManager routingRulesManager, HaGatewayConfiguration configuration)
+    {
+        this.routingRulesManager = requireNonNull(routingRulesManager, "routingRulesManager is null");
+        RoutingRulesConfiguration routingRulesConfiguration = requireNonNull(configuration, "configuration is null").getRoutingRules();
+        this.isRulesEngineEnabled = routingRulesConfiguration.isRulesEngineEnabled();
+        this.rulesType = routingRulesConfiguration.getRulesType();
+    }
+
+    public Response getRoutingRules()
+            throws IOException
+    {
+        if (isRulesEngineEnabled && rulesType == RulesType.EXTERNAL) {
+            return Response.status(Response.Status.NO_CONTENT)
+                    .entity(Result.fail("Routing rules are managed by an external service")).build();
+        }
+        List<RoutingRule> routingRulesList = routingRulesManager.getRoutingRules();
+        return Response.ok(Result.ok(routingRulesList)).build();
+    }
+
+    public Response updateRoutingRules(RoutingRule routingRule)
+            throws IOException
+    {
+        List<RoutingRule> routingRulesList = routingRulesManager.updateRoutingRule(routingRule);
+        return Response.ok(Result.ok(routingRulesList)).build();
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingAPI.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingAPI.java
@@ -77,7 +77,7 @@ final class TestRoutingAPI
     {
         Request request =
                 new Request.Builder()
-                        .url("http://localhost:" + routerPort + "/webapp/getRoutingRules")
+                        .url("http://localhost:" + routerPort + "/gateway/routing-rules/all")
                         .get()
                         .build();
         Response response = httpClient.newCall(request).execute();
@@ -105,7 +105,7 @@ final class TestRoutingAPI
         RoutingRule updatedRoutingRules = new RoutingRule("airflow", "if query from airflow, route to adhoc group", 0, List.of("result.put(\"routingGroup\", \"adhoc\")"), "request.getHeader(\"X-Trino-Source\") == \"JDBC\"");
         RequestBody requestBody = RequestBody.create(OBJECT_MAPPER.writeValueAsString(updatedRoutingRules), MediaType.parse("application/json; charset=utf-8"));
         Request request = new Request.Builder()
-                        .url("http://localhost:" + routerPort + "/webapp/updateRoutingRules")
+                        .url("http://localhost:" + routerPort + "/gateway/routing-rules/modify/update")
                         .addHeader("Content-Type", "application/json")
                         .post(requestBody)
                         .build();
@@ -116,7 +116,7 @@ final class TestRoutingAPI
         //Fetch the routing rules to see if the update was successful
         Request request2 =
                 new Request.Builder()
-                        .url("http://localhost:" + routerPort + "/webapp/getRoutingRules")
+                        .url("http://localhost:" + routerPort + "/gateway/routing-rules/all")
                         .get()
                         .build();
         Response response2 = httpClient.newCall(request2).execute();
@@ -139,11 +139,24 @@ final class TestRoutingAPI
         RoutingRule revertRoutingRules = new RoutingRule("airflow", "if query from airflow, route to etl group", 0, List.of("result.put(\"routingGroup\", \"etl\")"), "request.getHeader(\"X-Trino-Source\") == \"airflow\"");
         RequestBody requestBody3 = RequestBody.create(OBJECT_MAPPER.writeValueAsString(revertRoutingRules), MediaType.parse("application/json; charset=utf-8"));
         Request request3 = new Request.Builder()
-                .url("http://localhost:" + routerPort + "/webapp/updateRoutingRules")
+                .url("http://localhost:" + routerPort + "/gateway/routing-rules/modify/update")
                 .addHeader("Content-Type", "application/json")
                 .post(requestBody3)
                 .build();
         httpClient.newCall(request3).execute();
+    }
+
+    @Test
+    void testWebappRoutingRulesCompatibilityAPI()
+            throws Exception
+    {
+        Request request =
+                new Request.Builder()
+                        .url("http://localhost:" + routerPort + "/webapp/getRoutingRules")
+                        .get()
+                        .build();
+        Response response = httpClient.newCall(request).execute();
+        assertThat(response.code()).isEqualTo(200);
     }
 
     @Test


### PR DESCRIPTION
## Description

Add API specific routing rules endpoints under the API-role `/gateway` surface:
* `GET /gateway/routing-rules/all`
* `POST /gateway/routing-rules/modify/update`

**Reason**: API clients use API-role credentials and routing-rules management should be available on the API-role endpoint surface (not only under `/webapp` which requires `ADMIN` privileges).

Keep existing /webapp routing-rules endpoints for compatibility (no webapp breakage):
* `GET /webapp/getRoutingRules`
* `POST /webapp/updateRoutingRules`

Share routing-rules logic via RoutingRulesResourceHandler so `/gateway` and `/webapp` use the same implementation.

Update docs/gateway-api.md with the new API-role endpoints and compatibility note.

## Additional context and related issues

* Named list endpoint as `/gateway/routing-rules/all` for consistency with `/gateway/backend/all`.
* Updated TestRoutingAPI to cover `/gateway endpoints` and `/webapp/getRoutingRules compatibility`.

Side note: in the future we could converge on one API surface and treat the web UI as another API client.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required, with the following suggested text:

* Add API-role routing rules endpoints at `/gateway/routing-rules/all` and `/gateway/routing-rules/modify/update`, while retaining existing `/webapp` routing rules endpoints for compatibility.
