### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,7 @@ body:
 
   - type: textarea
     attributes:
-      label: Please describe the bug
+      label: Description
       description: Describe the problem, minimal steps to reproduce, as well expected and actual behavior. If something fails, include a stacktrace.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,6 @@ body:
       value: |
         * Verify that the issue is not already reported, looking at the [currently open issues](https://github.com/trinodb/trino-gateway/issues), use the `Filter` field to narrow down your search.
         * **Possible security vulnerabilities**: STOP and contact `security@trino.io` instead!
-        * Do **NOT** share any sensitive information like passwords, security tokens, private URLs etc.
 
   - type: input
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,34 @@
+---
+name: Bug report 🐞
+description: Problems, bugs and issues with Trino Gateway
+type: Bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        * Verify that the issue is not already reported, looking at the [currently open issues](https://github.com/trinodb/trino-gateway/issues), use the `Filter` field to narrow down your search.
+        * **Possible security vulnerabilities**: STOP here and contact `security@trino.io` instead!
+        * Do **NOT** share any sensitive information like passwords, security tokens, private URLs etc.
+
+  - type: input
+    attributes:
+      label: Trino Gateway version
+      description: Which Trino Gateway version are you using?
+      placeholder: "For example, 14 or a specific commit hash"
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Trino version(s)
+      description: Which Trino server version(s) are routed by the gateway?
+      placeholder: "Run `SELECT version();` on a backend Trino cluster"
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Please describe the bug
+      description: Describe the problem, minimal steps to reproduce, expected and actual behaviors. If something fails, include the stacktrace. You can include additional files by dragging and dropping them here.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
   - type: input
     attributes:
       label: Trino version(s)
-      description: Which Trino server version(s) are routed by the gateway?
+      description: Which Trino server version(s) are fronted by Trino Gateway?
       placeholder: "Run `SELECT version();` on a backend Trino cluster"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         * Verify that the issue is not already reported, looking at the [currently open issues](https://github.com/trinodb/trino-gateway/issues), use the `Filter` field to narrow down your search.
-        * **Possible security vulnerabilities**: STOP here and contact `security@trino.io` instead!
+        * **Possible security vulnerabilities**: STOP and contact `security@trino.io` instead!
         * Do **NOT** share any sensitive information like passwords, security tokens, private URLs etc.
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,6 +29,6 @@ body:
   - type: textarea
     attributes:
       label: Please describe the bug
-      description: Describe the problem, minimal steps to reproduce, expected and actual behaviors. If something fails, include the stacktrace. You can include additional files by dragging and dropping them here.
+      description: Describe the problem, minimal steps to reproduce, as well expected and actual behavior. If something fails, include a stacktrace.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 ---
 name: Bug report 🐞
-description: Problems, bugs and issues with Trino Gateway
+description: Problems, bugs, and issues with Trino Gateway
 type: Bug
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Trino Gateway version
       description: Which Trino Gateway version are you using?
-      placeholder: "For example, 14 or a specific commit hash"
+      placeholder: "For example, 14"
     validations:
       required: true
 
@@ -24,7 +24,7 @@ body:
       description: Which Trino server version(s) are routed by the gateway?
       placeholder: "Run `SELECT version();` on a backend Trino cluster"
     validations:
-      required: false
+      required: true
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: Slack
+    url: https://trino.io/slack.html
+    about: Ask a question or get help in the #trino-gateway-dev channel on the Trino Slack
+  - name: Documentation
+    url: https://trinodb.github.io/trino-gateway
+    about: Read the Trino Gateway documentation

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,6 +11,6 @@ body:
   - type: textarea
     attributes:
       label: Feature Request / Improvement
-      description: Describe the requested feature and explain the use case.
+      description: Describe the requested feature or improvement, and explain the use case.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,7 +10,7 @@ body:
 
   - type: textarea
     attributes:
-      label: Feature Request / Improvement
+      label: Description
       description: Describe the requested feature or improvement, and explain the use case.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,12 +1,11 @@
 name: Feature request
-description: New features with Trino Gateway
+description: New features for Trino Gateway
 type: Feature
 body:
   - type: markdown
     attributes:
       value: |
         * Verify that the feature request is not already reported, looking at the [open and closed issues](https://github.com/trinodb/trino-gateway/issues), use the `Filter` field to narrow down your search.
-        * Do **NOT** share any sensitive information like passwords, security tokens, private URLs etc.
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        * Verify that the issue is not already reported, looking at the [currently open issues](https://github.com/trinodb/trino-gateway/issues), use the `Filter` field to narrow down your search.
+        * Verify that the feature request is not already reported, looking at the [open and closed issues](https://github.com/trinodb/trino-gateway/issues), use the `Filter` field to narrow down your search.
         * Do **NOT** share any sensitive information like passwords, security tokens, private URLs etc.
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,16 @@
+name: Feature request
+description: New features with Trino Gateway
+type: Feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        * Verify that the issue is not already reported, looking at the [currently open issues](https://github.com/trinodb/trino-gateway/issues), use the `Filter` field to narrow down your search.
+        * Do **NOT** share any sensitive information like passwords, security tokens, private URLs etc.
+
+  - type: textarea
+    attributes:
+      label: Feature Request / Improvement
+      description: Describe the requested feature and explain the use case.
+    validations:
+      required: true


### PR DESCRIPTION
## Description

Add GitHub issue forms under `.github/ISSUE_TEMPLATE/`, adapted from the main Trino repository, so new issues are filed with structured information instead of a blank editor. Adds:

- `bug_report.yml` — bug report form (Trino Gateway version + optional backend Trino version(s), description/repro).
- `feature_request.yml` — feature request form.
- `config.yml` — contact links to the Trino Slack (`#trino-gateway-dev`) and the Trino Gateway documentation.

Fixes #992

## Additional context and related issues

Templates are based on trinodb/trino's [`.github/ISSUE_TEMPLATE/`](https://github.com/trinodb/trino/tree/master/.github/ISSUE_TEMPLATE) and adapted to gateway terminology. The security-disclosure warning (`security@trino.io`) is retained.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
