### PR TITLE
Fix dashboard line chart field name mismatch with API response

### DIFF
--- a/webapp/src/components/dashboard.tsx
+++ b/webapp/src/components/dashboard.tsx
@@ -162,7 +162,7 @@ function LineChart(props: {
       ])
     );
 
-    const timestamps = Object.values(displayData).flat().map(d => Number(d.timestamp));
+    const timestamps = Object.values(displayData).flat().map(d => d.epochMillis);
     let minTimestamp = Math.min(...timestamps);
     let maxTimestamp = Math.max(...timestamps);
     const xAxisTimeLabels: number[] = [];
@@ -196,7 +196,7 @@ function LineChart(props: {
         const data = displayData[d];
         const count = new Map<number, number>();
         for (const dataPoint of data) {
-          const xValueHHMM = Math.floor(Number(dataPoint.timestamp) / MINUTE) * MINUTE;
+          const xValueHHMM = Math.floor(dataPoint.epochMillis / MINUTE) * MINUTE;
           count.set(xValueHHMM, dataPoint.queryCount);
         }
         return {

--- a/webapp/src/types/dashboard.d.ts
+++ b/webapp/src/types/dashboard.d.ts
@@ -19,7 +19,7 @@ export interface  DistributionChartData {
 }
 
 export interface  LineChartData {
-  timestamp: number;
+  epochMillis: number;
   backendUrl: string;
   queryCount: number;
   name: string;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Because of mismatched field name in dashboard api response the query distribution graph doens't rendered. (related with https://github.com/trinodb/trino-gateway/pull/805)

<img width="1278" height="843" alt="스크린샷 2026-02-26 오후 1 16 15" src="https://github.com/user-attachments/assets/b8cbe0ae-7076-4707-bd1e-3f7a05aeee88" />

<img width="1268" height="843" alt="스크린샷 2026-02-26 오후 1 16 20" src="https://github.com/user-attachments/assets/f2e5bf33-b42e-4880-a41b-b617ca7bfc1b" />

The getDistribution api call reponse has `data.lineChart[].epochMillis` filed but the frontend application expect `timestamp` to use it as x axis data. 

After change frontend application's timestamp filed into `epochMillis` and the graph working properly.

<img width="1268" height="843" alt="스크린샷 2026-02-26 오후 1 17 28" src="https://github.com/user-attachments/assets/c87e998f-a8c9-4c3e-8bd6-bd15ea888f59" />


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
