### PR TITLE
Add Trino Gateway 20 release notes

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,7 +21,7 @@ It  copies the following, necessary files to current directory:
 ```shell
 #!/usr/bin/env sh
 
-VERSION=19
+VERSION=20
 BASE_URL="https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha"
 JAR_FILE="gateway-ha-$VERSION-jar-with-dependencies.jar"
 GATEWAY_JAR="gateway-ha.jar"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -44,7 +44,10 @@ Changes:
   ([#1003](https://github.com/trinodb/trino-gateway/pull/1003))
 
 More details and a list of all merged pull requests are [available in the
-milestone 19 list](https://github.com/trinodb/trino-gateway/pulls?q=is%3Apr+milestone%3A19+is%3Aclosed).
+milestone 19
+list](https://github.com/trinodb/trino-gateway/pulls?q=is%3Apr+milestone%3A19+is%3Aclosed)
+and the [GitHub release section for version
+19](https://github.com/trinodb/trino-gateway/releases/tag/19).
 
 ### Trino Gateway 18 (4 Mar 2026) { id="18" }
 
@@ -76,7 +79,10 @@ Changes:
   ([#805](https://github.com/trinodb/trino-gateway/pull/805))
 
 More details and a list of all merged pull requests are [available in the
-milestone 18 list](https://github.com/trinodb/trino-gateway/pulls?q=is%3Apr+milestone%3A18+is%3Aclosed).
+milestone 18
+list](https://github.com/trinodb/trino-gateway/pulls?q=is%3Apr+milestone%3A18+is%3Aclosed)
+and the [GitHub release section for version
+18](https://github.com/trinodb/trino-gateway/releases/tag/18).
 
 ### Trino Gateway 17 (31 Jan 2026) { id="17" }
 
@@ -120,7 +126,10 @@ Changes:
   ([#788](https://github.com/trinodb/trino-gateway/pull/788))
 
 More details and a list of all merged pull requests are [available in the
-milestone 17 list](https://github.com/trinodb/trino-gateway/pulls?q=is%3Apr+milestone%3A17+is%3Aclosed).
+milestone 17
+list](https://github.com/trinodb/trino-gateway/pulls?q=is%3Apr+milestone%3A17+is%3Aclosed)
+and the [GitHub release section for version
+17](https://github.com/trinodb/trino-gateway/releases/tag/17).
 
 ## 2025
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,35 @@
 
 ## 2026
 
+### Trino Gateway 20 (25 Jun 2026) { id="20" }
+
+Artifacts:
+
+* [JAR file gateway-ha-20-jar-with-dependencies.jar](https://repo1.maven.org/maven2/io/trino/gateway/gateway-ha/20/gateway-ha-20-jar-with-dependencies.jar)
+* Container image `trinodb/trino-gateway:20`
+* Source code as
+  [tar.gz](https://github.com/trinodb/trino-gateway/archive/refs/tags/20.tar.gz)
+  or [zip](https://github.com/trinodb/trino-gateway/archive/refs/tags/20.zip)
+* [Trino Helm chart](https://trinodb.github.io/charts/) `trino/trino-gateway` version `1.20.0`
+
+Changes:
+
+**General**
+
+* Fix runtime Jetty compression failures with the Docker image.
+  ([#1094](https://github.com/trinodb/trino-gateway/pull/1094))
+* Improve security of the `/webapp/findQueryHistory` endpoint.
+  ([#991](https://github.com/trinodb/trino-gateway/issues/991))
+* Prevent silent routing mistakes for `SHOW BRANCHES`, `CREATE`/`DROP BRANCH`,
+  `REFRESH VIEW`, and column `SET`/`DROP DEFAULT` statements.
+  ([#1121](https://github.com/trinodb/trino-gateway/pull/1121))
+
+More details and a list of all merged pull requests are [available in the
+milestone 20
+list](https://github.com/trinodb/trino-gateway/pulls?q=is%3Apr+milestone%3A20+is%3Aclosed)
+and the [GitHub release section for version
+20](https://github.com/trinodb/trino-gateway/releases/tag/20).
+
 ### Trino Gateway 19 (11 May 2026) { id="19" }
 
 Artifacts:


### PR DESCRIPTION
## Description

Assemble the release notes for Trino Gateway 20 release and adjust rest of docs to version 20.

Release date will be set to the planned date following our monthly release cadence after dev sync discussion and agreement

## Additional context and related issues

* Helm chart release PR to merge after the release at https://github.com/trinodb/charts/pull/425

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Verification for each pull request

Format: PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

Any dates missing in the list just had no merged PRs.

## 11 May 2026

* #1066 ✅ rn ✅ docs

## 12 May 2026

* #1067 ✅ rn ✅ docs

## 13 May 2026

* #1068 ✅ rn ✅ docs
* #1069 ✅ rn ✅ docs

## 14 May 2026

* #1071 ✅ rn ✅ docs
* #1072 ✅ rn ✅ docs

## 17 May 2026

* #1073 ✅ rn ✅ docs
* #1074 ✅ rn ✅ docs
* #1075 ✅ rn ✅ docs
* #1076 ✅ rn ✅ docs
* #1077 ✅ rn ✅ docs
* #1078 ✅ rn ✅ docs
* #1079 ✅ rn ✅ docs
* #1080 ✅ rn ✅ docs
* #1081 ✅ rn ✅ docs
* #1082 ✅ rn ✅ docs

## 19 May 2026

* #1083 ✅ rn ✅ docs


## 20 May 2026

* #1084 ✅ rn ✅ docs

## 21 May 2026

* #999 ✅ rn ✅ docs
* #1085 ✅ rn ✅ docs

## 24 May 2026

* #1086 ✅ rn ✅ docs
* #1088 ✅ rn ✅ docs
* #1089 ✅ rn ✅ docs
* #1090 ✅ rn ✅ docs
* #1091 ✅ rn ✅ docs
* #1087 ✅ rn ✅ docs

## 25 May 2026

* #1092 ✅ rn ✅ docs

## 26 May 2026

* #1093 ✅ rn ✅ docs

## 27 May 2026

* #1094 ✅ rn ✅ docs

## 28 May 2026

* #1095 ✅ rn ✅ docs

## 29 May 2026

* #1096 ✅ rn ✅ docs

## 31 May 2026

* #1103 ✅ rn ✅ docs
* #1102 ✅ rn ✅ docs
* #1101 ✅ rn ✅ docs
* #1100 ✅ rn ✅ docs
* #1099 ✅ rn ✅ docs
* #1098 ✅ rn ✅ docs
* #1097 ✅ rn ✅ docs

## 02 Jun 2026

* #1104 ✅ rn ✅ docs

## 03 Jun 2026

* #1106 ✅ rn ✅ docs
* #1105 ✅ rn ✅ docs

## 07 Jun 2026

* #1110 ✅ rn ✅ docs
* #1109 ✅ rn ✅ docs
* #1108 ✅ rn ✅ docs
* #1115 ✅ rn ✅ docs
* #1114 ✅ rn ✅ docs
* #1113 ✅ rn ✅ docs
* #1112 ✅ rn ✅ docs
* #1059 ✅ rn ✅ docs

## 09 Jun 2026

* #1117 ✅ rn ✅ docs

## 11 Jun 2026

* #1120 ✅ rn ✅ docs
* #1119 ✅ rn ✅ docs
* #1118 ✅ rn ✅ docs

## 14 Jun 2026

* #1127 ✅ rn ✅ docs
* #1126 ✅ rn ✅ docs
* #1125 ✅ rn ✅ docs
* #1124 ✅ rn ✅ docs
* #1123 ✅ rn ✅ docs
* #1122 ✅ rn ✅ docs
* #1128 ✅ rn ✅ docs

## 16 Jun 2026

* #1129 ✅ rn ✅ docs
* #1116 ✅ rn ✅ docs

## 17 Jun 2026

* #1121 ✅ rn ✅ docs

## 18 Jun 2026

* #1111 ✅ rn ✅ docs
* #1130 ✅ rn ✅ docs

## 21 Jun 2026

* #1131 ✅ rn ✅ docs
* #1132 ✅ rn ✅ docs
* #1133 ✅ rn ✅ docs
* #1134 ✅ rn ✅ docs
* #1135 ✅ rn ✅ docs
* #1136 ✅ rn ✅ docs
* #1139 ✅ rn ✅ docs
* #1140 ✅ rn ✅ docs
* #1141 ✅ rn ✅ docs

## 22 Jun 2026

* #1144 ✅ rn ✅ docs

## 25 Jun 2026

* #1146 ✅ rn ✅ docs

