### PR TITLE
Add tags support to gateway backends

### DIFF
--- a/docs/backend-tags.md
+++ b/docs/backend-tags.md
@@ -1,0 +1,103 @@
+# Backend tags
+
+Backend tags allow you to attach arbitrary metadata to a gateway backend. Today,
+the only mechanism for influencing routing decisions is the `routingGroup` field,
+which maps a query to a named cluster group. There is no way to store additional
+metadata on a backend that routing logic could inspect. Tags provide that
+foundation — a freeform list of strings on each backend that can be read by
+custom routing rules, scripts, or future gateway enhancements to enable more
+sophisticated routing behavior.
+
+Tags are stored as a list of strings on the backend and are returned in all
+backend API responses. A tag can be any nonblank string that does not contain a
+`,` character. Surrounding whitespace is trimmed, blank tags are ignored, and
+duplicate tags are removed. A common convention is `key:value` pairs, for
+example `env:prod` or `team:data-eng`.
+
+## Setting tags
+
+Tags can be set when creating or updating a backend via the
+[Gateway API](gateway-api.md):
+
+```shell
+curl -X POST http://localhost:8080/gateway/backend/modify/add \
+ -H "Content-Type: application/json" \
+ -d '{  "name": "trino-3",
+        "proxyTo": "http://localhost:8083",
+        "active": true,
+        "routingGroup": "adhoc",
+        "tags": ["env:prod", "team:data-eng", "size:XL"]
+    }'
+```
+
+!!! note "Commas are not allowed in tag values"
+    A tag value cannot contain a `,` character — the gateway will reject the
+    request with an `IllegalArgumentException`. If you need to express
+    multiple values for the same key, split them into separate tags rather
+    than combining them with a comma. For example, instead of
+    `"ver:440,476"`, use two tags: `"ver:440"` and `"ver:476"`.
+
+Tags are included in all backend list responses:
+
+```json
+[
+    {
+        "name": "trino-1",
+        "proxyTo": "http://localhost:8081",
+        "active": true,
+        "routingGroup": "adhoc",
+        "externalUrl": "http://localhost:8081",
+        "tags": ["env:prod", "size:S"]
+    },
+    {
+        "name": "trino-2",
+        "proxyTo": "http://localhost:8082",
+        "active": true,
+        "routingGroup": "adhoc",
+        "externalUrl": "http://localhost:8082",
+        "tags": ["env:test", "size:XL"]
+    }
+]
+```
+
+## Use cases
+
+Tags are a building block. The following examples illustrate the kinds of
+features that can be built on top of them. **These capabilities do not exist
+today** — they are examples of what custom routing rules or future gateway
+enhancements could implement using tags as the metadata source.
+
+### Sophisticated routing
+
+- **Environment routing** — Tag backends with `env:prod` or `env:test` and route
+  queries to the appropriate environment based on the query source or user.
+- **Team-based routing** — Tag backends with `team:bi-tools` or `team:data-eng`
+  and steer each team's queries to their dedicated cluster.
+- **Size-based routing** — Tag backends with `size:S`, `size:M`, or `size:XL`
+  and route large, resource-heavy queries to large clusters. Large queries can
+  hog resources for a long time, so routing them to appropriately sized clusters
+  reduces wait times for other queries.
+
+### Cluster upgrades and canary deployments
+
+- **Version tags** — Tag backends with `ver:476` to identify which Trino version
+  a cluster is running. Routing rules can inspect this tag to make
+  version-aware decisions, for example:
+    - *Session property compatibility* — drop or rewrite session properties
+      that have been deprecated or renamed before forwarding a query to an
+      older or newer cluster, so clients written against one version can still
+      run against another.
+    - *Pinning queries to a known-good version* — temporarily route all
+      traffic from a specific user, source, or query shape to a cluster
+      tagged with a particular version while investigating a regression
+      introduced in a newer release.
+- **Canary deployments** — Tag a backend with `route_percent:10` to signal that
+  only 10% of traffic should be sent to that cluster, enabling gradual rollouts
+  before promoting a new version to full traffic.
+
+### Operational metadata
+
+- **Region awareness** — Tag backends with the region they are deployed in (e.g.
+  `region:us-east-1`) to support geo-aware routing or failover logic.
+- **Ownership** — Tag backends with the owning team (e.g. `owner:platform-eng`)
+  to make it easier to identify cluster ownership in dashboards or alerting.

