### PR TITLE
Enhance API role /gateway/backend endpoints to update backendToStatus in-memory cache immediately

### DIFF
--- a/docs/operation.md
+++ b/docs/operation.md
@@ -16,6 +16,95 @@ Existing cluster information can also be modified using the edit button.
 
 ![trino.gateway.io/entity](./assets/trinogateway_cluster_page.png)
 
+## Cluster configuration and health status
+
+Trino Gateway tracks cluster state at two separate layers, each serving a
+different purpose.
+
+### Database: source of truth for configuration
+
+All cluster configuration is stored persistently in a database. This includes
+each cluster's name, routing group, proxy URL, external URL, and whether it is
+marked active or inactive.
+
+Any change made through the API or the admin UI — adding, updating, activating,
+deactivating, or deleting a cluster — is written to the database immediately.
+The database represents **what you have configured**: the intended state of the
+system. It persists across restarts.
+
+### Health check cache: source of truth for routing
+
+In addition to the database, Trino Gateway maintains an in-memory record of
+each cluster's current health. This cache is separate from the database and is
+used to make all query routing decisions.
+
+Each cluster in the cache has one of four health statuses:
+
+| Status | Meaning |
+|--------|---------|
+| `HEALTHY` | The cluster is reachable and accepting queries |
+| `UNHEALTHY` | The cluster failed its most recent health check |
+| `PENDING` | The cluster was recently added or changed and has not yet been health-checked |
+| `UNKNOWN` | Health status could not be determined |
+
+Only clusters with a `HEALTHY` status receive query traffic, regardless of
+whether the database marks them as active. A cluster in `PENDING` state does not
+receive traffic — it transitions to `HEALTHY` or `UNHEALTHY` once the next
+background health check evaluates it.
+
+The cache is updated by a background health check that runs at a configurable
+interval (default: every 1 minute, set via `monitor.taskDelay`). The health
+check mechanism itself is also configurable — by default it calls the `/v1/info`
+endpoint on each cluster, but JDBC, JMX, and Prometheus metrics are also
+supported.
+
+### How the two layers interact
+
+The database and health cache serve complementary roles:
+
+- **Database** — "what you configured"
+- **Health cache** — "what is actually reachable right now"
+
+When you make a change via the API or admin UI, both layers are updated
+immediately:
+
+| Action | Database | Health cache |
+|--------|----------|-------------|
+| Add a cluster | Written immediately | Set to `PENDING` if active, `UNKNOWN` if inactive |
+| Update a cluster | Written immediately | Reset to `PENDING` if active, `UNKNOWN` if inactive |
+| Activate a cluster | Written immediately | Set to `PENDING` |
+| Deactivate a cluster | Written immediately | Set to `UNKNOWN`; excluded from routing immediately |
+| Delete a cluster | Removed immediately | Removed from cache and JMX; excluded from routing immediately |
+
+Because the database and health cache are not updated atomically, a failure
+during the in-memory update could leave the two layers out of sync. To prevent
+this, each operation uses a compensation pattern: before applying any change,
+the current state is saved (previous health status and backend configuration).
+If the in-memory update fails after the database write succeeds, the database
+change is reverted using the saved state:
+
+| Action | Compensation on failure |
+|--------|------------------------|
+| Add a cluster | Delete the new entry from DB, remove health |
+| Update a cluster | Restore old config in DB, revert health |
+| Activate a cluster | Deactivate in DB, revert health |
+| Deactivate a cluster | Re-activate in DB, revert health |
+| Delete a cluster | Re-add old config to DB, revert health |
+
+For update and delete, compensation is skipped if the old backend configuration
+was not found before the operation, to avoid reverting to an unknown state. If
+the compensation itself fails, the compensation exception is attached to the
+original exception as a suppressed exception — the original is always the one
+thrown to the caller.
+
+A cluster that crashes or becomes unreachable after the last health check will
+remain active in the database but will be marked `UNHEALTHY` in the cache
+within one polling interval. During that window, in-flight queries already
+routed to that cluster may fail, but no new queries will be sent to it once the
+cache is updated.
+
+The health cache is not persisted — it is rebuilt from the database and
+repopulated by health checks each time Trino Gateway starts.
 
 ## Graceful shutdown
 

--- a/docs/routing-logic.md
+++ b/docs/routing-logic.md
@@ -9,7 +9,9 @@ Trino cluster that dealt with the earlier requests.
 If it is a new request, the Trino Gateway refers to [Routing rules](routing-rules.md) 
 to decide which group of clusters, called a 'Routing Group,' should handle it. 
 It then picks a cluster from that Routing Group to handle the request using 
-either an adaptive or round-robin strategy.
+either an adaptive or round-robin strategy. Only clusters that are currently
+healthy are eligible — see [Cluster configuration and health status](operation.md#cluster-configuration-and-health-status)
+for details on how health status is determined.
 
 ![Request Routing Flow](assets/gateway-routing-flow.svg)
 

--- a/gateway-ha/src/main/java/io/trino/gateway/baseapp/BaseApp.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/baseapp/BaseApp.java
@@ -35,6 +35,7 @@ import io.trino.gateway.ha.resource.GatewayWebAppResource;
 import io.trino.gateway.ha.resource.HaGatewayResource;
 import io.trino.gateway.ha.resource.LoginResource;
 import io.trino.gateway.ha.resource.PublicResource;
+import io.trino.gateway.ha.router.BackendLifecycleManager;
 import io.trino.gateway.ha.router.ForRouter;
 import io.trino.gateway.ha.router.RoutingManager;
 import io.trino.gateway.ha.router.RoutingRulesManager;
@@ -140,6 +141,7 @@ public class BaseApp
                 .setDefault()
                 .to(StochasticRoutingManager.class)
                 .in(Scopes.SINGLETON);
+        binder.bind(BackendLifecycleManager.class).in(Scopes.SINGLETON);
     }
 
     private static void addManagedApps(HaGatewayConfiguration configuration, Binder binder)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/GatewayResource.java
@@ -15,6 +15,7 @@ package io.trino.gateway.ha.resource;
 
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
+import io.trino.gateway.ha.router.BackendLifecycleManager;
 import io.trino.gateway.ha.router.GatewayBackendManager;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.GET;
@@ -37,11 +38,15 @@ public class GatewayResource
     private static final Logger log = Logger.get(GatewayResource.class);
 
     private final GatewayBackendManager gatewayBackendManager;
+    private final BackendLifecycleManager backendLifecycleManager;
 
     @Inject
