### PR TITLE
Add config for USER query history visibility

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -226,6 +226,19 @@ The following pages are available:
 - `history`
 - `routing-rules`
 
+### Configure query history visibility for USER role
+
+You can set `allowNonAdminToViewAllQueryHistory` to control whether `USER` role
+can view query history across users.
+
+```yaml
+uiConfiguration:
+  allowNonAdminToViewAllQueryHistory: false
+```
+
+- `false` (default): non-admin users can only view their own query history.
+- `true`: non-admin users can view query history across all users.
+
 ## Configure behind a load balancer
 
 A possible deployment of Trino Gateway is to run multiple instances of Trino 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/UIConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/UIConfiguration.java
@@ -20,6 +20,7 @@ import java.util.List;
 public class UIConfiguration
 {
     private List<String> disablePages;
+    private boolean allowNonAdminToViewAllQueryHistory;
 
     @JsonProperty
     public List<String> getDisablePages()
@@ -30,5 +31,16 @@ public class UIConfiguration
     public void setDisablePages(List<String> disablePages)
     {
         this.disablePages = disablePages;
+    }
+
+    @JsonProperty
+    public boolean isAllowNonAdminToViewAllQueryHistory()
+    {
+        return allowNonAdminToViewAllQueryHistory;
+    }
+
+    public void setAllowNonAdminToViewAllQueryHistory(boolean allowNonAdminToViewAllQueryHistory)
+    {
+        this.allowNonAdminToViewAllQueryHistory = allowNonAdminToViewAllQueryHistory;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/QueryHistoryRequest.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/domain/request/QueryHistoryRequest.java
@@ -21,7 +21,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  * @param page page index
  * @param size page size
- * @param user Query histories of specified user. ADMIN role is optional, other roles are mandatory.
+ * @param user Query histories of specified user. ADMIN role is optional. USER role is optional only when
+ *         allowNonAdminToViewAllQueryHistory is enabled in uiConfiguration.
  * @param externalUrl Optional, you can query the history based on the externalUrl.
  * @param queryId Optional, you can query the query history based on the queryId of Trino.
  */

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
@@ -122,7 +122,8 @@ public class GatewayWebAppResource
     public Response findQueryHistory(QueryHistoryRequest query, @Context SecurityContext securityContext)
     {
         TableData<?> queryHistory;
-        if (!securityContext.isUserInRole("ADMIN")) {
+        boolean isAdmin = securityContext.isUserInRole("ADMIN");
+        if (!isAdmin && !uiConfiguration.isAllowNonAdminToViewAllQueryHistory()) {
             queryHistory = queryHistoryManager.findQueryHistory(new QueryHistoryRequest(
                     query.page(),
                     query.size(),

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/config/TestHaGatewayConfiguration.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/config/TestHaGatewayConfiguration.java
@@ -13,6 +13,8 @@
  */
 package io.trino.gateway.ha.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +26,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TestHaGatewayConfiguration
 {
+    private static final ObjectMapper YAML_OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
+
     @Test
     void testDefaultStatementPaths()
     {
@@ -56,5 +60,18 @@ class TestHaGatewayConfiguration
         assertThatThrownBy(() -> haGatewayConfiguration.setAdditionalStatementPaths(ImmutableList.of("/api/v2", "/api/v2/statement")))
                 .isInstanceOf(HaGatewayConfiguration.HaGatewayConfigurationException.class)
                 .hasMessage("Statement paths cannot be prefixes of other statement paths");
+    }
+
+    @Test
+    void testUIConfigurationAllowsViewingAllQueryHistoryWhenEnabled()
+            throws Exception
+    {
+        UIConfiguration uiConfiguration = YAML_OBJECT_MAPPER.readValue(
+                """
+                allowNonAdminToViewAllQueryHistory: true
+                """,
+                UIConfiguration.class);
+
+        assertThat(uiConfiguration.isAllowNonAdminToViewAllQueryHistory()).isTrue();
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/resource/TestGatewayWebAppResource.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/resource/TestGatewayWebAppResource.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.resource;
+
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.config.UIConfiguration;
+import io.trino.gateway.ha.domain.TableData;
+import io.trino.gateway.ha.domain.request.QueryHistoryRequest;
+import io.trino.gateway.ha.router.BackendStateManager;
+import io.trino.gateway.ha.router.GatewayBackendManager;
+import io.trino.gateway.ha.router.QueryHistoryManager;
+import io.trino.gateway.ha.router.RoutingRulesManager;
+import jakarta.ws.rs.core.SecurityContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+final class TestGatewayWebAppResource
+{
+    @ParameterizedTest
+    @CsvSource({
+            "false, false, alice",
+            "false, true, bob",
+            "true, false, bob",
+            "true, true, bob",
+    })
+    void testUserFilterForQueryHistory(boolean isAdmin, boolean allowNonAdminToViewAllQueryHistory, String expectedUser)
+    {
+        QueryHistoryManager queryHistoryManager = mock(QueryHistoryManager.class);
+        when(queryHistoryManager.findQueryHistory(any())).thenReturn(new TableData<>(List.of(), 0));
+
+        SecurityContext securityContext = createSecurityContext(isAdmin, "alice");
+        GatewayWebAppResource resource = createResource(allowNonAdminToViewAllQueryHistory, queryHistoryManager);
+        QueryHistoryRequest request = new QueryHistoryRequest(2, 20, "bob", "ext", "query-id", "source-a");
+
+        assertThat(resource.findQueryHistory(request, securityContext).getStatus()).isEqualTo(200);
+
+        QueryHistoryRequest queryRequest = captureFindQueryHistoryRequest(queryHistoryManager);
+        assertThat(queryRequest.page()).isEqualTo(2);
+        assertThat(queryRequest.size()).isEqualTo(20);
+        assertThat(queryRequest.user()).isEqualTo(expectedUser);
+        assertThat(queryRequest.externalUrl()).isEqualTo("ext");
+        assertThat(queryRequest.queryId()).isEqualTo("query-id");
+        assertThat(queryRequest.source()).isEqualTo("source-a");
+    }
+
+    private static QueryHistoryRequest captureFindQueryHistoryRequest(QueryHistoryManager queryHistoryManager)
+    {
+        ArgumentCaptor<QueryHistoryRequest> requestCaptor = ArgumentCaptor.forClass(QueryHistoryRequest.class);
+        verify(queryHistoryManager).findQueryHistory(requestCaptor.capture());
+        return requestCaptor.getValue();
+    }
+
+    private static GatewayWebAppResource createResource(boolean isAllowNonAdminToViewAllQueryHistory, QueryHistoryManager queryHistoryManager)
+    {
+        HaGatewayConfiguration configuration = new HaGatewayConfiguration();
+        UIConfiguration uiConfiguration = new UIConfiguration();
+        uiConfiguration.setAllowNonAdminToViewAllQueryHistory(isAllowNonAdminToViewAllQueryHistory);
+        configuration.setUiConfiguration(uiConfiguration);
+
+        return new GatewayWebAppResource(
+                mock(GatewayBackendManager.class),
+                queryHistoryManager,
+                mock(BackendStateManager.class),
+                mock(RoutingRulesManager.class),
+                configuration);
+    }
+
+    private static SecurityContext createSecurityContext(boolean isAdmin, String username)
+    {
+        SecurityContext securityContext = mock(SecurityContext.class);
+        when(securityContext.isUserInRole("ADMIN")).thenReturn(isAdmin);
+        Principal principal = () -> username;
+        when(securityContext.getUserPrincipal()).thenReturn(principal);
+        return securityContext;
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingAPI.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingAPI.java
@@ -166,5 +166,6 @@ final class TestRoutingAPI
 
         assertThat(response.code()).isEqualTo(200);
         assertThat(uiConfiguration.getDisablePages()).containsExactly("routing-rules");
+        assertThat(uiConfiguration.isAllowNonAdminToViewAllQueryHistory()).isFalse();
     }
 }

--- a/webapp/src/components/history.tsx
+++ b/webapp/src/components/history.tsx
@@ -7,13 +7,14 @@ import { queryHistoryApi } from "../api/webapp/history";
 import { HistoryData, HistoryDetail } from "../types/history";
 import { formatTimestamp } from "../utils/time";
 import { backendsApi } from "../api/webapp/cluster";
-import { Role, useAccessStore } from "../store";
+import { Role, useAccessStore, useUIConfigurationStore } from "../store";
 import { BackendData } from "../types/cluster";
 import { TimezoneContext } from "./TimezoneContext";
 
 export function History() {
   const { Text } = Typography;
   const access = useAccessStore();
+  const allowNonAdminToViewAllQueryHistory = useUIConfigurationStore((state) => state.allowNonAdminToViewAllQueryHistory);
   const timezone = useContext(TimezoneContext).timezone;
   const [backendData, setBackendData] = useState<BackendData[]>();
   const [historyData, setHistoryData] = useState<HistoryData>();
@@ -116,7 +117,7 @@ export function History() {
                   </Form.Select.Option>
                 ))}
               </Form.Select>
-              <Form.Input field='user' label='User' initValue={form.user} disabled={!access.hasRole(Role.ADMIN)} style={{ width: 150 }} showClear />
+              <Form.Input field='user' label='User' initValue={form.user} disabled={!access.hasRole(Role.ADMIN) && !allowNonAdminToViewAllQueryHistory} style={{ width: 150 }} showClear />
               <Form.Input field='queryId' label='QueryId' style={{ width: 260 }} showClear placeholder={Locale.History.QueryIdTip} />
               <Form.Input field='source' label='Source' style={{ width:150 }} showClear />
               <Button htmlType='submit' style={{ width: 70 }}>{Locale.UI.Query}</Button>

--- a/webapp/src/components/layout.tsx
+++ b/webapp/src/components/layout.tsx
@@ -4,7 +4,7 @@ import styles from './layout.module.scss';
 import { useEffect, useState } from 'react';
 import { Link, useLocation } from "react-router-dom";
 import { hasPagePermission, routers, routersMapper } from '../router';
-import { Theme, useAccessStore, useConfigStore } from '../store';
+import { Theme, useAccessStore, useConfigStore, useUIConfigurationStore } from '../store';
 import { getUIConfiguration, logoutApi } from '../api/webapp/login';
 import Locale from "../locales";
 import { TimezoneDropdown } from "./TimezoneContext";
@@ -14,23 +14,23 @@ export const RootLayout = (props: {
 }) => {
   const access = useAccessStore();
   const config = useConfigStore();
+  const updateUIConfiguration = useUIConfigurationStore((state) => state.update);
+  const disabledPages = useUIConfigurationStore((state) => state.disabledPages);
   const location = useLocation();
   const { Header, Sider, Content } = Layout;
   const [collapsed, setCollapsed] = useState(false);
   const [selectedKey, setSelectedKey] = useState(location.pathname.substring(location.pathname.lastIndexOf('/') + 1));
   const [userProfile, setUserProfile] = useState(false);
-  const [disabledPages, setDisabledPages] = useState<string[]>(['']);
   const [filteredRouters, setFilteredRouters] = useState(routers);
 
   useEffect(() => {
       getUIConfiguration().then((res) => {
-          if (Object.keys(res).length == 0) {
-              setDisabledPages(res)
-          } else {
-              setDisabledPages(res.disablePages)
-          }
+          updateUIConfiguration({
+            disabledPages: Array.isArray(res?.disablePages) ? res.disablePages : [],
+            allowNonAdminToViewAllQueryHistory: !!res?.allowNonAdminToViewAllQueryHistory,
+          });
       })
-  }, []);
+  }, [updateUIConfiguration]);
 
     useEffect(() => {
         const routerFilters = disabledPages.length > 0 ?

--- a/webapp/src/store/index.ts
+++ b/webapp/src/store/index.ts
@@ -1,2 +1,3 @@
 export * from "./access";
 export * from "./config";
+export * from "./uiConfiguration";

--- a/webapp/src/store/uiConfiguration.ts
+++ b/webapp/src/store/uiConfiguration.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+
+export const DEFAULT_UI_CONFIGURATION = {
+  disabledPages: [] as string[],
+  allowNonAdminToViewAllQueryHistory: false,
+};
+
+export type UIConfiguration = typeof DEFAULT_UI_CONFIGURATION;
+
+export type UIConfigurationState = UIConfiguration & {
+  update: (patch: Partial<UIConfiguration>) => void;
+  reset: () => void;
+};
+
+export const useUIConfigurationStore = create<UIConfigurationState>()((set) => ({
+  ...DEFAULT_UI_CONFIGURATION,
+
+  update(patch) {
+    set((state) => ({ ...state, ...patch }));
+  },
+
+  reset() {
+    set(() => ({
+      ...DEFAULT_UI_CONFIGURATION,
+    }));
+  },
+}));


### PR DESCRIPTION
## Description

Add a new optional config under `uiConfiguration`:
* `allowUserRoleToViewAllQueryHistory` (default: false)

Behavior:
* `false`: keep existing behavior, `USER` role can only see own query history.
* `true`: allow `USER` role to view query history across users.

`ADMIN` role behavior is unchanged.

**Motivation**: some deployments need non-admin operators/support users to have full query visibility without granting full admin access.

## Additional context and related issues

Changes included:
* backend config + query history authorization logic update
* webapp history filter behavior aligned with the config
* safer UI config handling when disablePages is missing
* docs update for the new setting
* tests covering behavior and config exposure

# Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required, with the following suggested text:

```markdown
* Add `uiConfiguration.allowUserRoleToViewAllQueryHistory` to optionally allow `USER` role to view query history across all users
```
