### PR TITLE
Correct property name in release notes for version 19

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -25,9 +25,9 @@ Changes:
   directly.
   ([#656](https://github.com/trinodb/trino-gateway/issues/656))
 * [:warning: Breaking change:](#breaking) Rename routing configuration
-  `addXForwardedHeaders` to `addForwardedHeaders`.
+  `addXForwardedHeaders` to `forwardedHeadersEnabled`.
   ([#1005](https://github.com/trinodb/trino-gateway/pull/1005))
-* Fix HTTP header forwarding when `routing.addForwardedHeaders` is set to
+* Fix HTTP header forwarding when `routing.forwardedHeadersEnabled` is set to
   `false` to properly drop both the modern RFC 7239 `Forwarded` and the legacy
   `X-Forwarded-*` HTTP headers.
   ([#1005](https://github.com/trinodb/trino-gateway/pull/1005))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
 Correct the config property name in the notes for release version 19


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
This property was renamed twice in 2 different PRs and so I am using the name from the last one in PR
https://github.com/trinodb/trino-gateway/pull/1005

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Correct the config property name in the notes - `forwardedHeadersEnabled` instead of `addForwardedHeaders`
```