--- a/docs/gateway-api.md
+++ b/docs/gateway-api.md
@@ -18,7 +18,8 @@ curl -X POST http://localhost:8080/gateway/backend/modify/add \
  -d '{  "name": "trino-3",
         "proxyTo": "http://localhost:8083",
         "active": true,
-        "routingGroup": "adhoc"
+        "routingGroup": "adhoc",
+        "tags": ["env:prod"]
     }'
 ```
 
@@ -33,7 +34,8 @@ curl -X POST http://localhost:8080/gateway/backend/modify/add \
         "proxyTo": "http://localhost:8083",
         "active": true,
         "routingGroup": "adhoc",
-        "externalUrl": "http://localhost:8084"
+        "externalUrl": "http://localhost:8084",
+        "tags": ["env:prod"]
     }'
 ```
 
@@ -46,7 +48,8 @@ curl -X POST http://localhost:8080/gateway/backend/modify/update \
         "proxyTo": "http://localhost:8083",
         "active": true,
         "routingGroup": "adhoc",
-        "externalUrl": "http://localhost:8084"
+        "externalUrl": "http://localhost:8084",
+        "tags": ["env:prod"]
     }'
 ```
 
@@ -65,21 +68,24 @@ Returns a JSON array of Trino cluster:
         "proxyTo": "http://localhost:8081",
         "active": true,
         "routingGroup": "adhoc",
-        "externalUrl": "http://localhost:8081"
+        "externalUrl": "http://localhost:8081",
+        "tags": ["env:prod"]
     },
     {
         "name": "trino-2",
         "proxyTo": "http://localhost:8082",
         "active": true,
         "routingGroup": "adhoc",
-        "externalUrl": "http://localhost:8082"
+        "externalUrl": "http://localhost:8082",
+        "tags": ["env:test", "size:XL"]
     },
     {
         "name": "trino-3",
         "proxyTo": "http://localhost:8083",
         "active": true,
         "routingGroup": "adhoc",
-        "externalUrl": "http://localhost:8084"
+        "externalUrl": "http://localhost:8084",
+        "tags": []
     }
 ]
 ```
@@ -111,7 +117,8 @@ Returns a JSON array of active Trino clusters:
         "proxyTo": "http://localhost:8081",
         "active": true,
         "routingGroup": "adhoc",
