### PR TITLE
Fix routing rule classification of some statements

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -272,6 +272,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>26.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <version>9.7.0</version>

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/StatementUtils.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/StatementUtils.java
@@ -13,6 +13,7 @@
  */
 package io.trino.gateway.ha.router;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.airlift.log.Logger;
 import io.trino.sql.tree.AddColumn;
@@ -20,6 +21,7 @@ import io.trino.sql.tree.Analyze;
 import io.trino.sql.tree.Call;
 import io.trino.sql.tree.Comment;
 import io.trino.sql.tree.Commit;
+import io.trino.sql.tree.CreateBranch;
 import io.trino.sql.tree.CreateCatalog;
 import io.trino.sql.tree.CreateFunction;
 import io.trino.sql.tree.CreateMaterializedView;
@@ -33,8 +35,10 @@ import io.trino.sql.tree.Delete;
 import io.trino.sql.tree.Deny;
 import io.trino.sql.tree.DescribeInput;
 import io.trino.sql.tree.DescribeOutput;
+import io.trino.sql.tree.DropBranch;
 import io.trino.sql.tree.DropCatalog;
 import io.trino.sql.tree.DropColumn;
+import io.trino.sql.tree.DropDefaultValue;
 import io.trino.sql.tree.DropFunction;
 import io.trino.sql.tree.DropMaterializedView;
 import io.trino.sql.tree.DropNotNullConstraint;
@@ -44,6 +48,7 @@ import io.trino.sql.tree.DropTable;
 import io.trino.sql.tree.DropView;
 import io.trino.sql.tree.Explain;
 import io.trino.sql.tree.ExplainAnalyze;
+import io.trino.sql.tree.FastForwardBranch;
 import io.trino.sql.tree.Grant;
 import io.trino.sql.tree.GrantRoles;
 import io.trino.sql.tree.Insert;
@@ -51,6 +56,7 @@ import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.Prepare;
 import io.trino.sql.tree.Query;
 import io.trino.sql.tree.RefreshMaterializedView;
+import io.trino.sql.tree.RefreshView;
 import io.trino.sql.tree.RenameColumn;
 import io.trino.sql.tree.RenameMaterializedView;
 import io.trino.sql.tree.RenameSchema;
@@ -63,12 +69,14 @@ import io.trino.sql.tree.RevokeRoles;
 import io.trino.sql.tree.Rollback;
 import io.trino.sql.tree.SetAuthorizationStatement;
 import io.trino.sql.tree.SetColumnType;
+import io.trino.sql.tree.SetDefaultValue;
 import io.trino.sql.tree.SetPath;
 import io.trino.sql.tree.SetProperties;
 import io.trino.sql.tree.SetRole;
 import io.trino.sql.tree.SetSession;
 import io.trino.sql.tree.SetSessionAuthorization;
 import io.trino.sql.tree.SetTimeZone;
+import io.trino.sql.tree.ShowBranches;
 import io.trino.sql.tree.ShowCatalogs;
 import io.trino.sql.tree.ShowColumns;
 import io.trino.sql.tree.ShowCreate;
@@ -88,6 +96,7 @@ import io.trino.sql.tree.Update;
 import io.trino.sql.tree.Use;
 
 import java.util.Map;
+import java.util.Set;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.gateway.ha.router.QueryType.ALTER_TABLE_EXECUTE;
@@ -129,6 +138,7 @@ public final class StatementUtils
             .add(basicStatement(ShowSession.class, DESCRIBE))
             .add(basicStatement(ShowStats.class, DESCRIBE))
             .add(basicStatement(ShowTables.class, DESCRIBE))
+            .add(basicStatement(ShowBranches.class, DESCRIBE))
             // Table Procedure
             .add(basicStatement(TableExecute.class, ALTER_TABLE_EXECUTE))
             // DML
@@ -147,6 +157,7 @@ public final class StatementUtils
             .add(basicStatement(CreateMaterializedView.class, DATA_DEFINITION))
             .add(basicStatement(CreateCatalog.class, DATA_DEFINITION))
             .add(basicStatement(CreateFunction.class, DATA_DEFINITION))
+            .add(basicStatement(CreateBranch.class, DATA_DEFINITION))
             .add(basicStatement(CreateRole.class, DATA_DEFINITION))
             .add(basicStatement(CreateSchema.class, DATA_DEFINITION))
             .add(basicStatement(CreateTable.class, DATA_DEFINITION))
