### PR TITLE
Fix corruption of binary responses caused by UTF-8 decoding in proxy response

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyResponseHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyResponseHandler.java
@@ -23,7 +23,6 @@ import io.trino.gateway.ha.config.ProxyResponseConfiguration;
 import io.trino.gateway.proxyserver.ProxyResponseHandler.ProxyResponse;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 import static java.util.Objects.requireNonNull;
 
@@ -47,7 +46,7 @@ public class ProxyResponseHandler
     public ProxyResponse handle(Request request, Response response)
     {
         try {
-            return new ProxyResponse(response.getStatusCode(), response.getHeaders(), new String(response.getInputStream().readNBytes((int) responseSize.toBytes()), StandardCharsets.UTF_8));
+            return new ProxyResponse(response.getStatusCode(), response.getHeaders(), response.getInputStream().readNBytes((int) responseSize.toBytes()));
         }
         catch (IOException e) {
             throw new ProxyException("Failed reading response from remote Trino server", e);
@@ -57,7 +56,7 @@ public class ProxyResponseHandler
     public record ProxyResponse(
             int statusCode,
             ListMultimap<HeaderName, String> headers,
-            String body)
+            byte[] body)
     {
         public ProxyResponse
         {


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The gateway currently reads backend responses using UTF-8 string decoding:

`new String(response.getInputStream().readNBytes((int) responseSize.toBytes()), StandardCharsets.UTF_8)`

This will work for all text responses. But for binary assets like image/png, decoding binary content as UTF-8 modifies the byte stream, because invalid UTF-8 sequences are replaced or re-encoded. As a result, gateway returns corrupted/broken image to client.

One observable example is `'/ui/assets/logo.png`'. This returns a broken image.

## Solution

Avoiding the conversion of response body to a UTF-8 string fixes this issue. Forward the raw bytes return by the backend ensures images are transmitted without modification.

`response.getInputStream().readNBytes((int) responseSize.toBytes())`

## Result
Before this change:

![Gateway 3](https://github.com/user-attachments/assets/646f1e92-d3ca-4702-bf48-e729f6a5dec1)

![Gateway 5](https://github.com/user-attachments/assets/ee7d4475-817a-4c71-a934-15c9ae218690)


After this change:
`/ui/assets/logo.png` loads correctly through gateway

![Gateway 4](https://github.com/user-attachments/assets/e8b9e399-2629-4555-906b-f4a12f9861af)

![Gateway 6](https://github.com/user-attachments/assets/a575281f-3ebf-4268-8e88-568aa145ba32)


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
