### PR TITLE
Add Trino Gateway 19 release notes

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,7 +21,7 @@ It  copies the following, necessary files to current directory:
 ```shell
 #!/usr/bin/env sh
 
-VERSION=18
+VERSION=19
 BASE_URL="https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha"
 JAR_FILE="gateway-ha-$VERSION-jar-with-dependencies.jar"
 GATEWAY_JAR="gateway-ha.jar"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,50 @@
 
 ## 2026
 
+### Trino Gateway 19 (11 May 2026) { id="19" }
+
+Artifacts:
+
+* [JAR file gateway-ha-19-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/19/gateway-ha-19-jar-with-dependencies.jar)
+* Container image `trinodb/trino-gateway:19`
+* Source code as
+  [tar.gz](https://github.com/trinodb/trino-gateway/archive/refs/tags/19.tar.gz)
+  or [zip](https://github.com/trinodb/trino-gateway/archive/refs/tags/19.zip)
+* [Trino Helm chart](https://trinodb.github.io/charts/) `trino/trino-gateway` version `1.19.0`
+
+Changes:
+
+**General**
+
+* [:warning: Breaking change:](#breaking) Remove all resource group management
+  functionality. Existing resource group database tables are preserved and not
+  dropped on upgrade to avoid accidental data loss from Trino Gateway update.
+  New Trino Gateway deployments no longer create or manage these tables.
+  Resource groups are a Trino feature and must be managed through Trino
+  directly.
+  ([#656](https://github.com/trinodb/trino-gateway/issues/656))
+* [:warning: Breaking change:](#breaking) Rename routing configuration
+  `addXForwardedHeaders` to `addForwardedHeaders`.
+  ([#1005](https://github.com/trinodb/trino-gateway/pull/1005))
+* Fix HTTP header forwarding when `routing.addForwardedHeaders` is set to
+  `false` to properly drop both the modern RFC 7239 `Forwarded` and the legacy
+  `X-Forwarded-*` HTTP headers.
+  ([#1005](https://github.com/trinodb/trino-gateway/pull/1005))
+* Fix issue with eager evaluation of fallback routing for queries. 
+  ([#922](https://github.com/trinodb/trino-gateway/pull/922))
+* Prevent SQL analysis failures due to missing character encoding.
+  ([#1032](https://github.com/trinodb/trino-gateway/issues/1032))
+
+**UI**
+
+* Fix rendering of the query distribution chart.
+  ([#942](https://github.com/trinodb/trino-gateway/pull/942))
+* Improve application name display in header
+  ([#1003](https://github.com/trinodb/trino-gateway/pull/1003))
+
+More details and a list of all merged pull requests are [available in the
+milestone 19 list](https://github.com/trinodb/trino-gateway/pulls?q=is%3Apr+milestone%3A19+is%3Aclosed).
+
 ### Trino Gateway 18 (4 Mar 2026) { id="18" }
 
 Artifacts:


### PR DESCRIPTION
## Description

Assemble the release notes for Trino Gateway 19 release and adjust rest of docs to version 19.

Release date  will be set to the planned date following our monthly release cadence after dev sync discussion and agreement

## Additional context and related issues

* Helm chart release PR to merge after the release at https://github.com/trinodb/charts/pull/414

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Verification for each pull request

Format: PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

Any dates missing in the list just had no merged PRs.

## 4 Mar 2026

* #951 ✅ rn ✅ docs

## 5 Mar 2026

* #953 ✅ rn ✅ docs
* #954 ✅ rn ✅ docs

## 8 Mar 2026

* #956 ✅ rn ✅ docs
* #955 ✅ rn ✅ docs

## 10 Mar 2026

* #957 ✅ rn ✅ docs
* #958 ✅ rn ✅ docs

## 12 Mar 2026

* #959 ✅ rn ✅ docs

## 15 Mar 2026

* #962 ✅ rn ✅ docs
* #961 ✅ rn ✅ docs
* #964 ✅ rn ✅ docs
* #965 ✅ rn ✅ docs

## 16 Mar 2026

* #966 ✅ rn ✅ docs
* #968 ✅ rn ✅ docs
* #967 ✅ rn ✅ docs

## 18 Mar 2026

* #922 ✅ rn ✅ docs

## 19 Mar 2026

* #972 ✅ rn ✅ docs
* #971 ✅ rn ✅ docs
* #973 ✅ rn ✅ docs

## 22 Mar 2026

* #974 ✅ rn ✅ docs
* #975 ✅ rn ✅ docs
* #977 ✅ rn ✅ docs
* #982 ✅ rn ✅ docs
* #983 ✅ rn ✅ docs
* #976 ✅ rn ✅ docs
* #978 ✅ rn ✅ docs
* #979 ✅ rn ✅ docs
* #980 ✅ rn ✅ docs
* #981 ✅ rn ✅ docs

## 23 Mar 2026

* #985 ✅ rn ✅ docs

## 24 Mar 2026

* #989 ✅ rn ✅ docs
* #988 ✅ rn ✅ docs
* #987 ✅ rn ✅ docs
* #986 ✅ rn ✅ docs
* #942✅ rn ✅ docs

## 26 Mar 2026

* #990 ✅ rn ✅ docs

## 28 Mar 2026

* #994 ✅ rn ✅ docs
* #995 ✅ rn ✅ docs
* #997 ✅ rn ✅ docs

## 29 Mar 2026

* #996 ✅ rn ✅ docs
* #998 ✅ rn ✅ docs

## 31 Mar 2026

* #1000 ✅ rn ✅ docs
* #1001 ✅ rn ✅ docs

## 2 Apr 2026

* #1004 ✅ rn ✅ docs
* #1003 ✅ rn ✅ docs
* #1006 ✅ rn ✅ docs
* #1007 ✅ rn ✅ docs

## 5 Apr 2026

* #1008 ✅ rn ✅ docs
* #1009 ✅ rn ✅ docs
* #1010 ✅ rn ✅ docs

## 7 Apr 2026

* #993 ✅ rn ✅ docs
* #1011 ✅ rn ✅ docs

## 10 Apr 2026

* #1013 ✅ rn ✅ docs
* #1012 ✅ rn ✅ docs

## 12 Apr 2026

* #1014 ✅ rn ✅ docs
* #1015 ✅ rn ✅ docs

## 15 Apr 2026

* #1017 ✅ rn ✅ docs

## 16 Apr 2026

* #1019 ✅ rn ✅ docs

## 19 Apr 2026

* #1023 ✅ rn ✅ docs
* #1024 ✅ rn ✅ docs
* #1025 ✅ rn ✅ docs
* #1028 ✅ rn ✅ docs
* #1026 ✅ rn ✅ docs
* #1027 ✅ rn ✅ docs
* #1020 ✅ rn ✅ docs
* #1016 ✅ rn ✅ docs

## 20 Apr 2026

* #1030 ✅ rn ✅ docs

## 21 Apr 2026

* #1031 ✅ rn ✅ docs

## 26 Apr 2026

* #1034 ✅ rn ✅ docs
* #1037 ✅ rn ✅ docs
* #1038 ✅ rn ✅ docs
* #1036 ✅ rn ✅ docs
* #1035 ✅ rn ✅ docs

## 27 Apr 2026

* #1040 ✅ rn ✅ docs
* #1039 ✅ rn ✅ docs

## 29 Apr 2026

* #1041 ✅ rn ✅ docs
* #1005 ✅ rn ✅ docs

## 3 May 2026

* #1047 ✅ rn ✅ docs
* #1046 ✅ rn ✅ docs
* #1045 ✅ rn ✅ docs
* #1044 ✅ rn ✅ docs
* #1049 ✅ rn ✅ docs
* #1048 ✅ rn ✅ docs

## 5 May 2026

* #1050 ✅ rn ✅ docs
* #1051 ✅ rn ✅ docs

## 6 May 2026

* #1053 ✅ rn ✅ docs
* #1052 ✅ rn ✅ docs

## 7 May 2026

* #1058 ✅ rn ✅ docs
* #1057 ✅ rn ✅ docs

## 8 May 2026

* #969 ✅ rn ✅ docs

## 9 May 2026

* #1054 ✅ rn ✅ docs

## 10 May 2026

* #1060 ✅ rn ✅ docs
* #1061 ✅ rn ✅ docs
* #1062 ✅ rn ✅ docs
* #1064 ✅ rn ✅ docs
* #1063 ✅ rn ✅ docs

## 11 May 2026

* #1065 ✅ rn ✅ docs