### PR TITLE
Fix graceful shutdown 500 for in-flight queries on deactivated backends

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
@@ -26,6 +26,8 @@ import io.trino.gateway.ha.router.RoutingManager;
 import io.trino.gateway.ha.router.schema.RoutingSelectorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -80,10 +82,33 @@ public class RoutingTargetHandler
             return new RoutingTargetResponse(
                     new RoutingDestination(routingGroup, cluster, buildUriWithNewCluster(cluster, request), externalUrl),
                     request);
-        }).orElseGet(() -> getRoutingTargetResponse(request));
+        }).orElseGet(() -> getRoutingTargetResponse(queryId, request));
 
         logRewrite(routingTargetResponse.routingDestination().clusterHost(), request);
         return routingTargetResponse;
+    }
+
+    /**
+     * Resolves the routing target when no sticky backend was found for the request.
+     *
+     * <p>A request that carries a query id targets an already-submitted query rather than creating a new one.
+     * Per the graceful-shutdown contract, deactivating a backend only stops <em>new</em> queries from being
+     * routed there; in-flight queries identified by their query id must keep resolving to the cluster that holds
+     * them, even when that cluster has been deactivated. The sticky lookup in {@link #getPreviousCluster} already
+     * searches all backends (including deactivated ones) for such a query, so reaching this method with a query id
+     * present means the query could not be located on any backend. In that case routing should surface a clean
+     * {@code 404 Not Found} instead of falling through to the new-query active-backend selection, which throws
+     * {@code IllegalStateException: Number of active backends found zero} and is reported to the client as an
+     * opaque {@code 500 Internal Server Error}.
+     */
+    private RoutingTargetResponse getRoutingTargetResponse(Optional<String> queryId, HttpServletRequest request)
+    {
+        if (queryId.isPresent()) {
+            throw new WebApplicationException(
+                    "Could not find any backend for query id: " + queryId.get(),
+                    Response.Status.NOT_FOUND);
+        }
+        return getRoutingTargetResponse(request);
     }
 
     private RoutingTargetResponse getRoutingTargetResponse(HttpServletRequest request)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
