### PR TITLE
Parse statement bodies without explicit charset

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/PathFilter.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/PathFilter.java
@@ -70,7 +70,7 @@ public class PathFilter
      */
     public boolean isPathWhiteListed(String path)
     {
-        return statementPaths.stream().anyMatch(path::startsWith)
+        return isStatementPath(path)
                 || path.startsWith(V1_QUERY_PATH)
                 || path.startsWith(TRINO_UI_PATH)
                 || path.startsWith(V1_INFO_PATH)
@@ -78,5 +78,10 @@ public class PathFilter
                 || path.startsWith(UI_API_STATS_PATH)
                 || path.startsWith(OAUTH_PATH)
                 || extraWhitelistPatterns.stream().anyMatch(pattern -> pattern.matcher(path).matches());
+    }
+
+    public boolean isStatementPath(String path)
+    {
+        return statementPaths.stream().anyMatch(path::startsWith);
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/TrinoQueryProperties.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/TrinoQueryProperties.java
@@ -154,6 +154,11 @@ public class TrinoQueryProperties
 
     public TrinoQueryProperties(ContainerRequestContext requestContext, boolean isClientsUseV2Format, int maxBodySize)
     {
+        this(requestContext, isClientsUseV2Format, maxBodySize, false);
+    }
+
+    public TrinoQueryProperties(ContainerRequestContext requestContext, boolean isClientsUseV2Format, int maxBodySize, boolean assumeUtf8WithoutExplicitCharset)
+    {
         requireNonNull(requestContext, "requestContext is null");
         this.isClientsUseV2Format = isClientsUseV2Format;
         this.maxBodySize = maxBodySize;
@@ -162,7 +167,7 @@ public class TrinoQueryProperties
         defaultSchema = Optional.ofNullable(requestContext.getHeaderString(TRINO_SCHEMA_HEADER_NAME));
         if (requestContext.getMethod().equals(HttpMethod.POST)) {
             isNewQuerySubmission = true;
-            processRequestBody(requestContext);
+            processRequestBody(requestContext, assumeUtf8WithoutExplicitCharset);
         }
     }
 
@@ -251,7 +256,7 @@ public class TrinoQueryProperties
         }
     }
 
