### PR TITLE
Increase CI build timeout to 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: [25]
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout source
         uses: actions/checkout@v6


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino-gateway/issues/952