-        "externalUrl": "http://localhost:8081"
+        "externalUrl": "http://localhost:8081",
+        "tags": ["env:prod"]
     }
 ]
 ```

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/ProxyBackendConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/ProxyBackendConfiguration.java
@@ -15,6 +15,12 @@ package io.trino.gateway.ha.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNullElse;
 
 public class ProxyBackendConfiguration
 {
@@ -23,6 +29,7 @@ public class ProxyBackendConfiguration
     private String externalUrl;
     private String name;
     private String proxyTo;
+    private List<String> tags = ImmutableList.of();
 
     @JsonProperty
     public String getName()
@@ -85,5 +92,21 @@ public class ProxyBackendConfiguration
     public void setRoutingGroup(String routingGroup)
     {
         this.routingGroup = routingGroup;
+    }
+
+    @JsonProperty
+    public List<String> getTags()
+    {
+        return tags;
+    }
+
+    @JsonSetter
+    public void setTags(List<String> tags)
+    {
+        this.tags = requireNonNullElse(tags, ImmutableList.<String>of()).stream()
+                .filter(tag -> tag != null && !tag.isBlank())
+                .map(String::trim)
+                .distinct()
+                .collect(toImmutableList());
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/GatewayBackend.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/GatewayBackend.java
@@ -13,6 +13,7 @@
  */
 package io.trino.gateway.ha.persistence.dao;
 
+import jakarta.annotation.Nullable;
 import org.jdbi.v3.core.mapper.reflect.ColumnName;
 
 import static java.util.Objects.requireNonNull;
@@ -22,7 +23,8 @@ public record GatewayBackend(
         @ColumnName("routing_group") String routingGroup,
         @ColumnName("backend_url") String backendUrl,
         @ColumnName("external_url") String externalUrl,
-        @ColumnName("active") boolean active)
+        @ColumnName("active") boolean active,
+        @ColumnName("tags") @Nullable String tags)
 {
     public GatewayBackend
     {

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/GatewayBackendDao.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/GatewayBackendDao.java
@@ -33,18 +33,18 @@ public interface GatewayBackendDao
 
     @SqlUpdate(
             """
-            INSERT INTO gateway_backend (name, routing_group, backend_url, external_url, active)
-            VALUES (:name, :routingGroup, :backendUrl, :externalUrl, :active)
+            INSERT INTO gateway_backend (name, routing_group, backend_url, external_url, active, tags)
+            VALUES (:name, :routingGroup, :backendUrl, :externalUrl, :active, :tags)
             """)
-    void create(String name, String routingGroup, String backendUrl, String externalUrl, boolean active);
+    void create(String name, String routingGroup, String backendUrl, String externalUrl, boolean active, String tags);
 
     @SqlUpdate(
             """
             UPDATE gateway_backend
-            SET routing_group = :routingGroup, backend_url = :backendUrl, external_url = :externalUrl, active = :active
+            SET routing_group = :routingGroup, backend_url = :backendUrl, external_url = :externalUrl, active = :active, tags = :tags
             WHERE name = :name
             """)
-    void update(String name, String routingGroup, String backendUrl, String externalUrl, boolean active);
+    void update(String name, String routingGroup, String backendUrl, String externalUrl, boolean active, String tags);
 
     @SqlUpdate(
             """

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayWebAppResource.java
@@ -108,6 +108,7 @@ public class GatewayWebAppResource
             backendResponse.setStatus(backendState.trinoStatus().toString());
             backendResponse.setRoutingGroup(b.getRoutingGroup());
             backendResponse.setExternalUrl(b.getExternalUrl());
+            backendResponse.setTags(b.getTags());
             return backendResponse;
         }).toList();
         return Response.ok(Result.ok(data)).build();

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaGatewayManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaGatewayManager.java
@@ -17,6 +17,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.Ticker;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
@@ -34,6 +35,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
@@ -200,7 +202,7 @@ public class HaGatewayManager
         validateBackendConfiguration(backend);
         String backendProxyTo = removeTrailingSlash(backend.getProxyTo());
         String backendExternalUrl = removeTrailingSlash(backend.getExternalUrl());
-        dao.create(backend.getName(), backend.getRoutingGroup(), backendProxyTo, backendExternalUrl, backend.isActive());
+        dao.create(backend.getName(), backend.getRoutingGroup(), backendProxyTo, backendExternalUrl, backend.isActive(), tagsToString(backend.getTags()));
         invalidateBackendCache();
         return backend;
     }
@@ -213,10 +215,10 @@ public class HaGatewayManager
         String backendExternalUrl = removeTrailingSlash(backend.getExternalUrl());
         GatewayBackend model = dao.findFirstByName(backend.getName());
         if (model == null) {
-            dao.create(backend.getName(), backend.getRoutingGroup(), backendProxyTo, backendExternalUrl, backend.isActive());
+            dao.create(backend.getName(), backend.getRoutingGroup(), backendProxyTo, backendExternalUrl, backend.isActive(), tagsToString(backend.getTags()));
         }
         else {
-            dao.update(backend.getName(), backend.getRoutingGroup(), backendProxyTo, backendExternalUrl, backend.isActive());
+            dao.update(backend.getName(), backend.getRoutingGroup(), backendProxyTo, backendExternalUrl, backend.isActive(), tagsToString(backend.getTags()));
             logActivationStatusChange(backend.getName(), backend.isActive(), model.active());
         }
         invalidateBackendCache();
@@ -229,6 +231,10 @@ public class HaGatewayManager
         checkArgument(backend.getProxyTo() != null, "Backend proxyTo URL cannot be null");
         checkArgument(backend.getRoutingGroup() != null, "Backend routing group cannot be null");
         checkArgument(backend.getExternalUrl() != null, "Backend external url cannot be null");
+        for (String tag : backend.getTags()) {
+            checkArgument(tag != null && !tag.isBlank(), "Backend tag cannot be null or blank");
+            checkArgument(!tag.contains(","), "Backend tag cannot contain ',' character: %s", tag);
+        }
     }
 
     public void deleteBackend(String name)
@@ -247,9 +253,28 @@ public class HaGatewayManager
             backendConfig.setProxyTo(model.backendUrl());
             backendConfig.setExternalUrl(model.externalUrl());
             backendConfig.setName(model.name());
+            backendConfig.setTags(tagsFromString(model.tags()));
             proxyBackendConfigurations.add(backendConfig);
         }
         return proxyBackendConfigurations;
+    }
+
+    @VisibleForTesting
+    static String tagsToString(List<String> tags)
+    {
+        if (tags == null || tags.isEmpty()) {
+            return null;
+        }
+        return String.join(",", tags);
+    }
+
+    @VisibleForTesting
+    static List<String> tagsFromString(String tags)
+    {
+        if (isNullOrEmpty(tags)) {
+            return List.of();
+        }
+        return Splitter.on(',').trimResults().omitEmptyStrings().splitToList(tags);
     }
 
     public static String removeTrailingSlash(String url)

--- a/gateway-ha/src/main/resources/gateway-ha-persistence-mysql.sql
+++ b/gateway-ha/src/main/resources/gateway-ha-persistence-mysql.sql
@@ -3,7 +3,8 @@ name VARCHAR(256) PRIMARY KEY,
 routing_group VARCHAR (256),
 backend_url VARCHAR (256),
 external_url VARCHAR (256),
-active BOOLEAN
+active BOOLEAN,
+tags TEXT
 );
 
 CREATE TABLE IF NOT EXISTS query_history (

--- a/gateway-ha/src/main/resources/gateway-ha-persistence-postgres.sql
+++ b/gateway-ha/src/main/resources/gateway-ha-persistence-postgres.sql
@@ -3,7 +3,8 @@ name VARCHAR(256) PRIMARY KEY,
 routing_group VARCHAR (256),
 backend_url VARCHAR (256),
 external_url VARCHAR (256),
-active BOOLEAN
+active BOOLEAN,
+tags TEXT
 );
 
 CREATE TABLE IF NOT EXISTS query_history (

--- a/gateway-ha/src/main/resources/mysql/V5__add_tags_to_gateway_backend.sql
+++ b/gateway-ha/src/main/resources/mysql/V5__add_tags_to_gateway_backend.sql
@@ -1,0 +1,2 @@
+ALTER TABLE gateway_backend
+ADD COLUMN tags TEXT NULL;

--- a/gateway-ha/src/main/resources/oracle/V5__add_tags_to_gateway_backend.sql
+++ b/gateway-ha/src/main/resources/oracle/V5__add_tags_to_gateway_backend.sql
@@ -1,0 +1,1 @@
+ALTER TABLE gateway_backend ADD (tags CLOB NULL);

--- a/gateway-ha/src/main/resources/postgresql/V5__add_tags_to_gateway_backend.sql
+++ b/gateway-ha/src/main/resources/postgresql/V5__add_tags_to_gateway_backend.sql
@@ -1,0 +1,2 @@
+ALTER TABLE gateway_backend
+ADD COLUMN tags TEXT NULL;

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestHaGatewayManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestHaGatewayManager.java
@@ -24,12 +24,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.gateway.ha.TestingJdbcConnectionManager.createTestingJdbcConnectionManager;
 import static io.trino.gateway.ha.TestingJdbcConnectionManager.dataStoreConfig;
 import static io.trino.gateway.ha.TestingJdbcConnectionManager.destroyTestingDatabase;
+import static io.trino.gateway.ha.router.HaGatewayManager.tagsFromString;
+import static io.trino.gateway.ha.router.HaGatewayManager.tagsToString;
+import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -151,6 +155,169 @@ final class TestHaGatewayManager
     }
 
     @Test
+    void testAddBackendWithTags()
+    {
+        JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager(dataStoreConfig());
+        HaGatewayManager haGatewayManager = new HaGatewayManager(connectionManager.getJdbi(), new RoutingConfiguration(), new DatabaseCacheConfiguration());
+
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("tagged-backend");
+        backend.setRoutingGroup("adhoc");
+        backend.setProxyTo("tagged.trino.gateway.io");
+        backend.setExternalUrl("tagged.trino.gateway.io");
+        backend.setActive(true);
+        backend.setTags(List.of("prod", "us-east-1"));
+
+        haGatewayManager.addBackend(backend);
+
+        ProxyBackendConfiguration retrieved = haGatewayManager.getBackendByName("tagged-backend").orElseThrow();
+        assertThat(retrieved.getTags()).containsExactly("prod", "us-east-1");
+    }
+
+    @Test
+    void testAddBackendWithoutTagsReturnsEmptyList()
+    {
+        JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager(dataStoreConfig());
+        HaGatewayManager haGatewayManager = new HaGatewayManager(connectionManager.getJdbi(), new RoutingConfiguration(), new DatabaseCacheConfiguration());
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("untagged-backend");
+        backend.setRoutingGroup("adhoc");
+        backend.setProxyTo("untagged.trino.gateway.io");
+        backend.setExternalUrl("untagged.trino.gateway.io");
+        backend.setActive(true);
+        // tags not set — defaults to empty list
+
+        haGatewayManager.addBackend(backend);
+
+        ProxyBackendConfiguration retrieved = haGatewayManager.getBackendByName("untagged-backend").orElseThrow();
+        assertThat(retrieved.getTags()).isEmpty();
+    }
+
+    @Test
+    void testUpdateBackendTags()
+    {
+        JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager(dataStoreConfig());
+        HaGatewayManager haGatewayManager = new HaGatewayManager(connectionManager.getJdbi(), new RoutingConfiguration(), new DatabaseCacheConfiguration());
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("update-tags-backend");
+        backend.setRoutingGroup("adhoc");
+        backend.setProxyTo("update-tags.trino.gateway.io");
+        backend.setExternalUrl("update-tags.trino.gateway.io");
+        backend.setActive(true);
+        backend.setTags(List.of("dev"));
+        haGatewayManager.addBackend(backend);
+
+        backend.setTags(List.of("prod", "critical"));
+        haGatewayManager.updateBackend(backend);
+
+        ProxyBackendConfiguration retrieved = haGatewayManager.getBackendByName("update-tags-backend").orElseThrow();
+        assertThat(retrieved.getTags()).containsExactly("prod", "critical");
+    }
+
+    @Test
+    void testClearBackendTags()
+    {
+        JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager(dataStoreConfig());
+        HaGatewayManager haGatewayManager = new HaGatewayManager(connectionManager.getJdbi(), new RoutingConfiguration(), new DatabaseCacheConfiguration());
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("clear-tags-backend");
+        backend.setRoutingGroup("adhoc");
+        backend.setProxyTo("clear-tags.trino.gateway.io");
+        backend.setExternalUrl("clear-tags.trino.gateway.io");
+        backend.setActive(true);
+        backend.setTags(List.of("to-be-removed"));
+        haGatewayManager.addBackend(backend);
+
+        backend.setTags(List.of());
+        haGatewayManager.updateBackend(backend);
+
+        ProxyBackendConfiguration retrieved = haGatewayManager.getBackendByName("clear-tags-backend").orElseThrow();
+        assertThat(retrieved.getTags()).isEmpty();
+    }
+
+    @Test
+    void testTagsAreIncludedInGetAllBackends()
+    {
+        JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager(dataStoreConfig());
+        HaGatewayManager haGatewayManager = new HaGatewayManager(connectionManager.getJdbi(), new RoutingConfiguration(), new DatabaseCacheConfiguration());
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("all-backends-tags-backend");
+        backend.setRoutingGroup("adhoc");
+        backend.setProxyTo("all-backends-tags.trino.gateway.io");
+        backend.setExternalUrl("all-backends-tags.trino.gateway.io");
+        backend.setActive(true);
+        backend.setTags(List.of("env:prod", "region:us-west-2"));
+        haGatewayManager.addBackend(backend);
+
+        List<ProxyBackendConfiguration> allBackends = haGatewayManager.getAllBackends();
+        ProxyBackendConfiguration match = allBackends.stream()
+                .filter(b -> b.getName().equals("all-backends-tags-backend"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(match.getTags()).containsExactly("env:prod", "region:us-west-2");
+    }
+
+    @Test
+    void testAddBackendRejectsTagWithComma()
+    {
+        JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager(dataStoreConfig());
+        HaGatewayManager haGatewayManager = new HaGatewayManager(connectionManager.getJdbi(), new RoutingConfiguration(), new DatabaseCacheConfiguration());
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("comma-tag-backend");
+        backend.setRoutingGroup("adhoc");
+        backend.setProxyTo("comma-tag.trino.gateway.io");
+        backend.setExternalUrl("comma-tag.trino.gateway.io");
+        backend.setActive(true);
+        backend.setTags(List.of("version - 480,475"));
+
+        assertThatThrownBy(() -> haGatewayManager.addBackend(backend))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Backend tag cannot contain ',' character")
+                .hasMessageContaining("version - 480,475");
+    }
+
+    @Test
+    void testAddBackendNormalizesTags()
+    {
+        JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager(dataStoreConfig());
+        HaGatewayManager haGatewayManager = new HaGatewayManager(connectionManager.getJdbi(), new RoutingConfiguration(), new DatabaseCacheConfiguration());
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("normalized-tag-backend");
+        backend.setRoutingGroup("adhoc");
+        backend.setProxyTo("normalized-tag.trino.gateway.io");
+        backend.setExternalUrl("normalized-tag.trino.gateway.io");
+        backend.setActive(true);
+        // null and blank tags are dropped, surrounding whitespace is trimmed and duplicates are removed
+        backend.setTags(asList("env:prod", null, "   ", " env:prod ", "size:XL"));
+        assertThat(backend.getTags()).containsExactly("env:prod", "size:XL");
+
+        haGatewayManager.addBackend(backend);
+
+        ProxyBackendConfiguration retrieved = haGatewayManager.getBackendByName("normalized-tag-backend").orElseThrow();
+        assertThat(retrieved.getTags()).containsExactly("env:prod", "size:XL");
+    }
+
+    @Test
+    void testUpdateBackendRejectsTagWithComma()
+    {
+        JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager(dataStoreConfig());
+        HaGatewayManager haGatewayManager = new HaGatewayManager(connectionManager.getJdbi(), new RoutingConfiguration(), new DatabaseCacheConfiguration());
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("update-comma-tag-backend");
+        backend.setRoutingGroup("adhoc");
+        backend.setProxyTo("update-comma-tag.trino.gateway.io");
+        backend.setExternalUrl("update-comma-tag.trino.gateway.io");
+        backend.setActive(true);
+        backend.setTags(List.of("env:prod"));
+        haGatewayManager.addBackend(backend);
+
+        backend.setTags(List.of("a,b"));
+        assertThatThrownBy(() -> haGatewayManager.updateBackend(backend))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Backend tag cannot contain ',' character");
+    }
+
+    @Test
     void testRemoveTrailingSlashInUrl()
     {
         JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager(dataStoreConfig());
@@ -177,6 +344,34 @@ final class TestHaGatewayManager
 
         assertThat(haGatewayManager.getBackendByName("new-etl1").map(ProxyBackendConfiguration::getProxyTo)).hasValue("https://etl2.trino.gateway.io:443");
         assertThat(haGatewayManager.getBackendByName("new-etl1").map(ProxyBackendConfiguration::getExternalUrl)).hasValue("https://etl2.trino.gateway.io:443");
+    }
+
+    @Test
+    void testTagsToString()
+    {
+        assertThat(tagsToString(null)).isNull();
+        assertThat(tagsToString(List.of())).isNull();
+        assertThat(tagsToString(List.of("prod"))).isEqualTo("prod");
+        assertThat(tagsToString(List.of("prod", "us-east-1", "critical")))
+                .isEqualTo("prod,us-east-1,critical");
+    }
+
+    @Test
+    void testTagsFromString()
+    {
+        assertThat(tagsFromString(null)).isEmpty();
+        assertThat(tagsFromString("")).isEmpty();
+        assertThat(tagsFromString("   ")).isEmpty();
+        assertThat(tagsFromString("prod")).containsExactly("prod");
+        assertThat(tagsFromString("prod,us-east-1,critical"))
+                .containsExactly("prod", "us-east-1", "critical");
+        assertThat(tagsFromString("prod , us-east-1 , critical"))
+                .containsExactly("prod", "us-east-1", "critical");
+        assertThat(tagsFromString(",prod,,us-east-1,"))
+                .containsExactly("prod", "us-east-1");
+
+        List<String> original = List.of("prod", "us-east-1", "critical");
+        assertThat(tagsFromString(tagsToString(original))).isEqualTo(original);
     }
 
     private static class TestingTicker

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - Routing rules: routing-rules.md
       - Routing logic: routing-logic.md
       - Gateway API: gateway-api.md
+      - Backend tags: backend-tags.md
       - Code architecture: design.md
       - Migration to Airlift: migration-to-airlift.md
   - Contribute:

--- a/webapp/src/components/cluster.tsx
+++ b/webapp/src/components/cluster.tsx
@@ -65,6 +65,17 @@ export function Cluster() {
     );
   }
 
+  const tagsRender = (tags: string[]) => {
+    if (!tags || tags.length === 0) return null;
+    return (
+      <>
+        {tags.map((tag, index) => (
+          <Tag key={`${index}-${tag}`} style={{ marginRight: 4, marginBottom: 2 }}>{tag}</Tag>
+        ))}
+      </>
+    );
+  }
+
   const statusRender = (text: string) => {
       let statusColor: TagColor;
       switch (text) {
@@ -116,6 +127,7 @@ export function Cluster() {
             }} />
           <Column title="ProxyToUrl" dataIndex="proxyTo" key="proxyTo" render={linkRender} />
           <Column title="ExternalUrl" dataIndex="externalUrl" key="externalUrl" render={linkRender} />
+          <Column title="Tags" dataIndex="tags" key="tags" render={tagsRender} />
           <Column title="Queued" dataIndex="queued" key="queued" sorter={(a, b) => (!a || !b) ? 0 : a.queued - b.queued} />
           <Column title="Running" dataIndex="running" key="running" sorter={(a, b) => (!a || !b) ? 0 : a.running - b.running} />
           <Column title="Active" dataIndex="active" key="active" render={switchRender} />
@@ -206,6 +218,13 @@ export function Cluster() {
               { type: 'string', message: 'type error' },
             ]}
             initValue={form?.externalUrl}
+          />
+          <Form.TagInput
+            field="tags"
+            label="Tags"
+            initValue={form?.tags}
+            separator={[',']}
+            placeholder="Type a tag and press Enter"
           />
           <Form.Switch label="Active" field='active' initValue={form?.active || false} />
         </Form>

--- a/webapp/src/types/cluster.d.ts
+++ b/webapp/src/types/cluster.d.ts
@@ -7,4 +7,5 @@ export interface BackendData {
   queued: number;
   running: number;
   status: string;
+  tags: string[];
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
The backend stored in Gateway today has only limited fields (external url, proxy-to, name, active/not-active).
But to make some sophisticated routing decision, having tags on them would help. 
For instance the version of the cluster, environment (prod/test), team name etc.
This PR does the following -

- Flyway V5 migrations for PostgreSQL, MySQL, and Oracle
- GatewayBackend DAO record and GatewayBackendDao updated to include
  tags in INSERT/UPDATE queries
- ProxyBackendConfiguration exposes tags as List<String>
- HaGatewayManager converts between comma-separated DB storage and
  List<String>, with tagsToString/tagsFromString helpers
- GatewayWebAppResource propagates tags in getAllBackends response
- UI: Tags column in the backends table rendered as tag chips;
  TagInput in the create/edit modal with space-or-enter to add tags
  and × to remove them; editTagsRef ensures tags survive any
  Form.TagInput closure/submission quirks
- Unit tests for tagsToString/tagsFromString edge cases and
  integration tests covering create, update, clear, and list


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Tags in UI - 
<img width="1380" height="249" alt="Screenshot 2026-03-02 at 3 44 46 PM" src="https://github.com/user-attachments/assets/012c9718-44f3-453a-8eb0-a3b3c66531c2" />

Update box -
<img width="571" height="558" alt="Screenshot 2026-03-02 at 3 44 58 PM" src="https://github.com/user-attachments/assets/d1fd7e18-229a-423a-9dac-3d55da213d18" />

Tags updated - 
<img width="1363" height="332" alt="Screenshot 2026-03-02 at 3 45 18 PM" src="https://github.com/user-attachments/assets/360d4ed2-9355-4131-848a-d342dadba239" />


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes
Add tags to gateway backends

( ) This is not user-visible or is docs only, and no release notes are required.
( X ) Release notes are required, with the following suggested text:

```markdown
Add support for attaching tags to backends
* [:warning: Breaking change:](#breaking) Add a `tags` column to the `gateway_backend` table. Deployments with `runMigrationsEnabled` set to `false` must apply `V5__add_tags_to_gateway_backend.sql` manually before upgrading, otherwise all backend create and update requests fail, even when no tags are used.
```