@@ -156,12 +167,15 @@ public final class StatementUtils
             .add(basicStatement(DropCatalog.class, DATA_DEFINITION))
             .add(basicStatement(DropColumn.class, DATA_DEFINITION))
             .add(basicStatement(DropFunction.class, DATA_DEFINITION))
+            .add(basicStatement(DropBranch.class, DATA_DEFINITION))
             .add(basicStatement(DropMaterializedView.class, DATA_DEFINITION))
             .add(basicStatement(DropRole.class, DATA_DEFINITION))
             .add(basicStatement(DropSchema.class, DATA_DEFINITION))
             .add(basicStatement(DropTable.class, DATA_DEFINITION))
             .add(basicStatement(DropView.class, DATA_DEFINITION))
             .add(basicStatement(TruncateTable.class, DATA_DEFINITION))
+            .add(basicStatement(FastForwardBranch.class, DATA_DEFINITION))
+            .add(basicStatement(RefreshView.class, DATA_DEFINITION))
             .add(basicStatement(Grant.class, DATA_DEFINITION))
             .add(basicStatement(GrantRoles.class, DATA_DEFINITION))
             .add(basicStatement(Prepare.class, DATA_DEFINITION))
@@ -176,6 +190,8 @@ public final class StatementUtils
             .add(basicStatement(RevokeRoles.class, DATA_DEFINITION))
             .add(basicStatement(Rollback.class, DATA_DEFINITION))
             .add(basicStatement(SetColumnType.class, DATA_DEFINITION))
+            .add(basicStatement(SetDefaultValue.class, DATA_DEFINITION))
+            .add(basicStatement(DropDefaultValue.class, DATA_DEFINITION))
             .add(basicStatement(DropNotNullConstraint.class, DATA_DEFINITION))
             .add(basicStatement(SetPath.class, DATA_DEFINITION))
             .add(basicStatement(SetRole.class, DATA_DEFINITION))
@@ -200,6 +216,12 @@ public final class StatementUtils
         }
         log.warn("Unsupported statement type: %s", statement.getClass());
         return "UNKNOWN";
