### PR TITLE
Add missing libstdc++ dependency in runtime docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,8 @@ RUN \
     dnf update -y && \
     dnf install --installroot /tmp/overlay --setopt install_weak_deps=false --nodocs -y \
       less \
-      zlib `#required by java` \
+      libstdc++ `# required by Brotli native library` \
+      zlib `# required by java` \
       curl-minimal grep `# required by health-check` \
       shadow-utils `# required by useradd` \
       tar `# required to support kubectl cp` && \


### PR DESCRIPTION
## Description
Since the migration from `ubi-minimal` to `ubi-micro`, the runtime image no longer contains the `libstdc++` runtime library required by the Brotli native library (for Jetty compression).

This causes gateway startup failures with:
```
2026-05-24T09:03:58.935Z        ERROR   main    io.airlift.http.server.HttpServer       Error loading http server compression
java.util.ServiceConfigurationError: org.eclipse.jetty.compression.Compression: Provider org.eclipse.jetty.compression.brotli.BrotliCompression could not be instantiated
...
Caused by: java.lang.UnsatisfiedLinkError: Failed to load Brotli native library...
...
Caused by: java.lang.UnsatisfiedLinkError: Caused by: java.lang.UnsatisfiedLinkError: /tmp/com_aayushatharva_brotli4j_175362864808270/libbrotli.so: libstdc++.so.6: cannot open shared object file: No such file or directorylibbrotli.so: libstdc++.so.6: cannot open shared object file: No such file or directory
```

The fix seems to be adding the `libstdc++` package to the overlay installed in the Dockerfile.
I tested it out by building the new image (for `arm64` only) and making sure the errors no longer appear.

## Additional context and related issues
The issue appears to have been introduced after the migration from
```
registry.access.redhat.com/ubi9/ubi-minimal:latest
```
to:
```
registry.access.redhat.com/ubi10/ubi-micro:latest
```
in PR #779 (officially since gateway v17)

## Release notes

() This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required, with the following suggested text:

```markdown
* Fix missing `libstdc++.so.6` runtime error by adding `libstdc++` to Docker image for Brotli native library support.
```
