### PR TITLE
Set default charset to utf8

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/TrinoQueryProperties.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/TrinoQueryProperties.java
@@ -273,10 +273,10 @@ public class TrinoQueryProperties
 
         String charset = mediaType.getParameters().get("charset");
         if (charset == null) {
-            log.debug("charset is not set in the request");
-            return;
+            // RFC 7231 leaves the default charset to the recipient; Trino's coordinator
+            // decodes statement bodies as UTF-8, and most Trino clients omit the parameter.
+            charset = UTF_8.name();
         }
-
         if (!UTF_8.name().equalsIgnoreCase(charset)) {
             log.debug("Request charset is not UTF-8 (%s), skipping query parsing", charset);
             return;

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestTrinoQueryProperties.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestTrinoQueryProperties.java
@@ -489,13 +489,49 @@ final class TestTrinoQueryProperties
         assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
     }
 
+    @Test
+    void testQueryParsingWhenContentTypeHasNoCharset()
+            throws IOException
+    {
+        String query = "SELECT * FROM mycatalog.myschema.mytable";
+        ContainerRequestContext mockRequest = prepareMockRequest(query, MediaType.valueOf("application/json"));
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // Trino HTTP clients commonly omit the charset parameter; treat the body as UTF-8 so routing rules still see the parsed query.
+        assertThat(trinoQueryProperties.getCatalogs()).containsExactly("mycatalog");
+        assertThat(trinoQueryProperties.getSchemas()).containsExactly("myschema");
+        assertThat(trinoQueryProperties.getTables()).hasSize(1);
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testQueryParsingSkippedForNonUtf8Charset()
+            throws IOException
+    {
+        String query = "SELECT * FROM mycatalog.myschema.mytable";
+        ContainerRequestContext mockRequest = prepareMockRequest(query, MediaType.valueOf("application/json; charset=ISO-8859-1"));
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // An explicit non-UTF-8 charset is still skipped, since the body bytes cannot be safely decoded as UTF-8.
+        assertThat(trinoQueryProperties.getBody()).isEmpty();
+        assertThat(trinoQueryProperties.getCatalogs()).isEmpty();
+        assertThat(trinoQueryProperties.getSchemas()).isEmpty();
+        assertThat(trinoQueryProperties.getTables()).isEmpty();
+    }
+
     private ContainerRequestContext prepareMockRequest(String query)
+    {
+        return prepareMockRequest(query, MediaType.valueOf("application/json; charset=UTF-8"));
+    }
+
+    private ContainerRequestContext prepareMockRequest(String query, MediaType mediaType)
     {
         ContainerRequestContext mockRequest = mock(ContainerRequestContext.class);
         when(mockRequest.getMethod()).thenReturn(HttpMethod.POST);
         when(mockRequest.hasEntity()).thenReturn(true);
 
-        MediaType mediaType = MediaType.valueOf("application/json; charset=UTF-8");
         when(mockRequest.getMediaType()).thenReturn(mediaType);
 
         InputStream entityStream = new ByteArrayInputStream(query.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Set default charset to utf8

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

- https://github.com/trinodb/trino-gateway/issues/1032

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix SQL analysis failure when default charset is not set.
```