@@ -48,6 +48,9 @@ public abstract class BaseRoutingManager
         implements RoutingManager
 {
     private static final Logger log = Logger.get(BaseRoutingManager.class);
+    // Upper bound for waiting on a single backend query probe. Slightly above the probe's combined connect
+    // and read timeouts (5s each) so a slow or stuck backend cannot block resolution of an in-flight query.
+    private static final long QUERY_PROBE_TIMEOUT_SECONDS = 12;
     private final ExecutorService executorService = Executors.newFixedThreadPool(5);
     private final GatewayBackendManager gatewayBackendManager;
     private final ConcurrentHashMap<String, TrinoStatus> backendToStatus;
@@ -201,35 +204,46 @@ public abstract class BaseRoutingManager
         List<ProxyBackendConfiguration> backends = gatewayBackendManager.getAllBackends();
 
         Map<String, Future<Integer>> responseCodes = new HashMap<>();
-        try {
-            for (ProxyBackendConfiguration backend : backends) {
-                String target = backend.getProxyTo() + "/v1/query/" + queryId;
+        for (ProxyBackendConfiguration backend : backends) {
+            String target = backend.getProxyTo() + "/v1/query/" + queryId;
 
-                Future<Integer> call =
-                        executorService.submit(
-                                () -> {
-                                    URL url = URI.create(target).toURL();
-                                    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-                                    conn.setConnectTimeout((int) TimeUnit.SECONDS.toMillis(5));
-                                    conn.setReadTimeout((int) TimeUnit.SECONDS.toMillis(5));
-                                    conn.setRequestMethod(HttpMethod.HEAD);
-                                    return conn.getResponseCode();
-                                });
-                responseCodes.put(backend.getProxyTo(), call);
-            }
+            Future<Integer> call =
+                    executorService.submit(
+                            () -> {
+                                URL url = URI.create(target).toURL();
+                                HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+                                conn.setConnectTimeout((int) TimeUnit.SECONDS.toMillis(5));
+                                conn.setReadTimeout((int) TimeUnit.SECONDS.toMillis(5));
+                                conn.setRequestMethod(HttpMethod.HEAD);
+                                return conn.getResponseCode();
+                            });
+            responseCodes.put(backend.getProxyTo(), call);
+        }
+        try {
             for (Map.Entry<String, Future<Integer>> entry : responseCodes.entrySet()) {
-                if (entry.getValue().isDone()) {
-                    int responseCode = entry.getValue().get();
+                // Wait for each probe (rather than only inspecting already-completed ones) so a backend that
+                // holds the query is reliably found instead of being skipped because its probe had not completed
+                // yet. This matters during graceful shutdown: the holding backend may be deactivated (and
+                // therefore excluded from the active-backend fallback below) but still healthy, so the only way
+                // an in-flight query keeps resolving is by locating it here. Each wait is bounded just above the
+                // connect/read timeouts so a single slow or stuck backend cannot block the search, and a failure
+                // probing one backend must not abort the search for the remaining ones.
+                try {
+                    int responseCode = entry.getValue().get(QUERY_PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
                     if (responseCode == 200) {
                         log.info("Found query [%s] on backend [%s]", queryId, entry.getKey());
                         setBackendForQueryId(queryId, entry.getKey());
                         return entry.getKey();
                     }
                 }
+                catch (Exception e) {
+                    log.warn("Query id [%s] not found on backend [%s]: %s", queryId, entry.getKey(), e.getLocalizedMessage());
+                }
             }
         }
-        catch (Exception e) {
-            log.warn("Query id [%s] not found", queryId);
+        finally {
+            // Stop probing once the search is over (a match was found or no backend had the query).
+            responseCodes.values().forEach(future -> future.cancel(true));
         }
         // Fallback on first active backend if queryId mapping not found.
         return gatewayBackendManager.getActiveBackends(defaultRoutingGroup).stream()

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandler.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandler.java
@@ -28,6 +28,7 @@ import io.trino.gateway.ha.router.schema.ExternalRouterResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -333,6 +334,51 @@ class TestRoutingTargetHandler
         // Fallback routing would throw (no backends for the routing group)
         when(routingManager.provideBackendConfiguration(any(), any()))
                 .thenThrow(new IllegalStateException("Number of active backends found zero"));
+
+        RoutingTargetResponse response = handler.resolveRouting(uiRequest);
+        assertThat(response.routingDestination().clusterHost()).isEqualTo(backendUrl);
+    }
+
+    @Test // regression test for https://github.com/trinodb/trino-gateway/issues/943
+    void testResolveRoutingForExistingQueryWithNoActiveBackendsReturnsNotFound()
+    {
+        // A request that polls an already-submitted query (query id present) whose owning cluster
+        // has been deactivated for graceful shutdown, and whose sticky lookup can no longer locate
+        // the backend. This must not surface the new-query "Number of active backends found zero"
+        // failure (HTTP 500); it should resolve to a clean 404 Not Found instead.
+        String queryId = "20240101_000000_00002_bbbbb";
+
+        HttpServletRequest uiRequest = Mockito.mock(HttpServletRequest.class);
+        when(uiRequest.getMethod()).thenReturn(HttpMethod.GET);
+        when(uiRequest.getRequestURI()).thenReturn("/ui/query.html");
+        when(uiRequest.getQueryString()).thenReturn(queryId);
+
+        // Sticky lookup cannot locate the backend for the query id.
+        when(routingManager.findBackendForQueryId(queryId)).thenReturn(null);
+
+        assertThatThrownBy(() -> handler.resolveRouting(uiRequest))
+                .isInstanceOf(WebApplicationException.class)
+                .satisfies(thrown -> assertThat(((WebApplicationException) thrown).getResponse().getStatus())
+                        .isEqualTo(Response.Status.NOT_FOUND.getStatusCode()));
+    }
+
+    @Test // regression test for https://github.com/trinodb/trino-gateway/issues/943
+    void testResolveRoutingForExistingQueryResolvesToDeactivatedBackend()
+    {
+        // A request that polls an already-submitted query whose owning cluster was deactivated but is
+        // still located by the sticky lookup must route to that cluster, even though the active-backend
+        // selection for new queries would have nothing to choose from.
+        String queryId = "20240101_000000_00003_ccccc";
+        String backendUrl = "https://deactivated-but-healthy.example.com";
+
+        HttpServletRequest uiRequest = Mockito.mock(HttpServletRequest.class);
+        when(uiRequest.getMethod()).thenReturn(HttpMethod.GET);
+        when(uiRequest.getRequestURI()).thenReturn("/ui/query.html");
+        when(uiRequest.getQueryString()).thenReturn(queryId);
+
+        when(routingManager.findBackendForQueryId(queryId)).thenReturn(backendUrl);
+        when(routingManager.findRoutingGroupForQueryId(queryId)).thenReturn("shutting-down-group");
+        when(routingManager.findExternalUrlForQueryId(queryId)).thenReturn(backendUrl);
 
         RoutingTargetResponse response = handler.resolveRouting(uiRequest);
         assertThat(response.routingDestination().clusterHost()).isEqualTo(backendUrl);


### PR DESCRIPTION
## Description

During graceful shutdown, deactivating a cluster (Active switch off, coordinator still HEALTHY) caused the gateway to return `500 Internal Server Error` for requests that poll an already-submitted query (for example `GET nextUri`). The request failed with `IllegalStateException: Number of active backends found zero` from `BaseRoutingManager.provideDefaultBackendConfiguration`.

The documented contract is that deactivation should only stop *new* queries from being routed; in-flight queries identified by their query id must keep resolving to the coordinator that holds them, even when that coordinator is deactivated. A zero-active-backends `500` should only surface for *new* query submissions.

There were two problems:

1. `BaseRoutingManager.searchAllBackendForQuery` only inspected probes that had *already* completed (`Future.isDone()`) at the moment the result loop ran. Probes submitted to the shared 5-thread pool are almost never finished that quickly, so the backend that actually holds the query — including a deactivated-but-healthy one (`getAllBackends()` includes deactivated backends) — was routinely skipped. The method then fell through to its active-backend fallback, which throws when the routing group has no active backend.
2. When the query id genuinely could not be resolved to any backend, `RoutingTargetHandler` fell through to the new-query active-backend selection, surfacing the same opaque `500` instead of a clean status.

### Fix

- `searchAllBackendForQuery` now waits for each probe (bounded just above the connect/read timeouts so a single slow or stuck backend cannot block resolution) and cancels the remaining probes once the search ends. A failed probe no longer aborts the search for the other backends. This lets an in-flight query reliably resolve to its holding cluster, even when that cluster is deactivated.
- `RoutingTargetHandler.resolveRouting` distinguishes a request that carries a query id (an existing query) from a new-query submission. When sticky resolution still finds no backend for an existing query, it returns a clean `404 Not Found` rather than falling into the new-query selection that throws `500`. New-query submissions keep the existing zero-active-backends behavior unchanged.

## Additional context and related issues

Maintainer Chaho12 (MEMBER) confirmed the expected behavior on the issue and noted it worked correctly in version 11.

This is a behavior change for the existing-query path (no longer a `500` when the holding cluster is deactivated), confined to the routing handler and the query-id search so the throwing `provideBackendConfiguration` contract for the new-query path is unchanged.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
* Fix `500 Internal Server Error` when polling an already-submitted query whose cluster was deactivated for graceful shutdown. In-flight queries now keep resolving to the deactivated-but-healthy cluster that holds them, and an unresolvable query id returns `404 Not Found` instead of `500`. ({issue}`943`)
```

Fixes #943