-    private void processRequestBody(ContainerRequestContext requestContext)
+    private void processRequestBody(ContainerRequestContext requestContext, boolean assumeUtf8WithoutExplicitCharset)
     {
         if (!requestContext.hasEntity()) {
             return;
@@ -259,18 +264,25 @@ public class TrinoQueryProperties
 
         MediaType mediaType = requestContext.getMediaType();
         if (mediaType == null) {
-            return;
+            if (!assumeUtf8WithoutExplicitCharset) {
+                return;
+            }
+            log.debug("Content-Type is not set in the request, assuming UTF-8");
         }
+        else {
+            String charset = mediaType.getParameters().get("charset");
+            if (charset == null) {
+                if (!assumeUtf8WithoutExplicitCharset) {
+                    log.debug("charset is not set in the request");
+                    return;
+                }
+                log.debug("charset is not set in the request, assuming UTF-8");
+            }
 
-        String charset = mediaType.getParameters().get("charset");
-        if (charset == null) {
-            log.debug("charset is not set in the request");
-            return;
-        }
-
-        if (!UTF_8.name().equalsIgnoreCase(charset)) {
-            log.debug("Request charset is not UTF-8 (%s), skipping query parsing", charset);
-            return;
+            if (charset != null && !UTF_8.name().equalsIgnoreCase(charset)) {
+                log.debug("Request charset is not UTF-8 (%s), skipping query parsing", charset);
+                return;
+            }
         }
 
         InputStream entityStream = requestContext.getEntityStream();

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/QueryMetadataParser.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/QueryMetadataParser.java
@@ -65,6 +65,7 @@ public class QueryMetadataParser
         if (path == null || !isAnalyzeRequest || !pathFilter.isPathWhiteListed(path)) {
             return;
         }
+        boolean isStatementPath = pathFilter.isStatementPath(path);
 
         log.debug("Processing query metadata for path: %s", path);
         // Buffer the entity (aka body of the request) for future reads during request processing
@@ -73,7 +74,7 @@ public class QueryMetadataParser
 
         TrinoQueryProperties queryProps;
         try {
-            queryProps = new TrinoQueryProperties(requestContext, isClientsUseV2Format, maxBodySize);
+            queryProps = new TrinoQueryProperties(requestContext, isClientsUseV2Format, maxBodySize, isStatementPath);
         }
         catch (Exception ex) {
             log.warn(ex, "Failed to parse query properties for query text: [%s]. Error: %s. Using empty properties.",

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestPathFilter.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestPathFilter.java
@@ -72,11 +72,15 @@ class TestPathFilter
         assertThat(pathFilter.isPathWhiteListed(V1_STATEMENT_PATH)).isTrue();
         assertThat(pathFilter.isPathWhiteListed(V1_STATEMENT_PATH + "/executing")).isTrue();
         assertThat(pathFilter.isPathWhiteListed(V1_STATEMENT_PATH + "/queued")).isTrue();
+        assertThat(pathFilter.isStatementPath(V1_STATEMENT_PATH)).isTrue();
+        assertThat(pathFilter.isStatementPath(V1_STATEMENT_PATH + "/queued")).isTrue();
 
         // Test V2 statement path (from our configuration)
         assertThat(pathFilter.isPathWhiteListed("/v2/statement")).isTrue();
         assertThat(pathFilter.isPathWhiteListed("/v2/statement/query456")).isTrue();
         assertThat(pathFilter.isPathWhiteListed("/v2/statement/batch")).isTrue();
+        assertThat(pathFilter.isStatementPath("/v2/statement")).isTrue();
+        assertThat(pathFilter.isStatementPath("/v2/statement/batch")).isTrue();
     }
 
     @Test
@@ -102,6 +106,8 @@ class TestPathFilter
     void testNonWhitelistedPaths()
     {
         assertThat(pathFilter.isPathWhiteListed("/v3/statement")).isFalse(); // Not in our statement paths
+        assertThat(pathFilter.isStatementPath("/v3/statement")).isFalse(); // Not in our statement paths
+        assertThat(pathFilter.isStatementPath(V1_QUERY_PATH)).isFalse(); // Hardcoded non-statement path
         assertThat(pathFilter.isPathWhiteListed("/api/v2/custom/users")).isFalse(); // Doesn't match v1 pattern
         assertThat(pathFilter.isPathWhiteListed("/status")).isFalse(); // Not health/status
         assertThat(pathFilter.isPathWhiteListed("/metrics/extra")).isFalse(); // metrics is exact match only

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestTrinoQueryProperties.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestTrinoQueryProperties.java
@@ -482,13 +482,77 @@ final class TestTrinoQueryProperties
         assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
     }
 
+    @Test
+    void testStatementBodyWithoutContentTypeDefaultsToUtf8()
+    {
+        String query = "PREPARE my_query FROM SELECT 1";
+        ContainerRequestContext mockRequest = prepareMockRequest(query, null);
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024, true);
+
+        assertThat(trinoQueryProperties.getBody()).isEqualTo(query);
+        assertThat(trinoQueryProperties.getQueryType()).isEqualTo("Prepare");
+        assertThat(trinoQueryProperties.getResourceGroupQueryType()).isEqualTo("DATA_DEFINITION");
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testStatementBodyWithoutCharsetDefaultsToUtf8()
+    {
+        String query = "DESCRIBE OUTPUT my_query";
+        MediaType mediaType = MediaType.valueOf("text/plain");
+        ContainerRequestContext mockRequest = prepareMockRequest(query, mediaType);
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024, true);
+
+        assertThat(trinoQueryProperties.getBody()).isEqualTo(query);
+        assertThat(trinoQueryProperties.getQueryType()).isEqualTo("DescribeOutput");
+        assertThat(trinoQueryProperties.getResourceGroupQueryType()).isEqualTo("DESCRIBE");
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testStatementBodyWithExplicitNonUtf8CharsetSkipsParsing()
+    {
+        String query = "PREPARE my_query FROM SELECT 1";
+        MediaType mediaType = MediaType.valueOf("text/plain; charset=ISO-8859-1");
+        ContainerRequestContext mockRequest = prepareMockRequest(query, mediaType);
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024, true);
+
+        assertThat(trinoQueryProperties.getBody()).isEmpty();
+        assertThat(trinoQueryProperties.getQueryType()).isEmpty();
+        assertThat(trinoQueryProperties.getResourceGroupQueryType()).isEmpty();
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
+    @Test
+    void testMissingCharsetSkipsParsingWhenUtf8DefaultIsDisabled()
+    {
+        String query = "PREPARE my_query FROM SELECT 1";
+        MediaType mediaType = MediaType.valueOf("text/plain");
+        ContainerRequestContext mockRequest = prepareMockRequest(query, mediaType);
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        assertThat(trinoQueryProperties.getBody()).isEmpty();
+        assertThat(trinoQueryProperties.getQueryType()).isEmpty();
+        assertThat(trinoQueryProperties.getResourceGroupQueryType()).isEmpty();
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
+    }
+
     private ContainerRequestContext prepareMockRequest(String query)
+    {
+        MediaType mediaType = MediaType.valueOf("application/json; charset=UTF-8");
+        return prepareMockRequest(query, mediaType);
+    }
+
+    private ContainerRequestContext prepareMockRequest(String query, MediaType mediaType)
     {
         ContainerRequestContext mockRequest = mock(ContainerRequestContext.class);
         when(mockRequest.getMethod()).thenReturn(HttpMethod.POST);
         when(mockRequest.hasEntity()).thenReturn(true);
 
-        MediaType mediaType = MediaType.valueOf("application/json; charset=UTF-8");
         when(mockRequest.getMediaType()).thenReturn(mediaType);
 
         InputStream entityStream = new ByteArrayInputStream(query.getBytes(StandardCharsets.UTF_8));

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestQueryMetadataParser.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestQueryMetadataParser.java
@@ -141,9 +141,13 @@ final class TestQueryMetadataParser
 
         ArgumentCaptor<TrinoQueryProperties> captor = ArgumentCaptor.forClass(TrinoQueryProperties.class);
         verify(requestContext).setProperty(eq(TRINO_QUERY_PROPERTIES), captor.capture());
-        TrinoQueryProperties queryProperties = (TrinoQueryProperties) requestContext.getProperty(TRINO_QUERY_PROPERTIES);
-        assertThat(queryProperties).isEqualTo(null);
+        TrinoQueryProperties queryProperties = captor.getValue();
+        assertThat(queryProperties.getBody()).isEqualTo(query);
+        assertThat(queryProperties.getQueryType()).isEqualTo("Query");
+        assertThat(queryProperties.getResourceGroupQueryType()).isEqualTo("SELECT");
+        assertThat(queryProperties.isQueryParsingSuccessful()).isTrue();
         verify((ContainerRequest) requestContext).bufferEntity();
+        verify(requestContext).getEntityStream();
     }
 
     @Test
@@ -176,8 +180,11 @@ final class TestQueryMetadataParser
         verify((ContainerRequest) requestContext).bufferEntity();
         verify(requestContext).getEntityStream();
 
-        TrinoQueryProperties queryProperties = (TrinoQueryProperties) requestContext.getProperty(TRINO_QUERY_PROPERTIES);
-        assertThat(queryProperties).isEqualTo(null);
+        TrinoQueryProperties queryProperties = captor.getValue();
+        assertThat(queryProperties.getBody()).isEmpty();
+        assertThat(queryProperties.getQueryType()).isEmpty();
+        assertThat(queryProperties.getResourceGroupQueryType()).isEmpty();
+        assertThat(queryProperties.isQueryParsingSuccessful()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Default statement body parsing to UTF-8 when Content-Type is missing or lacks a charset.
- Keep explicit non-UTF-8 charsets skipped.

## Tests
- CI=true ./mvnw -pl gateway-ha -Dtest=TestTrinoQueryProperties,TestPathFilter,TestQueryMetadataParser test