### PR TITLE
Update org.apache.directory.api:api-all to 2.1.8

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>org.apache.directory.api</groupId>
             <artifactId>api-all</artifactId>
-            <version>2.1.7</version>
+            <version>2.1.8</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.servicemix.bundles</groupId>


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