+    }
+
+    @VisibleForTesting
+    static Set<Class<? extends Statement>> statementsWithKnownQueryType()
+    {
+        return STATEMENT_QUERY_TYPES.keySet();
     }
 
     private static <T extends Statement> StatementTypeInfo<T> basicStatement(Class<T> statementType, QueryType queryType)

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStatementUtils.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStatementUtils.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.ClassPath;
+import io.trino.sql.parser.SqlParser;
+import io.trino.sql.tree.Execute;
+import io.trino.sql.tree.ExecuteImmediate;
+import io.trino.sql.tree.ExplainAnalyze;
+import io.trino.sql.tree.Statement;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.trino.gateway.ha.router.StatementUtils.getResourceGroupQueryType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestStatementUtils
+{
+    private final SqlParser parser = new SqlParser();
+
+    // Excluded on purpose: ExplainAnalyze is resolved to its target query's type by
+    // getResourceGroupQueryType; Execute/ExecuteImmediate are unwrapped by the caller
+    // (TrinoQueryProperties) and, like upstream getQueryType, have no mapping of their own.
+    private static final Set<Class<? extends Statement>> UNMAPPED_BY_DESIGN =
+            ImmutableSet.<Class<? extends Statement>>builder()
+                    .add(Execute.class)
+                    .add(ExecuteImmediate.class)
+                    .add(ExplainAnalyze.class)
+                    .build();
+
+    @Test
+    void testCommonStatementsMapToResourceGroupQueryType()
+    {
+        assertResourceGroupQueryType("SELECT 1", "SELECT");
+        assertResourceGroupQueryType("CREATE TABLE t (a integer)", "DATA_DEFINITION");
+    }
+
+    @Test
+    void testBranchStatementsMapToResourceGroupQueryType()
+    {
+        // Branch DDL must be classified like the rest of Trino's StatementUtils
+        // so that queryType-based routing rules (e.g. resourceGroupQueryType == "DATA_DEFINITION") match.
+        assertResourceGroupQueryType("SHOW BRANCHES FROM TABLE t", "DESCRIBE");
+        assertResourceGroupQueryType("CREATE BRANCH b IN TABLE t", "DATA_DEFINITION");
+        assertResourceGroupQueryType("DROP BRANCH b IN TABLE t", "DATA_DEFINITION");
+        assertResourceGroupQueryType("ALTER BRANCH fb IN TABLE t FAST FORWARD TO tb", "DATA_DEFINITION");
+    }
+
+    @Test
+    void testRefreshViewMapsToResourceGroupQueryType()
+    {
+        assertResourceGroupQueryType("ALTER VIEW a REFRESH", "DATA_DEFINITION");
+    }
+
+    @Test
+    void testColumnDefaultValueStatementsMapToResourceGroupQueryType()
+    {
+        assertResourceGroupQueryType("ALTER TABLE foo.t ALTER COLUMN a SET DEFAULT 123", "DATA_DEFINITION");
+        assertResourceGroupQueryType("ALTER TABLE foo.t ALTER COLUMN a DROP DEFAULT", "DATA_DEFINITION");
+    }
+
+    // Drift guard: this map is a hand-maintained copy of io.trino.util.StatementUtils and silently
+    // returns "UNKNOWN" for any statement it forgot. When dep.trino.version is bumped and Trino adds
+    // a new Statement type, this fails instead of requiring a manual diff against upstream.
+    @Test
+    void testEveryStatementTypeIsClassified()
+            throws IOException
+    {
+        Set<Class<?>> discovered = ClassPath.from(Statement.class.getClassLoader())
+                .getTopLevelClasses("io.trino.sql.tree").stream()
+                .map(ClassPath.ClassInfo::load)
+                .filter(Statement.class::isAssignableFrom)
+                .filter(clazz -> !clazz.equals(Statement.class))
+                .filter(clazz -> !Modifier.isAbstract(clazz.getModifiers()))
+                .collect(Collectors.toSet());
+
+        // Guard against a fail-open scan: Guava ClassPath only enumerates file:// / URLClassLoader
+        // entries, so under a Surefire manifest-jar or module-path run it can return an empty/partial
+        // set, which would make the drift guard below pass vacuously. Requiring the scan to rediscover
+        // every already-mapped type proves it actually enumerated the package (and needs no magic number).
+        assertThat(discovered)
+                .as("classpath scan did not rediscover all mapped Statement types in io.trino.sql.tree — "
+                        + "the scan likely could not enumerate the classloader, so the drift guard would pass vacuously")
+                .containsAll(StatementUtils.statementsWithKnownQueryType());
+
+        Set<Class<?>> unmapped = discovered.stream()
+                .filter(clazz -> !StatementUtils.statementsWithKnownQueryType().contains(clazz))
+                .filter(clazz -> !UNMAPPED_BY_DESIGN.contains(clazz))
+                .collect(Collectors.toSet());
+
+        assertThat(unmapped)
+                .as("Statement types missing from StatementUtils.STATEMENT_QUERY_TYPES (add them, or to UNMAPPED_BY_DESIGN if intentionally special-cased)")
+                .isEmpty();
+    }
+
+    private void assertResourceGroupQueryType(@Language("sql") String sql, String expectedQueryType)
+    {
+        assertThat(getResourceGroupQueryType(parser.createStatement(sql))).isEqualTo(expectedQueryType);
+    }
+}


### PR DESCRIPTION
## Description
`StatementUtils` (a copy of `io.trino.util.StatementUtils`) hasn't been synced since it was introduced, so `SHOW BRANCHES`, `CREATE`/`DROP`/`FAST FORWARD BRANCH`, `REFRESH VIEW`, and column `SET`/`DROP DEFAULT` fall through to `"UNKNOWN"`. Routing rules matching on `getResourceGroupQueryType()` (e.g. `"DATA_DEFINITION"`) silently miss these statements.

This PR adds the 7 missing mappings, plus a test that scans `io.trino.sql.tree` and fails if any `Statement` subclass is unmapped — so future Trino dependency bumps catch drift automatically.

## Additional context and related issues
`StatementUtils` is marked `//modified version of io.trino.util.StatementUtils`, and `docs/routing-rules.md` documents `getResourceGroupQueryType()` as matching Trino's values.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required, with the following suggested text:

```markdown
* Fix routing rules classifying `SHOW BRANCHES`, branch DDL, `REFRESH VIEW`, and column `SET`/`DROP DEFAULT` statements as `UNKNOWN` for `getResourceGroupQueryType()`.
```
