### PR TITLE
Remove duplicated mapping key

### DIFF
--- a/webapp/pnpm-lock.yaml
+++ b/webapp/pnpm-lock.yaml
@@ -2048,11 +2048,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  use-sync-external-store@1.6.0:
-    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   utility-types@3.11.0:
     resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
     engines: {node: '>= 4'}
@@ -4564,10 +4559,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  use-sync-external-store@1.6.0(react@18.2.0):
-    dependencies:
-      react: 18.2.0
 
   use-sync-external-store@1.6.0(react@18.2.0):
     dependencies:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Remove duplicated mapping key in `pnpm-lock.yaml`


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
```
$ npx pnpm dedupe --check
 WARN  Ignoring broken lockfile at /Users/ypoon/Documents/projects/trino-gateway-alt/webapp: The lockfile at "/Users/ypoon/Documents/projects/trino-gateway-alt/webapp/pnpm-lock.yaml" is broken: duplicated mapping key (2051:3)

 2048 |     peerDependencies:
 2049 |       react: ^16.8.0 || ^17.0.0  ...
 2050 |
 2051 |   use-sync-external-store@1.6.0:
----------^
 2052 |     resolution: {integrity: sha5 ...
 2053 |     peerDependencies:
 WARN  deprecated eslint@8.57.1: This version is no longer supported. Please see https://eslint.org/version-support for other options.
 WARN  6 deprecated subdependencies found: @humanwhocodes/config-array@0.13.0, @humanwhocodes/object-schema@2.0.3, @types/zrender@5.0.0, glob@7.2.3, inflight@1.0.6, rimraf@3.0.2
Progress: resolved 537, reused 479, downloaded 0, added 0, done


$ yamllint pnpm-lock.yaml | grep -v "line too long"
pnpm-lock.yaml
  1:1       warning  missing document start "---"  (document-start)
  2051:3    error    duplication of key "use-sync-external-store@1.6.0" in mapping  (key-duplicates)
  4572:3    error    duplication of key "use-sync-external-store@1.6.0(react@18.2.0)" in mapping  (key-duplicates)
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.