### PR TITLE
Expand CI runs to Java 26 and 27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [25]
+        include: 
+          - { java-version: 25 }
+          - { java-version: 26 }
+          - { java-version: 27-ea }
     timeout-minutes: 30
     steps:
       - name: Checkout source
@@ -33,6 +36,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java-version }}
+          cache: 'maven'
           distribution: 'temurin'
       - name: Build with Maven
         run: $MAVEN clean verify

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,8 +21,8 @@ or execute the following command:
 
 #### Locally
 
-This project requires Java 25. Note that higher version of Java have not been
-verified and may run into unexpected issues.
+This project requires Java 25. Higher version of Java are verified in our CI
+pipeline, but may run into unexpected issues.
 
 Run `./mvnw clean install` to build `trino-gateway`. VM options required for
 compilation and testing are specified in `.mvn/jvm.config`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,8 +21,9 @@ Consider the following requirements for your Trino Gateway installation.
 
 ### Java
 
-Trino Gateway requires a Java 25 runtime. Older versions of Java can not be
-used. Newer versions might work but are not tested.
+Trino Gateway requires a Java 25 runtime. Lower versions of Java can not be
+used. Higher versions are verified in our CI pipelines, but you may run into
+unexpected issues. 
 
 Verify the Java version on your system with `java -version`.
 


### PR DESCRIPTION
## Description

Adopting approach from Trino.

## Additional context and related issues

Probably have to update docs. Will check after CI passes.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