-    public GatewayResource(GatewayBackendManager gatewayBackendManager)
+    public GatewayResource(
+            GatewayBackendManager gatewayBackendManager,
+            BackendLifecycleManager backendLifecycleManager)
     {
         this.gatewayBackendManager = requireNonNull(gatewayBackendManager, "gatewayBackendManager is null");
+        this.backendLifecycleManager = requireNonNull(backendLifecycleManager, "backendLifecycleManager is null");
     }
 
     @GET
@@ -69,7 +74,7 @@ public class GatewayResource
     public Response deactivateBackend(@PathParam("name") String name)
     {
         try {
-            this.gatewayBackendManager.deactivateBackend(name);
+            backendLifecycleManager.deactivateBackend(name);
         }
         catch (Exception e) {
             log.error(e, e.getMessage());
@@ -83,7 +88,7 @@ public class GatewayResource
     public Response activateBackend(@PathParam("name") String name)
     {
         try {
-            this.gatewayBackendManager.activateBackend(name);
+            backendLifecycleManager.activateBackend(name);
         }
         catch (Exception e) {
             log.error(e, e.getMessage());

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/resource/HaGatewayResource.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/resource/HaGatewayResource.java
@@ -15,8 +15,7 @@ package io.trino.gateway.ha.resource;
 
 import com.google.inject.Inject;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
-import io.trino.gateway.ha.router.GatewayBackendManager;
-import io.trino.gateway.ha.router.HaGatewayManager;
+import io.trino.gateway.ha.router.BackendLifecycleManager;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -31,19 +30,19 @@ import static java.util.Objects.requireNonNull;
 @Produces(MediaType.APPLICATION_JSON)
 public class HaGatewayResource
 {
-    private final GatewayBackendManager haGatewayManager;
+    private final BackendLifecycleManager backendLifecycleManager;
 
     @Inject
-    public HaGatewayResource(GatewayBackendManager haGatewayManager)
+    public HaGatewayResource(BackendLifecycleManager backendLifecycleManager)
     {
-        this.haGatewayManager = requireNonNull(haGatewayManager, "haGatewayManager is null");
+        this.backendLifecycleManager = requireNonNull(backendLifecycleManager, "backendLifecycleManager is null");
     }
 
     @Path("/add")
     @POST
     public Response addBackend(ProxyBackendConfiguration backend)
     {
-        ProxyBackendConfiguration updatedBackend = haGatewayManager.addBackend(backend);
+        ProxyBackendConfiguration updatedBackend = backendLifecycleManager.addBackend(backend);
         return Response.ok(updatedBackend).build();
     }
 
@@ -51,7 +50,7 @@ public class HaGatewayResource
     @POST
     public Response updateBackend(ProxyBackendConfiguration backend)
     {
-        ProxyBackendConfiguration updatedBackend = haGatewayManager.updateBackend(backend);
+        ProxyBackendConfiguration updatedBackend = backendLifecycleManager.updateBackend(backend);
         return Response.ok(updatedBackend).build();
     }
 
@@ -59,7 +58,7 @@ public class HaGatewayResource
     @POST
     public Response removeBackend(String name)
     {
-        ((HaGatewayManager) haGatewayManager).deleteBackend(name);
+        backendLifecycleManager.deleteBackend(name);
         return Response.ok().build();
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/BackendLifecycleManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/BackendLifecycleManager.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.trino.gateway.ha.clustermonitor.ClusterStats;
+import io.trino.gateway.ha.clustermonitor.TrinoStatus;
+import io.trino.gateway.ha.config.ProxyBackendConfiguration;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class BackendLifecycleManager
+{
+    private static final Logger log = Logger.get(BackendLifecycleManager.class);
+
+    private final GatewayBackendManager gatewayBackendManager;
+    private final RoutingManager routingManager;
+    private final BackendStateManager backendStateManager;
+
+    @Inject
+    public BackendLifecycleManager(
+            GatewayBackendManager gatewayBackendManager,
+            RoutingManager routingManager,
+            BackendStateManager backendStateManager)
+    {
+        this.gatewayBackendManager = requireNonNull(gatewayBackendManager, "gatewayBackendManager is null");
+        this.routingManager = requireNonNull(routingManager, "routingManager is null");
+        this.backendStateManager = requireNonNull(backendStateManager, "backendStateManager is null");
+    }
+
+    public void deactivateBackend(String name)
+    {
+        Optional<TrinoStatus> previousHealth = routingManager.getBackEndHealth(name);
+        gatewayBackendManager.deactivateBackend(name);
+        try {
+            routingManager.updateBackEndHealth(name, TrinoStatus.UNKNOWN);
+            backendStateManager.updateStates(name, ClusterStats.builder(name).trinoStatus(TrinoStatus.UNKNOWN).build());
+        }
+        catch (RuntimeException e) {
+            log.error(e, "In-memory update failed after deactivating backend '%s', reverting", name);
+            compensate(e, () -> {
+                gatewayBackendManager.activateBackend(name);
+                revertHealth(name, previousHealth, e);
+            });
+            throw e;
+        }
+    }
+
+    public void activateBackend(String name)
+    {
+        Optional<TrinoStatus> previousHealth = routingManager.getBackEndHealth(name);
+        gatewayBackendManager.activateBackend(name);
+        try {
+            routingManager.updateBackEndHealth(name, TrinoStatus.PENDING);
+            backendStateManager.updateStates(name, ClusterStats.builder(name).trinoStatus(TrinoStatus.PENDING).build());
+        }
+        catch (RuntimeException e) {
+            log.error(e, "In-memory update failed after activating backend '%s', reverting", name);
+            compensate(e, () -> {
+                gatewayBackendManager.deactivateBackend(name);
+                revertHealth(name, previousHealth, e);
+            });
+            throw e;
+        }
+    }
+
+    public ProxyBackendConfiguration addBackend(ProxyBackendConfiguration backend)
+    {
+        ProxyBackendConfiguration result = gatewayBackendManager.addBackend(backend);
+        try {
+            syncBackendState(result.getName(), result.isActive());
+        }
+        catch (RuntimeException e) {
+            log.error(e, "In-memory update failed after adding backend '%s', reverting", result.getName());
+            compensate(e, () -> {
+                ((HaGatewayManager) gatewayBackendManager).deleteBackend(result.getName());
+                revertHealth(result.getName(), Optional.empty(), e);
+            });
+            throw e;
+        }
+        return result;
+    }
+
+    public ProxyBackendConfiguration updateBackend(ProxyBackendConfiguration backend)
+    {
+        Optional<ProxyBackendConfiguration> oldBackend = gatewayBackendManager.getBackendByName(backend.getName());
+        Optional<TrinoStatus> previousHealth = routingManager.getBackEndHealth(backend.getName());
+        ProxyBackendConfiguration result = gatewayBackendManager.updateBackend(backend);
+        try {
+            syncBackendState(result.getName(), result.isActive());
+        }
+        catch (RuntimeException e) {
+            log.error(e, "In-memory update failed after updating backend '%s', reverting", result.getName());
+            if (oldBackend.isPresent()) {
+                compensate(e, () -> {
+                    gatewayBackendManager.updateBackend(oldBackend.get());
+                    revertHealth(result.getName(), previousHealth, e);
+                });
+            }
+            throw e;
+        }
+        return result;
+    }
+
+    public void deleteBackend(String name)
+    {
+        Optional<ProxyBackendConfiguration> oldBackend = gatewayBackendManager.getBackendByName(name);
+        Optional<TrinoStatus> previousHealth = routingManager.getBackEndHealth(name);
+        ((HaGatewayManager) gatewayBackendManager).deleteBackend(name);
+        try {
+            routingManager.removeBackEndHealth(name);
+            backendStateManager.removeStates(name);
+        }
+        catch (RuntimeException e) {
+            log.error(e, "In-memory cleanup failed after deleting backend '%s', reverting", name);
+            if (oldBackend.isPresent()) {
+                compensate(e, () -> {
+                    gatewayBackendManager.addBackend(oldBackend.get());
+                    revertHealth(name, previousHealth, e);
+                });
+            }
+            throw e;
+        }
+    }
+
+    private void syncBackendState(String name, boolean active)
+    {
+        TrinoStatus trinoStatus = active ? TrinoStatus.PENDING : TrinoStatus.UNKNOWN;
+        routingManager.updateBackEndHealth(name, trinoStatus);
+        backendStateManager.updateStates(name, ClusterStats.builder(name).trinoStatus(trinoStatus).build());
+    }
+
+    private static void compensate(RuntimeException cause, Runnable action)
+    {
+        try {
+            action.run();
+        }
+        catch (RuntimeException e) {
+            cause.addSuppressed(e);
+        }
+    }
+
+    private void revertHealth(String name, Optional<TrinoStatus> previousHealth, RuntimeException originalException)
+    {
+        try {
+            if (previousHealth.isPresent()) {
+                routingManager.updateBackEndHealth(name, previousHealth.get());
+            }
+            else {
+                routingManager.removeBackEndHealth(name);
+            }
+        }
+        catch (RuntimeException revertException) {
+            originalException.addSuppressed(revertException);
+        }
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/BackendStateManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/BackendStateManager.java
@@ -21,16 +21,16 @@ import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 import org.weakref.jmx.MBeanExporter;
 import org.weakref.jmx.Managed;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.Objects.requireNonNull;
 
 public class BackendStateManager
 {
     private final MBeanExporter exporter;
-    private final Map<String, ClusterStats> clusterStats = new HashMap<>();
-    private final Map<String, ClusterStatsJMX> clusterStatsJMXs = new HashMap<>();
+    private final Map<String, ClusterStats> clusterStats = new ConcurrentHashMap<>();
+    private final Map<String, ClusterStatsJMX> clusterStatsJMXs = new ConcurrentHashMap<>();
 
     @Inject
     public BackendStateManager(MBeanExporter exporter)
@@ -44,31 +44,41 @@ public class BackendStateManager
         return clusterStats.getOrDefault(name, ClusterStats.builder(name).build());
     }
 
-    public void updateStates(String clusterId, ClusterStats stats)
+    public synchronized void updateStates(String clusterId, ClusterStats stats)
     {
-        if (!clusterStatsJMXs.containsKey(clusterId)) {
+        clusterStatsJMXs.computeIfAbsent(clusterId, id -> {
             ClusterStatsJMX clusterStatsJMX = new ClusterStatsJMX(stats);
             exporter.exportWithGeneratedName(
                     clusterStatsJMX,
                     ClusterStatsJMX.class,
-                    ImmutableMap.<String, String>builder()
-                            .put("name", "ClusterStats")
-                            .put("cluster_id", clusterId)
-                            .build());
-            clusterStatsJMXs.put(clusterId, clusterStatsJMX);
-        }
-        else {
-            clusterStatsJMXs.get(clusterId).updateFrom(stats);
-        }
+                    clusterIdProperties(id));
+            return clusterStatsJMX;
+        }).updateFrom(stats);
         clusterStats.put(clusterId, stats);
+    }
+
+    public synchronized void removeStates(String clusterId)
+    {
+        if (clusterStatsJMXs.remove(clusterId) != null) {
+            exporter.unexportWithGeneratedName(ClusterStatsJMX.class, clusterIdProperties(clusterId));
+        }
+        clusterStats.remove(clusterId);
+    }
+
+    private static Map<String, String> clusterIdProperties(String clusterId)
+    {
+        return ImmutableMap.<String, String>builder()
+                .put("name", "ClusterStats")
+                .put("cluster_id", clusterId)
+                .build();
     }
 
     public static class ClusterStatsJMX
     {
-        private int runningQueryCount;
-        private int queuedQueryCount;
-        private int numWorkerNodes;
-        private TrinoStatus trinoStatus;
+        private volatile int runningQueryCount;
+        private volatile int queuedQueryCount;
+        private volatile int numWorkerNodes;
+        private volatile TrinoStatus trinoStatus;
 
         public ClusterStatsJMX(ClusterStats clusterStats)
         {

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
@@ -160,10 +160,23 @@ public abstract class BaseRoutingManager
     }
 
     @Override
+    public Optional<TrinoStatus> getBackEndHealth(String backendId)
+    {
+        return Optional.ofNullable(backendToStatus.get(backendId));
+    }
+
+    @Override
     public void updateBackEndHealth(String backendId, TrinoStatus value)
     {
         log.info("backend %s isHealthy %s", backendId, value);
         backendToStatus.put(backendId, value);
+    }
+
+    @Override
+    public void removeBackEndHealth(String backendId)
+    {
+        log.info("Removing backend %s from health tracking", backendId);
+        backendToStatus.remove(backendId);
     }
 
     @Override

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
@@ -18,9 +18,18 @@ import io.trino.gateway.ha.clustermonitor.TrinoStatus;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RoutingManager
 {
+    /**
+     * Returns the current health status of a backend cluster.
+     *
+     * @param backendId the unique identifier of the backend cluster
+     * @return the health status, or empty if the backend is not tracked
+     */
+    Optional<TrinoStatus> getBackEndHealth(String backendId);
+
     /**
      * Updates the health status of a backend cluster.
      *
@@ -28,6 +37,13 @@ public interface RoutingManager
      * @param value the health status of the backend (UP, DOWN, etc.)
      */
     void updateBackEndHealth(String backendId, TrinoStatus value);
+
+    /**
+     * Removes a backend cluster from health tracking entirely.
+     *
+     * @param backendId the unique identifier of the backend cluster to remove
+     */
+    void removeBackEndHealth(String backendId);
 
     /**
      * Updates the statistics for all backend clusters.

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/resource/TestGatewayResource.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/resource/TestGatewayResource.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.resource;
+
+import io.airlift.json.JsonCodec;
+import io.trino.gateway.ha.HaGatewayLauncher;
+import io.trino.gateway.ha.HaGatewayTestUtils;
+import io.trino.gateway.ha.clustermonitor.ClusterStats;
+import io.trino.gateway.ha.clustermonitor.TrinoStatus;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+import java.io.File;
+import java.io.IOException;
+
+import static io.trino.gateway.ha.util.TestcontainersUtils.createPostgreSqlContainer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(Lifecycle.PER_CLASS)
+final class TestGatewayResource
+{
+    private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+
+    private final PostgreSQLContainer postgresql = createPostgreSqlContainer();
+    private final OkHttpClient httpClient = new OkHttpClient();
+    final int routerPort = 22001 + (int) (Math.random() * 1000);
+
+    @BeforeAll
+    void setup()
+            throws Exception
+    {
+        postgresql.start();
+        File configFile = HaGatewayTestUtils.buildGatewayConfig(
+                postgresql, routerPort, "test-config-no-monitor-template.yml");
+        HaGatewayLauncher.main(new String[] {configFile.getAbsolutePath()});
+        addBackend("activate-test", false);
+        addBackend("deactivate-test", true);
+    }
+
+    @Test
+    void testActivateBackendSetsPendingInHealthCache()
+            throws IOException
+    {
+        Request request = new Request.Builder()
+                .url("http://localhost:%s/gateway/backend/activate/activate-test".formatted(routerPort))
+                .post(RequestBody.create("", JSON))
+                .build();
+        try (Response response = httpClient.newCall(request).execute()) {
+            assertThat(response.isSuccessful()).isTrue();
+        }
+
+        assertThat(getBackendState("activate-test").trinoStatus()).isEqualTo(TrinoStatus.PENDING);
+    }
+
+    @Test
+    void testDeactivateBackendSetsUnhealthyInHealthCache()
+            throws IOException
+    {
+        Request request = new Request.Builder()
+                .url("http://localhost:%s/gateway/backend/deactivate/deactivate-test".formatted(routerPort))
+                .post(RequestBody.create("", JSON))
+                .build();
+        try (Response response = httpClient.newCall(request).execute()) {
+            assertThat(response.isSuccessful()).isTrue();
+        }
+
+        assertThat(getBackendState("deactivate-test").trinoStatus()).isEqualTo(TrinoStatus.UNKNOWN);
+    }
+
+    @Test
+    void testActivateBackendDoesNotUpdateHealthCacheOnError()
+            throws IOException
+    {
+        Request request = new Request.Builder()
+                .url("http://localhost:%s/gateway/backend/activate/nonexistent".formatted(routerPort))
+                .post(RequestBody.create("", JSON))
+                .build();
+        try (Response response = httpClient.newCall(request).execute()) {
+            assertThat(response.code()).isEqualTo(404);
+        }
+
+        Request stateRequest = new Request.Builder()
+                .url("http://localhost:%s/api/public/backends/nonexistent/state".formatted(routerPort))
+                .get()
+                .build();
+        try (Response response = httpClient.newCall(stateRequest).execute()) {
+            assertThat(response.code()).isEqualTo(404);
+        }
+    }
+
+    @Test
+    void testDeactivateBackendDoesNotUpdateHealthCacheOnError()
+            throws IOException
+    {
+        Request request = new Request.Builder()
+                .url("http://localhost:%s/gateway/backend/deactivate/nonexistent".formatted(routerPort))
+                .post(RequestBody.create("", JSON))
+                .build();
+        try (Response response = httpClient.newCall(request).execute()) {
+            assertThat(response.code()).isEqualTo(404);
+        }
+
+        Request stateRequest = new Request.Builder()
+                .url("http://localhost:%s/api/public/backends/nonexistent/state".formatted(routerPort))
+                .get()
+                .build();
+        try (Response response = httpClient.newCall(stateRequest).execute()) {
+            assertThat(response.code()).isEqualTo(404);
+        }
+    }
+
+    private void addBackend(String name, boolean active)
+            throws IOException
+    {
+        String body = ("{\"name\":\"%s\",\"proxyTo\":\"http://localhost:9999\","
+                + "\"externalUrl\":\"http://localhost:9999\","
+                + "\"routingGroup\":\"adhoc\",\"active\":%s}")
+                .formatted(name, active);
+        Request request = new Request.Builder()
+                .url("http://localhost:%s/gateway/backend/modify/add".formatted(routerPort))
+                .post(RequestBody.create(body, JSON))
+                .build();
+        try (Response response = httpClient.newCall(request).execute()) {
+            assertThat(response.isSuccessful()).isTrue();
+        }
+    }
+
+    private ClusterStats getBackendState(String name)
+            throws IOException
+    {
+        Request request = new Request.Builder()
+                .url("http://localhost:%s/api/public/backends/%s/state".formatted(routerPort, name))
+                .get()
+                .build();
+        try (Response response = httpClient.newCall(request).execute()) {
+            return JsonCodec.jsonCodec(ClusterStats.class).fromJson(response.body().string());
+        }
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/resource/TestHaGatewayResource.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/resource/TestHaGatewayResource.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.resource;
+
+import io.airlift.json.JsonCodec;
+import io.trino.gateway.ha.HaGatewayLauncher;
+import io.trino.gateway.ha.HaGatewayTestUtils;
+import io.trino.gateway.ha.clustermonitor.ClusterStats;
+import io.trino.gateway.ha.clustermonitor.TrinoStatus;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+import java.io.File;
+import java.io.IOException;
+
+import static io.trino.gateway.ha.util.TestcontainersUtils.createPostgreSqlContainer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(Lifecycle.PER_CLASS)
+final class TestHaGatewayResource
+{
+    private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+
+    private final PostgreSQLContainer postgresql = createPostgreSqlContainer();
+    private final OkHttpClient httpClient = new OkHttpClient();
+    final int routerPort = 23001 + (int) (Math.random() * 1000);
+
+    @BeforeAll
+    void setup()
+            throws Exception
+    {
+        postgresql.start();
+        File configFile = HaGatewayTestUtils.buildGatewayConfig(
+                postgresql, routerPort, "test-config-no-monitor-template.yml");
+        HaGatewayLauncher.main(new String[] {configFile.getAbsolutePath()});
+        addBackend("update-to-active-test", false);
+        addBackend("update-to-inactive-test", true);
+        addBackend("remove-test", true);
+    }
+
+    @Test
+    void testAddActiveBackendSetsPendingInHealthCache()
+            throws IOException
+    {
+        addBackend("add-active-test", true);
+
+        assertThat(getBackendState("add-active-test").trinoStatus()).isEqualTo(TrinoStatus.PENDING);
+    }
+
+    @Test
+    void testAddInactiveBackendSetsUnhealthyInHealthCache()
+            throws IOException
+    {
+        addBackend("add-inactive-test", false);
+
+        assertThat(getBackendState("add-inactive-test").trinoStatus()).isEqualTo(TrinoStatus.UNKNOWN);
+    }
+
+    @Test
+    void testUpdateActiveBackendSetsPendingInHealthCache()
+            throws IOException
+    {
+        String body = ("{\"name\":\"%s\",\"proxyTo\":\"http://localhost:9999\","
+                + "\"externalUrl\":\"http://localhost:9999\","
+                + "\"routingGroup\":\"adhoc\",\"active\":true}")
+                .formatted("update-to-active-test");
+        Request request = new Request.Builder()
+                .url("http://localhost:%s/gateway/backend/modify/update".formatted(routerPort))
+                .post(RequestBody.create(body, JSON))
+                .build();
+        try (Response response = httpClient.newCall(request).execute()) {
+            assertThat(response.isSuccessful()).isTrue();
+        }
+
+        assertThat(getBackendState("update-to-active-test").trinoStatus()).isEqualTo(TrinoStatus.PENDING);
+    }
+
+    @Test
+    void testUpdateInactiveBackendSetsUnhealthyInHealthCache()
+            throws IOException
+    {
+        String body = ("{\"name\":\"%s\",\"proxyTo\":\"http://localhost:9999\","
+                + "\"externalUrl\":\"http://localhost:9999\","
+                + "\"routingGroup\":\"adhoc\",\"active\":false}")
+                .formatted("update-to-inactive-test");
+        Request request = new Request.Builder()
+                .url("http://localhost:%s/gateway/backend/modify/update".formatted(routerPort))
+                .post(RequestBody.create(body, JSON))
+                .build();
+        try (Response response = httpClient.newCall(request).execute()) {
+            assertThat(response.isSuccessful()).isTrue();
+        }
+
+        assertThat(getBackendState("update-to-inactive-test").trinoStatus()).isEqualTo(TrinoStatus.UNKNOWN);
+    }
+
+    @Test
+    void testRemoveBackendCleansUpState()
+            throws IOException
+    {
+        assertThat(getBackendState("remove-test").trinoStatus()).isEqualTo(TrinoStatus.PENDING);
+
+        Request request = new Request.Builder()
+                .url("http://localhost:%s/gateway/backend/modify/delete".formatted(routerPort))
+                .post(RequestBody.create("remove-test", JSON))
+                .build();
+        try (Response response = httpClient.newCall(request).execute()) {
+            assertThat(response.isSuccessful()).isTrue();
+        }
+
+        Request backendRequest = new Request.Builder()
+                .url("http://localhost:%s/api/public/backends/remove-test".formatted(routerPort))
+                .get()
+                .build();
+        try (Response response = httpClient.newCall(backendRequest).execute()) {
+            assertThat(response.code()).isEqualTo(404);
+        }
+
+        Request allBackendsRequest = new Request.Builder()
+                .url("http://localhost:%s/gateway/backend/all".formatted(routerPort))
+                .get()
+                .build();
+        try (Response response = httpClient.newCall(allBackendsRequest).execute()) {
+            assertThat(response.isSuccessful()).isTrue();
+            assertThat(response.body().string()).doesNotContain("remove-test");
+        }
+
+        Request stateRequest = new Request.Builder()
+                .url("http://localhost:%s/api/public/backends/remove-test/state".formatted(routerPort))
+                .get()
+                .build();
+        try (Response response = httpClient.newCall(stateRequest).execute()) {
+            assertThat(response.code()).isEqualTo(404);
+        }
+    }
+
+    private void addBackend(String name, boolean active)
+            throws IOException
+    {
+        String body = ("{\"name\":\"%s\",\"proxyTo\":\"http://localhost:9999\","
+                + "\"externalUrl\":\"http://localhost:9999\","
+                + "\"routingGroup\":\"adhoc\",\"active\":%s}")
+                .formatted(name, active);
+        Request request = new Request.Builder()
+                .url("http://localhost:%s/gateway/backend/modify/add".formatted(routerPort))
+                .post(RequestBody.create(body, JSON))
+                .build();
+        try (Response response = httpClient.newCall(request).execute()) {
+            assertThat(response.isSuccessful()).isTrue();
+        }
+    }
+
+    private ClusterStats getBackendState(String name)
+            throws IOException
+    {
+        Request request = new Request.Builder()
+                .url("http://localhost:%s/api/public/backends/%s/state".formatted(routerPort, name))
+                .get()
+                .build();
+        try (Response response = httpClient.newCall(request).execute()) {
+            return JsonCodec.jsonCodec(ClusterStats.class).fromJson(response.body().string());
+        }
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestBackendLifecycleManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestBackendLifecycleManager.java
@@ -1,0 +1,385 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import io.trino.gateway.ha.clustermonitor.ClusterStats;
+import io.trino.gateway.ha.clustermonitor.TrinoStatus;
+import io.trino.gateway.ha.config.ProxyBackendConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+final class TestBackendLifecycleManager
+{
+    @Mock
+    private HaGatewayManager gatewayBackendManager;
+
+    @Mock
+    private RoutingManager routingManager;
+
+    @Mock
+    private BackendStateManager backendStateManager;
+
+    private BackendLifecycleManager manager;
+
+    @BeforeEach
+    void setUp()
+    {
+        manager = new BackendLifecycleManager(gatewayBackendManager, routingManager, backendStateManager);
+    }
+
+    // --- deactivateBackend ---
+
+    @Test
+    void testDeactivateHappyPath()
+    {
+        when(routingManager.getBackEndHealth("backend1")).thenReturn(Optional.of(TrinoStatus.HEALTHY));
+
+        manager.deactivateBackend("backend1");
+
+        InOrder order = inOrder(gatewayBackendManager, routingManager, backendStateManager);
+        order.verify(gatewayBackendManager).deactivateBackend("backend1");
+        order.verify(routingManager).updateBackEndHealth("backend1", TrinoStatus.UNKNOWN);
+        order.verify(backendStateManager).updateStates(eq("backend1"), any(ClusterStats.class));
+    }
+
+    @Test
+    void testDeactivateCompensatesWhenRoutingManagerFails()
+    {
+        when(routingManager.getBackEndHealth("backend1")).thenReturn(Optional.of(TrinoStatus.HEALTHY));
+        doThrow(new RuntimeException("routing update failed"))
+                .when(routingManager).updateBackEndHealth("backend1", TrinoStatus.UNKNOWN);
+
+        assertThatThrownBy(() -> manager.deactivateBackend("backend1"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("routing update failed");
+
+        verify(gatewayBackendManager).deactivateBackend("backend1");
+        verify(routingManager).updateBackEndHealth("backend1", TrinoStatus.HEALTHY);
+        verify(gatewayBackendManager).activateBackend("backend1");
+    }
+
+    @Test
+    void testDeactivateCompensatesWhenBackendStateManagerFails()
+    {
+        when(routingManager.getBackEndHealth("backend1")).thenReturn(Optional.of(TrinoStatus.HEALTHY));
+        doThrow(new RuntimeException("state update failed"))
+                .when(backendStateManager).updateStates(eq("backend1"), any(ClusterStats.class));
+
+        assertThatThrownBy(() -> manager.deactivateBackend("backend1"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("state update failed");
+
+        verify(routingManager).updateBackEndHealth("backend1", TrinoStatus.HEALTHY);
+        verify(gatewayBackendManager).activateBackend("backend1");
+    }
+
+    @Test
+    void testDeactivateRemovesHealthWhenNoPreviousState()
+    {
+        when(routingManager.getBackEndHealth("backend1")).thenReturn(Optional.empty());
+        doThrow(new RuntimeException("routing update failed"))
+                .when(routingManager).updateBackEndHealth("backend1", TrinoStatus.UNKNOWN);
+
+        assertThatThrownBy(() -> manager.deactivateBackend("backend1"))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(routingManager).removeBackEndHealth("backend1");
+        verify(gatewayBackendManager).activateBackend("backend1");
+    }
+
+    // --- activateBackend ---
+
+    @Test
+    void testActivateHappyPath()
+    {
+        when(routingManager.getBackEndHealth("backend1")).thenReturn(Optional.of(TrinoStatus.UNKNOWN));
+
+        manager.activateBackend("backend1");
+
+        InOrder order = inOrder(gatewayBackendManager, routingManager, backendStateManager);
+        order.verify(gatewayBackendManager).activateBackend("backend1");
+        order.verify(routingManager).updateBackEndHealth("backend1", TrinoStatus.PENDING);
+        order.verify(backendStateManager).updateStates(eq("backend1"), any(ClusterStats.class));
+    }
+
+    @Test
+    void testActivateCompensatesWhenRoutingManagerFails()
+    {
+        when(routingManager.getBackEndHealth("backend1")).thenReturn(Optional.of(TrinoStatus.UNKNOWN));
+        doThrow(new RuntimeException("routing update failed"))
+                .when(routingManager).updateBackEndHealth("backend1", TrinoStatus.PENDING);
+
+        assertThatThrownBy(() -> manager.activateBackend("backend1"))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(routingManager).updateBackEndHealth("backend1", TrinoStatus.UNKNOWN);
+        verify(gatewayBackendManager).deactivateBackend("backend1");
+    }
+
+    @Test
+    void testActivateCompensatesWhenBackendStateManagerFails()
+    {
+        when(routingManager.getBackEndHealth("backend1")).thenReturn(Optional.of(TrinoStatus.UNKNOWN));
+        doThrow(new RuntimeException("state update failed"))
+                .when(backendStateManager).updateStates(eq("backend1"), any(ClusterStats.class));
+
+        assertThatThrownBy(() -> manager.activateBackend("backend1"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("state update failed");
+
+        verify(routingManager).updateBackEndHealth("backend1", TrinoStatus.UNKNOWN);
+        verify(gatewayBackendManager).deactivateBackend("backend1");
+    }
+
+    @Test
+    void testActivateRemovesHealthWhenNoPreviousState()
+    {
+        when(routingManager.getBackEndHealth("backend1")).thenReturn(Optional.empty());
+        doThrow(new RuntimeException("routing update failed"))
+                .when(routingManager).updateBackEndHealth("backend1", TrinoStatus.PENDING);
+
+        assertThatThrownBy(() -> manager.activateBackend("backend1"))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(routingManager).removeBackEndHealth("backend1");
+        verify(gatewayBackendManager).deactivateBackend("backend1");
+    }
+
+    // --- addBackend ---
+
+    @Test
+    void testAddBackendHappyPath()
+    {
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("backend1");
+        backend.setActive(true);
+        when(gatewayBackendManager.addBackend(backend)).thenReturn(backend);
+
+        manager.addBackend(backend);
+
+        InOrder order = inOrder(gatewayBackendManager, routingManager, backendStateManager);
+        order.verify(gatewayBackendManager).addBackend(backend);
+        order.verify(routingManager).updateBackEndHealth("backend1", TrinoStatus.PENDING);
+        order.verify(backendStateManager).updateStates(eq("backend1"), any(ClusterStats.class));
+    }
+
+    @Test
+    void testAddBackendCompensatesWhenRoutingManagerFails()
+    {
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("backend1");
+        backend.setActive(true);
+        when(gatewayBackendManager.addBackend(backend)).thenReturn(backend);
+        doThrow(new RuntimeException("routing update failed"))
+                .when(routingManager).updateBackEndHealth(eq("backend1"), any(TrinoStatus.class));
+
+        assertThatThrownBy(() -> manager.addBackend(backend))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(gatewayBackendManager).deleteBackend("backend1");
+    }
+
+    @Test
+    void testAddBackendCompensatesWhenBackendStateManagerFails()
+    {
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("backend1");
+        backend.setActive(true);
+        when(gatewayBackendManager.addBackend(backend)).thenReturn(backend);
+        doThrow(new RuntimeException("state update failed"))
+                .when(backendStateManager).updateStates(eq("backend1"), any(ClusterStats.class));
+
+        assertThatThrownBy(() -> manager.addBackend(backend))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(gatewayBackendManager).deleteBackend("backend1");
+    }
+
+    // --- updateBackend ---
+
+    @Test
+    void testUpdateBackendHappyPath()
+    {
+        ProxyBackendConfiguration oldBackend = new ProxyBackendConfiguration();
+        oldBackend.setName("backend1");
+        oldBackend.setActive(false);
+
+        ProxyBackendConfiguration newBackend = new ProxyBackendConfiguration();
+        newBackend.setName("backend1");
+        newBackend.setActive(true);
+
+        when(gatewayBackendManager.getBackendByName("backend1")).thenReturn(Optional.of(oldBackend));
+        when(routingManager.getBackEndHealth("backend1")).thenReturn(Optional.of(TrinoStatus.UNKNOWN));
+        when(gatewayBackendManager.updateBackend(newBackend)).thenReturn(newBackend);
+
+        manager.updateBackend(newBackend);
+
+        InOrder order = inOrder(gatewayBackendManager, routingManager, backendStateManager);
+        order.verify(gatewayBackendManager).updateBackend(newBackend);
+        order.verify(routingManager).updateBackEndHealth("backend1", TrinoStatus.PENDING);
+        order.verify(backendStateManager).updateStates(eq("backend1"), any(ClusterStats.class));
+    }
+
+    @Test
+    void testUpdateBackendCompensatesWhenInMemoryUpdateFails()
+    {
+        ProxyBackendConfiguration oldBackend = new ProxyBackendConfiguration();
+        oldBackend.setName("backend1");
+        oldBackend.setActive(false);
+
+        ProxyBackendConfiguration newBackend = new ProxyBackendConfiguration();
+        newBackend.setName("backend1");
+        newBackend.setActive(true);
+
+        when(gatewayBackendManager.getBackendByName("backend1")).thenReturn(Optional.of(oldBackend));
+        when(routingManager.getBackEndHealth("backend1")).thenReturn(Optional.of(TrinoStatus.UNKNOWN));
+        when(gatewayBackendManager.updateBackend(newBackend)).thenReturn(newBackend);
+        doThrow(new RuntimeException("routing update failed"))
+                .when(routingManager).updateBackEndHealth(eq("backend1"), any(TrinoStatus.class));
+
+        assertThatThrownBy(() -> manager.updateBackend(newBackend))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(gatewayBackendManager).updateBackend(oldBackend);
+    }
+
+    @Test
+    void testUpdateBackendDoesNotCompensateWhenNoOldBackendExists()
+    {
+        ProxyBackendConfiguration newBackend = new ProxyBackendConfiguration();
+        newBackend.setName("backend1");
+        newBackend.setActive(true);
+
+        when(gatewayBackendManager.getBackendByName("backend1")).thenReturn(Optional.empty());
+        when(routingManager.getBackEndHealth("backend1")).thenReturn(Optional.of(TrinoStatus.UNKNOWN));
+        when(gatewayBackendManager.updateBackend(newBackend)).thenReturn(newBackend);
+        doThrow(new RuntimeException("routing update failed"))
+                .when(routingManager).updateBackEndHealth(eq("backend1"), any(TrinoStatus.class));
+
+        assertThatThrownBy(() -> manager.updateBackend(newBackend))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(gatewayBackendManager, times(1)).updateBackend(newBackend);
+    }
+
+    // --- deleteBackend ---
+
+    @Test
+    void testDeleteBackendHappyPath()
+    {
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("backend1");
+
+        when(gatewayBackendManager.getBackendByName("backend1")).thenReturn(Optional.of(backend));
+        when(routingManager.getBackEndHealth("backend1")).thenReturn(Optional.of(TrinoStatus.HEALTHY));
+
+        manager.deleteBackend("backend1");
+
+        InOrder order = inOrder(gatewayBackendManager, routingManager, backendStateManager);
+        order.verify(gatewayBackendManager).deleteBackend("backend1");
+        order.verify(routingManager).removeBackEndHealth("backend1");
+        order.verify(backendStateManager).removeStates("backend1");
+    }
+
+    @Test
+    void testDeleteBackendCompensatesWhenRoutingManagerCleanupFails()
+    {
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("backend1");
+
+        when(gatewayBackendManager.getBackendByName("backend1")).thenReturn(Optional.of(backend));
+        when(routingManager.getBackEndHealth("backend1")).thenReturn(Optional.of(TrinoStatus.HEALTHY));
+        doThrow(new RuntimeException("cleanup failed"))
+                .when(routingManager).removeBackEndHealth("backend1");
+
+        assertThatThrownBy(() -> manager.deleteBackend("backend1"))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(routingManager).updateBackEndHealth("backend1", TrinoStatus.HEALTHY);
+        verify(gatewayBackendManager).addBackend(backend);
+    }
+
+    @Test
+    void testDeleteBackendCompensatesWhenBackendStateManagerRemoveFails()
+    {
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("backend1");
+
+        when(gatewayBackendManager.getBackendByName("backend1")).thenReturn(Optional.of(backend));
+        when(routingManager.getBackEndHealth("backend1")).thenReturn(Optional.of(TrinoStatus.HEALTHY));
+        doThrow(new RuntimeException("state removal failed"))
+                .when(backendStateManager).removeStates("backend1");
+
+        assertThatThrownBy(() -> manager.deleteBackend("backend1"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("state removal failed");
+
+        verify(routingManager).updateBackEndHealth("backend1", TrinoStatus.HEALTHY);
+        verify(gatewayBackendManager).addBackend(backend);
+    }
+
+    @Test
+    void testDeleteBackendDoesNotCompensateWhenNoOldBackendExists()
+    {
+        when(gatewayBackendManager.getBackendByName("backend1")).thenReturn(Optional.empty());
+        when(routingManager.getBackEndHealth("backend1")).thenReturn(Optional.of(TrinoStatus.HEALTHY));
+        doThrow(new RuntimeException("cleanup failed"))
+                .when(routingManager).removeBackEndHealth("backend1");
+
+        assertThatThrownBy(() -> manager.deleteBackend("backend1"))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(gatewayBackendManager, never()).addBackend(any());
+    }
+
+    // --- compensation mechanism ---
+
+    @Test
+    void testCompensationFailureAttachesSuppressedException()
+    {
+        when(routingManager.getBackEndHealth("backend1")).thenReturn(Optional.of(TrinoStatus.HEALTHY));
+        RuntimeException primary = new RuntimeException("routing update failed");
+        doThrow(primary)
+                .when(routingManager).updateBackEndHealth("backend1", TrinoStatus.UNKNOWN);
+        doThrow(new RuntimeException("rollback failed"))
+                .when(gatewayBackendManager).activateBackend("backend1");
+
+        assertThatThrownBy(() -> manager.deactivateBackend("backend1"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("routing update failed")
+                .satisfies(e -> {
+                    assertThatThrownBy(() -> {
+                        throw e.getSuppressed()[e.getSuppressed().length - 1];
+                    })
+                            .hasMessage("rollback failed");
+                });
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestBackendStateManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestBackendStateManager.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import io.trino.gateway.ha.clustermonitor.ClusterStats;
+import io.trino.gateway.ha.clustermonitor.TrinoStatus;
+import io.trino.gateway.ha.config.ProxyBackendConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.weakref.jmx.MBeanExporter;
+
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+final class TestBackendStateManager
+{
+    private MBeanExporter exporter;
+    private BackendStateManager backendStateManager;
+
+    @BeforeEach
+    void setUp()
+    {
+        exporter = MBeanExporter.withPlatformMBeanServer();
+        backendStateManager = new BackendStateManager(exporter);
+    }
+
+    @AfterEach
+    void tearDown()
+    {
+        exporter.unexportAll();
+    }
+
+    @Test
+    void testRemoveStatesUnexportsJmxBean()
+    {
+        String clusterId = "test-cluster";
+        ClusterStats stats = ClusterStats.builder(clusterId)
+                .trinoStatus(TrinoStatus.HEALTHY)
+                .runningQueryCount(5)
+                .queuedQueryCount(2)
+                .numWorkerNodes(10)
+                .build();
+
+        backendStateManager.updateStates(clusterId, stats);
+
+        assertThat(exporter.getExportedObjects()).hasSize(1);
+
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName(clusterId);
+        assertThat(backendStateManager.getBackendState(backend).trinoStatus()).isEqualTo(TrinoStatus.HEALTHY);
+
+        backendStateManager.removeStates(clusterId);
+
+        assertThat(exporter.getExportedObjects()).isEmpty();
+        assertThat(backendStateManager.getBackendState(backend).trinoStatus()).isEqualTo(TrinoStatus.UNKNOWN);
+    }
+
+    @Test
+    void testRemoveStatesForNonexistentClusterDoesNotThrow()
+    {
+        assertThatNoException().isThrownBy(() -> backendStateManager.removeStates("nonexistent"));
+    }
+
+    @Test
+    void testConcurrentUpdateAndRemoveLeavesConsistentState()
+            throws Exception
+    {
+        String clusterId = "concurrent-cluster";
+        int iterations = 20;
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            for (int i = 0; i < iterations; i++) {
+                backendStateManager.updateStates(
+                        clusterId,
+                        ClusterStats.builder(clusterId).trinoStatus(TrinoStatus.HEALTHY).build());
+
+                CyclicBarrier barrier = new CyclicBarrier(2);
+
+                Future<?> updater = executor.submit(() -> {
+                    barrier.await(5, TimeUnit.SECONDS);
+                    backendStateManager.updateStates(
+                            clusterId,
+                            ClusterStats.builder(clusterId).trinoStatus(TrinoStatus.PENDING).build());
+                    return null;
+                });
+
+                Future<?> remover = executor.submit(() -> {
+                    barrier.await(5, TimeUnit.SECONDS);
+                    backendStateManager.removeStates(clusterId);
+                    return null;
+                });
+
+                updater.get(5, TimeUnit.SECONDS);
+                remover.get(5, TimeUnit.SECONDS);
+
+                ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+                backend.setName(clusterId);
+                ClusterStats state = backendStateManager.getBackendState(backend);
+                int exportedCount = exporter.getExportedObjects().size();
+
+                // Either both exist (update won) or neither exists (remove won)
+                boolean stateExists = state.trinoStatus() != TrinoStatus.UNKNOWN;
+                boolean jmxExists = exportedCount > 0;
+                assertThat(stateExists)
+                        .as("iteration %d: clusterStats and JMX must agree", i)
+                        .isEqualTo(jmxExists);
+
+                backendStateManager.removeStates(clusterId);
+            }
+        }
+        finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/gateway-ha/src/test/resources/test-config-no-monitor-template.yml
+++ b/gateway-ha/src/test/resources/test-config-no-monitor-template.yml
@@ -1,0 +1,20 @@
+serverConfig:
+  node.environment: test
+  http-server.http.port: ${ENV:REQUEST_ROUTER_PORT}
+
+includeClusterHostInResponse: true
+dataStore:
+  jdbcUrl: ${ENV:POSTGRESQL_JDBC_URL}
+  user: ${ENV:POSTGRESQL_USER}
+  password: ${ENV:POSTGRESQL_PASSWORD}
+  driver: org.postgresql.Driver
+
+clusterStatsConfiguration:
+  monitorType: INFO_API
+
+monitor:
+  taskDelay: 1h
+
+gatewayCookieConfiguration:
+  enabled: true
+  cookieSigningSecret: "kjlhbfrewbyuo452cds3dc1234ancdsjh"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The gateway maintains 2 tiers of state:

Database (source of truth): on every routing request, the list of active backends is queried fresh from the DB
In-memory `RoutingManager.backendToStatus` (health cache): a `ConcurrentHashMap<String, TrinoStatus>` that is only updated by `ActiveClusterMonitor`, which runs on a configurable schedule (default 60 seconds)
At request time, routing works as a 2-step filter:

- `getActiveBackends(routingGroup)`: fresh DB query (always current)
- `removeIf(isBackendNotHealthy())`: checks in-memory health cache (stale by up to 60 seconds)
- route to selected backend

Only backends with `TrinoStatus.HEALTHY` in the cache are routable. A null entry or anything other than HEALTHY causes the backend to be filtered out.

There are 5 write endpoints for the API role.

1. `/gateway/backend/modify/add`
2. `/gateway/backend/modify/update`
3. `/gateway/backend/modify/delete`
4. `/gateway/backend/activate/{name}`
5. `/gateway/backend/deactivate/{name}`

However, the problem is that these API role endpoints only write to the database; they DO NOT update the `RoutingManager`'s in-memory `backendToStatus` health cache. Therefore, this causes several corner cases, where the gateway's routing decisions is inconsistent with the DB state.

Corner case 1

`gateway/backend/modify/update`: stale HEALTHY after URL change
Suppose a backend's URL is updated (e.g. points to a new cluster), but the in-memory `backendToStatus` still holds the old HEALTHY status from the previous health check against the old URL. THe gateway will route traffic to this new URL as if it were confirmed healthy, when it might actually be unreachable / broken. Requests will fail up to 60 seconds until the new health check occurs.

Corner case 2

`gateway/backend/deactivate/{name}`: stale HEALTHY survives into the next activation
Suppose a backend is deactivated, the DB immediately excludes it from future `getActiveBackends()` queries, so routing is correct in the short term. However, `backendToStatus` retains the last HEALTHY entry, and `ActiveClusterMonitor` only monitors active backends. Therefore, once deactivated, the backend's health entry is never updated again. This stale HEALTHY entry becomes a problem when the backend is later reactivated. It will re-enter `getActiveBackends()` results, and upon finding the stale HEALTHY entry, the gateway may immediately route traffic to it with any new health verification.

The list of corner cases is not comprehensive, but just gives you an idea. 

The ADMIN role endpoint `/entity?entityType=GATEWAY_BACKEND` prevents this inconsistency, by updating both the DB AND the in-memory `backendToStatus` health cache. It sets the backend's status to PENDING, which will prevent the gateway from routing requests to it until the next periodic health check returns HEALTHY.

This PR copies the logic from the ADMIN role endpoint, over to the API role endpoints.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino-gateway/issues/1018



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
