### PR TITLE
Check Web UI dependency licenses

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -581,6 +581,17 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>test licenses script</id>
+                        <goals>
+                            <goal>pnpm</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <arguments>run test:licenses</arguments>
+                            <skip>${skipTests}</skip>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>build</id>
                         <goals>
                             <goal>pnpm</goal>

--- a/webapp/allowed-licenses.txt
+++ b/webapp/allowed-licenses.txt
@@ -1,0 +1,9 @@
+(MIT OR CC0-1.0)
+0BSD
+Apache-2.0
+BSD-2-Clause
+BSD-3-Clause
+CC-BY-4.0
+ISC
+MIT
+Python-2.0

--- a/webapp/allowed-licenses.txt
+++ b/webapp/allowed-licenses.txt
@@ -1,9 +1,10 @@
-(MIT OR CC0-1.0)
 0BSD
 Apache-2.0
 BSD-2-Clause
 BSD-3-Clause
+CC-BY-3.0
 CC-BY-4.0
+CC0-1.0
 ISC
 MIT
 Python-2.0

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "node scripts/check-licenses.js && tsc && vite build",
+    "check:licenses": "node scripts/check-licenses.js",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node scripts/check-licenses.js && tsc && vite build",
+    "build": "node --test scripts/check-licenses.test.js && node scripts/check-licenses.js && tsc && vite build",
     "check:licenses": "node scripts/check-licenses.js",
+    "test:licenses": "node --test scripts/check-licenses.test.js",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
@@ -34,6 +35,7 @@
     "eslint": "^8.53.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.5.4",
+    "spdx-expression-parse": "5.0.0",
     "typescript": "^5.9.3",
     "vite": "^5.4.21",
     "vite-plugin-svgr": "^4.5.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node --test scripts/check-licenses.test.js && node scripts/check-licenses.js && tsc && vite build",
+    "build": "pnpm run check:licenses && tsc && vite build",
     "check:licenses": "node scripts/check-licenses.js",
     "test:licenses": "node --test scripts/check-licenses.test.js",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node scripts/check-licenses.js && tsc && vite build",
+    "build": "node --test scripts/check-licenses.test.js && node scripts/check-licenses.js && tsc && vite build",
     "check:licenses": "node scripts/check-licenses.js",
+    "test:licenses": "node --test scripts/check-licenses.test.js",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
@@ -34,6 +35,7 @@
     "eslint": "^8.53.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.26",
+    "spdx-expression-parse": "5.0.0",
     "typescript": "^5.9.3",
     "vite": "^5.4.21",
     "vite-plugin-svgr": "^4.5.0",

--- a/webapp/pnpm-lock.yaml
+++ b/webapp/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 2.102.0(react@18.3.1)
       '@douyinfe/semi-ui':
         specifier: ^2.102.0
-        version: 2.102.0(@floating-ui/dom@1.8.0)(@tiptap/suggestion@3.29.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@7.2.0)
+        version: 2.102.0(@floating-ui/dom@1.8.0)(@tiptap/suggestion@3.29.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vvo/tzdb':
         specifier: ^6.198.0
         version: 6.198.0
@@ -62,22 +62,25 @@ importers:
         version: 18.2.15
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.21.0
-        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@8.53.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.9.3))(eslint@8.53.0)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^6.21.0
-        version: 6.21.0(eslint@8.53.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+        version: 6.21.0(eslint@8.53.0)(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(supports-color@7.2.0)(vite@5.4.21(sass@1.103.1))
+        version: 4.7.0(vite@5.4.21(sass@1.103.1))
       eslint:
         specifier: ^8.53.0
-        version: 8.53.0(supports-color@7.2.0)
+        version: 8.53.0
       eslint-plugin-react-hooks:
         specifier: ^4.6.2
-        version: 4.6.2(eslint@8.53.0(supports-color@7.2.0))
+        version: 4.6.2(eslint@8.53.0)
       eslint-plugin-react-refresh:
         specifier: ^0.5.4
-        version: 0.5.4(eslint@8.53.0(supports-color@7.2.0))
+        version: 0.5.4(eslint@8.53.0)
+      spdx-expression-parse:
+        specifier: 5.0.0
+        version: 5.0.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -86,7 +89,7 @@ importers:
         version: 5.4.21(sass@1.103.1)
       vite-plugin-svgr:
         specifier: ^4.5.0
-        version: 4.5.0(rollup@4.59.1)(supports-color@7.2.0)(typescript@5.9.3)(vite@5.4.21(sass@1.103.1))
+        version: 4.5.0(rollup@4.59.1)(typescript@5.9.3)(vite@5.4.21(sass@1.103.1))
 
 packages:
 
@@ -491,42 +494,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.6.0':
     resolution: {integrity: sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.6.0':
     resolution: {integrity: sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.6.0':
     resolution: {integrity: sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.6.0':
     resolution: {integrity: sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.6.0':
     resolution: {integrity: sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.6.0':
     resolution: {integrity: sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==}
@@ -594,79 +591,66 @@ packages:
     resolution: {integrity: sha512-KUizqxpwaR2AZdAUsMWfL/C94pUu7TKpoPd88c8yFVixJ+l9hejkrwoK5Zj3wiNh65UeyryKnJyxL1b7yNqFQA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.1':
     resolution: {integrity: sha512-MZoQ/am77ckJtZGFAtPucgUuJWiop3m2R3lw7tC0QCcbfl4DRhQUBUkHWCkcrT3pqy5Mzv5QQgY6Dmlba6iTWg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.1':
     resolution: {integrity: sha512-Sez95TP6xGjkWB1608EfhCX1gdGrO5wzyN99VqzRtC17x/1bhw5VU1V0GfKUwbW/Xr1J8mSasoFoJa6Y7aGGSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.1':
     resolution: {integrity: sha512-9Cs2Seq98LWNOJzR89EGTZoiP8EkZ9UbQhBlDgfAkM6asVna1xJ04W2CLYWDN/RpUgOjtQvcv8wQVi1t5oQazA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.1':
     resolution: {integrity: sha512-n9yqttftgFy7IrNEnHy1bOp6B4OSe8mJDiPkT7EqlM9FnKOwUMnCK62ixW0Kd9Clw0/wgvh8+SqaDXMFvw3KqQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.1':
     resolution: {integrity: sha512-SfpNXDzVTqs/riak4xXcLpq5gIQWsqGWMhN1AGRQKB4qGSs4r0sEs3ervXPcE1O9RsQ5bm8Muz6zmQpQnPss1g==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.1':
     resolution: {integrity: sha512-LjaChED0wQnjKZU+tsmGbN+9nN1XhaWUkAlSbTdhpEseCS4a15f/Q8xC2BN4GDKRzhhLZpYtJBZr2NZhR0jvNw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.1':
     resolution: {integrity: sha512-ojW7iTJSIs4pwB2xV6QXGwNyDctvXOivYllttuPbXguuKDX5vwpqYJsHc6D2LZzjDGHML414Tuj3LvVPe1CT1A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.1':
     resolution: {integrity: sha512-FP+Q6WTcxxvsr0wQczhSE+tOZvFPV8A/mUE6mhZYFW9/eea/y/XqAgRoLLMuE9Cz0hfX5bi7p116IWoB+P237A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.1':
     resolution: {integrity: sha512-L1uD9b/Ig8Z+rn1KttCJjwhN1FgjRMBKsPaBsDKkfUl7GfFq71pU4vWCnpOsGljycFEbkHWARZLf4lMYg3WOLw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.1':
     resolution: {integrity: sha512-EZc9NGTk/oSUzzOD4nYY4gIjteo2M3CiozX6t1IXGCOdgxJTlVu/7EdPeiqeHPSIrxkLhavqpBAUCfvC6vBOug==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.1':
     resolution: {integrity: sha512-NQ9KyU1Anuy59L8+HHOKM++CoUxrQWrZWXRik4BJFm+7i5NP6q/SW43xIBr80zzt+PDBJ7LeNmloQGfa0JGk0w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.1':
     resolution: {integrity: sha512-GZkLk2t6naywsveSFBsEb0PLU+JC9ggVjbndsbG20VPhar6D1gkMfCx4NfP9owpovBXTN+eRdqGSkDGIxPHhmQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.1':
     resolution: {integrity: sha512-1hjG9Jpl2KDOetr64iQd8AZAEjkDUUK5RbDkYWsViYLC1op1oNzdjMJeFiofcGhqbNTaY2kfgqowE7DILifsrA==}
@@ -2126,6 +2110,15 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@5.0.0:
+    resolution: {integrity: sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
@@ -2320,20 +2313,20 @@ snapshots:
 
   '@babel/compat-data@7.29.0': {}
 
-  '@babel/core@7.29.0(supports-color@7.2.0)':
+  '@babel/core@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helpers': 7.28.6
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@7.2.0)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2358,19 +2351,19 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-module-imports@7.28.6(supports-color@7.2.0)':
+  '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.29.0(supports-color@7.2.0)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
-      '@babel/helper-module-imports': 7.28.6(supports-color@7.2.0)
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0(supports-color@7.2.0)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -2391,14 +2384,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0(supports-color@7.2.0))':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0(supports-color@7.2.0))':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/runtime@7.29.7': {}
@@ -2409,7 +2402,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.29.0(supports-color@7.2.0)':
+  '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
@@ -2417,7 +2410,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2463,11 +2456,11 @@ snapshots:
     dependencies:
       bezier-easing: 2.1.0
 
-  '@douyinfe/semi-foundation@2.102.0(supports-color@7.2.0)':
+  '@douyinfe/semi-foundation@2.102.0':
     dependencies:
       '@douyinfe/semi-animation': 2.102.0
       '@douyinfe/semi-json-viewer-core': 2.102.0
-      '@mdx-js/mdx': 3.1.1(supports-color@7.2.0)
+      '@mdx-js/mdx': 3.1.1
       async-validator: 3.5.2
       classnames: 2.5.1
       date-fns: 2.30.0
@@ -2477,7 +2470,7 @@ snapshots:
       lottie-web: 5.13.0
       memoize-one: 5.2.1
       prismjs: 1.30.0
-      remark-gfm: 4.0.1(supports-color@7.2.0)
+      remark-gfm: 4.0.1
       scroll-into-view-if-needed: 2.2.31
     transitivePeerDependencies:
       - supports-color
@@ -2502,14 +2495,14 @@ snapshots:
 
   '@douyinfe/semi-theme-default@2.102.0': {}
 
-  '@douyinfe/semi-ui@2.102.0(@floating-ui/dom@1.8.0)(@tiptap/suggestion@3.29.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@7.2.0)':
+  '@douyinfe/semi-ui@2.102.0(@floating-ui/dom@1.8.0)(@tiptap/suggestion@3.29.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2))(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@dnd-kit/utilities': 3.2.2(react@18.3.1)
       '@douyinfe/semi-animation': 2.102.0
       '@douyinfe/semi-animation-react': 2.102.0
-      '@douyinfe/semi-foundation': 2.102.0(supports-color@7.2.0)
+      '@douyinfe/semi-foundation': 2.102.0
       '@douyinfe/semi-icons': 2.102.0(react@18.3.1)
       '@douyinfe/semi-illustrations': 2.102.0(react@18.3.1)
       '@douyinfe/semi-theme-default': 2.102.0
@@ -2618,24 +2611,24 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@8.53.0(supports-color@7.2.0))':
+  '@eslint-community/eslint-utils@4.4.0(eslint@8.53.0)':
     dependencies:
-      eslint: 8.53.0(supports-color@7.2.0)
+      eslint: 8.53.0
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@8.53.0(supports-color@7.2.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@8.53.0)':
     dependencies:
-      eslint: 8.53.0(supports-color@7.2.0)
+      eslint: 8.53.0
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.10.0': {}
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/eslintrc@2.1.4(supports-color@7.2.0)':
+  '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -2659,10 +2652,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@humanwhocodes/config-array@0.11.14(supports-color@7.2.0)':
+  '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2690,7 +2683,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mdx-js/mdx@3.1.1(supports-color@7.2.0)':
+  '@mdx-js/mdx@3.1.1':
     dependencies:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
@@ -2702,14 +2695,14 @@ snapshots:
       estree-util-is-identifier-name: 3.0.0
       estree-util-scope: 1.0.0
       estree-walker: 3.0.3
-      hast-util-to-jsx-runtime: 2.3.6(supports-color@7.2.0)
+      hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
       recma-jsx: 1.0.1(acorn@8.18.0)
       recma-stringify: 1.0.0
-      rehype-recma: 1.0.0(supports-color@7.2.0)
-      remark-mdx: 3.1.1(supports-color@7.2.0)
-      remark-parse: 11.0.0(supports-color@7.2.0)
+      rehype-recma: 1.0.0
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
       remark-rehype: 11.1.2
       source-map: 0.7.6
       unified: 11.0.5
@@ -2876,54 +2869,54 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.1':
     optional: true
 
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0(supports-color@7.2.0))':
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0(supports-color@7.2.0))':
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0(supports-color@7.2.0))':
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0(supports-color@7.2.0))':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0(supports-color@7.2.0))':
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0(supports-color@7.2.0))':
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0(supports-color@7.2.0))':
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0(supports-color@7.2.0))':
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-preset@8.1.0(@babel/core@7.29.0(supports-color@7.2.0))':
+  '@svgr/babel-preset@8.1.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0(supports-color@7.2.0))
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0(supports-color@7.2.0))
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0(supports-color@7.2.0))
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.0(supports-color@7.2.0))
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.0(supports-color@7.2.0))
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.0(supports-color@7.2.0))
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0(supports-color@7.2.0))
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/core': 7.29.0
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
 
-  '@svgr/core@8.1.0(supports-color@7.2.0)(typescript@5.9.3)':
+  '@svgr/core@8.1.0(typescript@5.9.3)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/core': 7.29.0
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@5.9.3)
       snake-case: 3.0.4
@@ -2936,11 +2929,11 @@ snapshots:
       '@babel/types': 7.29.0
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(supports-color@7.2.0)(typescript@5.9.3))(supports-color@7.2.0)':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0(supports-color@7.2.0))
-      '@svgr/core': 8.1.0(supports-color@7.2.0)(typescript@5.9.3)
+      '@babel/core': 7.29.0
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
+      '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
@@ -3218,16 +3211,16 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@8.53.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.9.3))(eslint@8.53.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 6.21.0(eslint@8.53.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.53.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/type-utils': 6.21.0(eslint@8.53.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.53.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.53.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.53.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 8.53.0(supports-color@7.2.0)
+      debug: 4.4.3
+      eslint: 8.53.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -3238,14 +3231,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.21.0(eslint@8.53.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@6.21.0(eslint@8.53.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 8.53.0(supports-color@7.2.0)
+      debug: 4.4.3
+      eslint: 8.53.0
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3256,12 +3249,12 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
 
-  '@typescript-eslint/type-utils@6.21.0(eslint@8.53.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@6.21.0(eslint@8.53.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.53.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 8.53.0(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.53.0)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 8.53.0
       ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -3270,11 +3263,11 @@ snapshots:
 
   '@typescript-eslint/types@6.21.0': {}
 
-  '@typescript-eslint/typescript-estree@6.21.0(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -3285,15 +3278,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@6.21.0(eslint@8.53.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@6.21.0(eslint@8.53.0)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.53.0(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.53.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(supports-color@7.2.0)(typescript@5.9.3)
-      eslint: 8.53.0(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
+      eslint: 8.53.0
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
@@ -3308,11 +3301,11 @@ snapshots:
 
   '@ungap/structured-clone@1.3.3': {}
 
-  '@vitejs/plugin-react@4.7.0(supports-color@7.2.0)(vite@5.4.21(sass@1.103.1))':
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21(sass@1.103.1))':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@7.2.0)
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0(supports-color@7.2.0))
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0(supports-color@7.2.0))
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
@@ -3456,17 +3449,13 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.7
 
-  debug@4.3.4(supports-color@7.2.0):
+  debug@4.3.4:
     dependencies:
       ms: 2.1.2
-    optionalDependencies:
-      supports-color: 7.2.0
 
-  debug@4.4.3(supports-color@7.2.0):
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 7.2.0
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -3555,13 +3544,13 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-plugin-react-hooks@4.6.2(eslint@8.53.0(supports-color@7.2.0)):
+  eslint-plugin-react-hooks@4.6.2(eslint@8.53.0):
     dependencies:
-      eslint: 8.53.0(supports-color@7.2.0)
+      eslint: 8.53.0
 
-  eslint-plugin-react-refresh@0.5.4(eslint@8.53.0(supports-color@7.2.0)):
+  eslint-plugin-react-refresh@0.5.4(eslint@8.53.0):
     dependencies:
-      eslint: 8.53.0(supports-color@7.2.0)
+      eslint: 8.53.0
 
   eslint-scope@7.2.2:
     dependencies:
@@ -3570,20 +3559,20 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint@8.53.0(supports-color@7.2.0):
+  eslint@8.53.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.53.0(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.53.0)
       '@eslint-community/regexpp': 4.10.0
-      '@eslint/eslintrc': 2.1.4(supports-color@7.2.0)
+      '@eslint/eslintrc': 2.1.4
       '@eslint/js': 8.53.0
-      '@humanwhocodes/config-array': 0.11.14(supports-color@7.2.0)
+      '@humanwhocodes/config-array': 0.11.14
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.2.0
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@7.2.0)
+      debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -3752,7 +3741,7 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  hast-util-to-estree@3.1.3(supports-color@7.2.0):
+  hast-util-to-estree@3.1.3:
     dependencies:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
@@ -3762,9 +3751,9 @@ snapshots:
       estree-util-attach-comments: 3.0.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1(supports-color@7.2.0)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@7.2.0)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@7.2.0)
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -3773,7 +3762,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  hast-util-to-jsx-runtime@2.3.6(supports-color@7.2.0):
+  hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.5
@@ -3782,9 +3771,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1(supports-color@7.2.0)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@7.2.0)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@7.2.0)
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -3919,14 +3908,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.3(supports-color@7.2.0):
+  mdast-util-from-markdown@2.0.3:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2(supports-color@7.2.0)
+      micromark: 4.0.2
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -3944,67 +3933,67 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0(supports-color@7.2.0):
+  mdast-util-gfm-footnote@2.1.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0(supports-color@7.2.0):
+  mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0(supports-color@7.2.0):
+  mdast-util-gfm-table@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0(supports-color@7.2.0):
+  mdast-util-gfm-task-list-item@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0(supports-color@7.2.0):
+  mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0(supports-color@7.2.0)
-      mdast-util-gfm-strikethrough: 2.0.0(supports-color@7.2.0)
-      mdast-util-gfm-table: 2.0.0(supports-color@7.2.0)
-      mdast-util-gfm-task-list-item: 2.0.0(supports-color@7.2.0)
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1(supports-color@7.2.0):
+  mdast-util-mdx-expression@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0(supports-color@7.2.0):
+  mdast-util-mdx-jsx@3.2.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
@@ -4012,7 +4001,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -4021,23 +4010,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx@3.0.0(supports-color@7.2.0):
+  mdast-util-mdx@3.0.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
-      mdast-util-mdx-expression: 2.0.1(supports-color@7.2.0)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@7.2.0)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1(supports-color@7.2.0):
+  mdast-util-mdxjs-esm@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -4321,10 +4310,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2(supports-color@7.2.0):
+  micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -4613,36 +4602,36 @@ snapshots:
       unified: 11.0.5
       vfile: 6.0.3
 
-  rehype-recma@1.0.0(supports-color@7.2.0):
+  rehype-recma@1.0.0:
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.5
-      hast-util-to-estree: 3.1.3(supports-color@7.2.0)
+      hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
 
-  remark-gfm@4.0.1(supports-color@7.2.0):
+  remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0(supports-color@7.2.0)
+      mdast-util-gfm: 3.1.0
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0(supports-color@7.2.0)
+      remark-parse: 11.0.0
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-mdx@3.1.1(supports-color@7.2.0):
+  remark-mdx@3.1.1:
     dependencies:
-      mdast-util-mdx: 3.0.0(supports-color@7.2.0)
+      mdast-util-mdx: 3.0.0
       micromark-extension-mdxjs: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0(supports-color@7.2.0):
+  remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -4747,6 +4736,15 @@ snapshots:
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@5.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
 
   stringify-entities@4.0.4:
     dependencies:
@@ -4862,11 +4860,11 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-svgr@4.5.0(rollup@4.59.1)(supports-color@7.2.0)(typescript@5.9.3)(vite@5.4.21(sass@1.103.1)):
+  vite-plugin-svgr@4.5.0(rollup@4.59.1)(typescript@5.9.3)(vite@5.4.21(sass@1.103.1)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.59.1)
-      '@svgr/core': 8.1.0(supports-color@7.2.0)(typescript@5.9.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(supports-color@7.2.0)(typescript@5.9.3))(supports-color@7.2.0)
+      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
       vite: 5.4.21(sass@1.103.1)
     transitivePeerDependencies:
       - rollup

--- a/webapp/pnpm-lock.yaml
+++ b/webapp/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.4.26
         version: 0.4.26(eslint@8.53.0)
+      spdx-expression-parse:
+        specifier: 5.0.0
+        version: 5.0.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -491,36 +494,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -594,66 +603,79 @@ packages:
     resolution: {integrity: sha512-KUizqxpwaR2AZdAUsMWfL/C94pUu7TKpoPd88c8yFVixJ+l9hejkrwoK5Zj3wiNh65UeyryKnJyxL1b7yNqFQA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.1':
     resolution: {integrity: sha512-MZoQ/am77ckJtZGFAtPucgUuJWiop3m2R3lw7tC0QCcbfl4DRhQUBUkHWCkcrT3pqy5Mzv5QQgY6Dmlba6iTWg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.1':
     resolution: {integrity: sha512-Sez95TP6xGjkWB1608EfhCX1gdGrO5wzyN99VqzRtC17x/1bhw5VU1V0GfKUwbW/Xr1J8mSasoFoJa6Y7aGGSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.1':
     resolution: {integrity: sha512-9Cs2Seq98LWNOJzR89EGTZoiP8EkZ9UbQhBlDgfAkM6asVna1xJ04W2CLYWDN/RpUgOjtQvcv8wQVi1t5oQazA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.1':
     resolution: {integrity: sha512-n9yqttftgFy7IrNEnHy1bOp6B4OSe8mJDiPkT7EqlM9FnKOwUMnCK62ixW0Kd9Clw0/wgvh8+SqaDXMFvw3KqQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.1':
     resolution: {integrity: sha512-SfpNXDzVTqs/riak4xXcLpq5gIQWsqGWMhN1AGRQKB4qGSs4r0sEs3ervXPcE1O9RsQ5bm8Muz6zmQpQnPss1g==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.1':
     resolution: {integrity: sha512-LjaChED0wQnjKZU+tsmGbN+9nN1XhaWUkAlSbTdhpEseCS4a15f/Q8xC2BN4GDKRzhhLZpYtJBZr2NZhR0jvNw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.1':
     resolution: {integrity: sha512-ojW7iTJSIs4pwB2xV6QXGwNyDctvXOivYllttuPbXguuKDX5vwpqYJsHc6D2LZzjDGHML414Tuj3LvVPe1CT1A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.1':
     resolution: {integrity: sha512-FP+Q6WTcxxvsr0wQczhSE+tOZvFPV8A/mUE6mhZYFW9/eea/y/XqAgRoLLMuE9Cz0hfX5bi7p116IWoB+P237A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.1':
     resolution: {integrity: sha512-L1uD9b/Ig8Z+rn1KttCJjwhN1FgjRMBKsPaBsDKkfUl7GfFq71pU4vWCnpOsGljycFEbkHWARZLf4lMYg3WOLw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.1':
     resolution: {integrity: sha512-EZc9NGTk/oSUzzOD4nYY4gIjteo2M3CiozX6t1IXGCOdgxJTlVu/7EdPeiqeHPSIrxkLhavqpBAUCfvC6vBOug==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.1':
     resolution: {integrity: sha512-NQ9KyU1Anuy59L8+HHOKM++CoUxrQWrZWXRik4BJFm+7i5NP6q/SW43xIBr80zzt+PDBJ7LeNmloQGfa0JGk0w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.1':
     resolution: {integrity: sha512-GZkLk2t6naywsveSFBsEb0PLU+JC9ggVjbndsbG20VPhar6D1gkMfCx4NfP9owpovBXTN+eRdqGSkDGIxPHhmQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.1':
     resolution: {integrity: sha512-1hjG9Jpl2KDOetr64iQd8AZAEjkDUUK5RbDkYWsViYLC1op1oNzdjMJeFiofcGhqbNTaY2kfgqowE7DILifsrA==}
@@ -2128,6 +2150,15 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@5.0.0:
+    resolution: {integrity: sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -4777,6 +4808,15 @@ snapshots:
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@5.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
 
   stringify-entities@4.0.4:
     dependencies:

--- a/webapp/scripts/check-licenses.js
+++ b/webapp/scripts/check-licenses.js
@@ -1,0 +1,105 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const webappDirectory = path.resolve(scriptDirectory, '..');
+const nodeModulesDirectory = path.join(webappDirectory, 'node_modules', '.pnpm');
+const allowedLicensesPath = path.join(webappDirectory, 'allowed-licenses.txt');
+
+function readAllowedLicenses()
+{
+    return new Set(fs.readFileSync(allowedLicensesPath, 'utf8')
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line && !line.startsWith('#')));
+}
+
+function packageLicense(packageJson)
+{
+    if (typeof packageJson.license === 'string' && packageJson.license.trim()) {
+        return packageJson.license.trim();
+    }
+
+    if (Array.isArray(packageJson.licenses)) {
+        const licenses = packageJson.licenses
+            .map((license) => typeof license === 'string' ? license : license?.type)
+            .filter(Boolean)
+            .map((license) => license.trim())
+            .filter(Boolean);
+        if (licenses.length > 0) {
+            return licenses.join(' OR ');
+        }
+    }
+
+    return undefined;
+}
+// Read package manifests because pnpm-lock.yaml does not record licenses.
+function packageJsonFiles()
+{
+    if (!fs.existsSync(nodeModulesDirectory)) {
+        throw new Error('node_modules/.pnpm was not found. Run pnpm install before checking licenses.');
+    }
+
+    return fs.readdirSync(nodeModulesDirectory, {withFileTypes: true})
+        .filter((entry) => entry.isDirectory())
+        .flatMap((entry) => {
+            const nestedNodeModules = path.join(nodeModulesDirectory, entry.name, 'node_modules');
+            if (!fs.existsSync(nestedNodeModules)) {
+                return [];
+            }
+
+            return fs.readdirSync(nestedNodeModules, {withFileTypes: true})
+                .filter((packageEntry) => packageEntry.isDirectory() && !packageEntry.name.startsWith('.'))
+                .flatMap((packageEntry) => {
+                    const packagePath = path.join(nestedNodeModules, packageEntry.name);
+                    if (packageEntry.name.startsWith('@')) {
+                        return fs.readdirSync(packagePath, {withFileTypes: true})
+                            .filter((scopedPackageEntry) => scopedPackageEntry.isDirectory())
+                            .map((scopedPackageEntry) => path.join(packagePath, scopedPackageEntry.name, 'package.json'));
+                    }
+                    return [path.join(packagePath, 'package.json')];
+                });
+        })
+        .filter((packageJsonPath) => fs.existsSync(packageJsonPath));
+}
+
+function checkLicenses()
+{
+    const allowedLicenses = readAllowedLicenses();
+    const packages = new Map();
+
+    for (const packageJsonPath of packageJsonFiles()) {
+        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+        const packageName = `${packageJson.name}@${packageJson.version}`;
+        packages.set(packageName, packageLicense(packageJson));
+    }
+
+    const missingLicenses = [];
+    const disallowedLicenses = [];
+
+    for (const [packageName, license] of [...packages.entries()].sort()) {
+        if (!license) {
+            missingLicenses.push(packageName);
+        }
+        else if (!allowedLicenses.has(license)) {
+            disallowedLicenses.push(`${packageName}: ${license}`);
+        }
+    }
+
+    if (missingLicenses.length || disallowedLicenses.length) {
+        if (missingLicenses.length) {
+            console.error('Packages without license metadata:');
+            console.error(missingLicenses.join('\n'));
+        }
+        if (disallowedLicenses.length) {
+            console.error('Packages with licenses not listed in allowed-licenses.txt:');
+            console.error(disallowedLicenses.join('\n'));
+        }
+        process.exit(1);
+    }
+
+    console.log(`Verified licenses for ${packages.size} Web UI dependencies.`);
+}
+
+checkLicenses();

--- a/webapp/scripts/check-licenses.js
+++ b/webapp/scripts/check-licenses.js
@@ -158,6 +158,8 @@ function checkLicenses()
     console.log(`Verified licenses for ${packages.size} Web UI dependencies.`);
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+const scriptPath = fileURLToPath(import.meta.url);
+
+if (process.argv[1] && fs.realpathSync(process.argv[1]) === scriptPath) {
     checkLicenses();
 }

--- a/webapp/scripts/check-licenses.js
+++ b/webapp/scripts/check-licenses.js
@@ -9,7 +9,8 @@ const nodeModulesDirectory = path.join(webappDirectory, 'node_modules', '.pnpm')
 const allowedLicensesPath = path.join(webappDirectory, 'allowed-licenses.txt');
 
 function readAllowedLicenses()
-    {//allowlist validation once read
+    {
+        //validate allowlist once read
     const licenses = fs.readFileSync(allowedLicensesPath, 'utf8')
         .split(/\r?\n/)
         .map((line) => line.trim())
@@ -120,6 +121,16 @@ function packageJsonFiles()
         .filter((packageJsonPath) => fs.existsSync(packageJsonPath));
 }
 
+function parseLicense(license)
+{
+    try {
+        return parseSpdxExpression(license);
+    }
+    catch {
+        return undefined;
+    }
+}
+
 function checkLicenses()
 {
     const allowedLicenses = readAllowedLicenses();
@@ -133,25 +144,36 @@ function checkLicenses()
 
     const missingLicenses = [];
     const disallowedLicenses = [];
+    const invalidLicenses = []; 
 
     for (const [packageName, license] of [...packages.entries()].sort()) {
         if (!license) {
             missingLicenses.push(packageName);
+        }
+        else if (!parseLicense(license)) {
+            invalidLicenses.push(`${packageName}: ${license}`);
         }
         else if (!isLicenseAllowed(license, allowedLicenses)) {
             disallowedLicenses.push(`${packageName}: ${license}`);
         }
     }
 
-    if (missingLicenses.length || disallowedLicenses.length) {
+    if (missingLicenses.length || invalidLicenses.length || disallowedLicenses.length) {
         if (missingLicenses.length) {
             console.error('Packages without license metadata:');
             console.error(missingLicenses.join('\n'));
         }
+
+        if (invalidLicenses.length) {
+            console.error('Packages with invalid SPDX license expressions:');
+            console.error(invalidLicenses.join('\n'));
+        }
+
         if (disallowedLicenses.length) {
             console.error('Packages with licenses not listed in allowed-licenses.txt:');
             console.error(disallowedLicenses.join('\n'));
         }
+
         process.exit(1);
     }
 

--- a/webapp/scripts/check-licenses.js
+++ b/webapp/scripts/check-licenses.js
@@ -9,23 +9,14 @@ const nodeModulesDirectory = path.join(webappDirectory, 'node_modules', '.pnpm')
 const allowedLicensesPath = path.join(webappDirectory, 'allowed-licenses.txt');
 
 function readAllowedLicenses()
-    {
-        //validate allowlist once read
+{
     const licenses = fs.readFileSync(allowedLicensesPath, 'utf8')
         .split(/\r?\n/)
         .map((line) => line.trim())
         .filter((line) => line && !line.startsWith('#'));
 
-    const invalid = licenses.filter((license) => {
-        try {
-            parseSpdxExpression(license);
-            return false;
-        }
-        catch {
-            return true;
-        }
-    });
-    //throws if allowlist entry invalid
+    const invalid = licenses.filter((license) => !parseLicense(license));
+
     if (invalid.length) {
         throw new Error(
             `Invalid SPDX identifiers in allowed-licenses.txt: ${invalid.join(', ')}`
@@ -82,15 +73,23 @@ function isParsedLicenseAllowed(expression, allowedLicenses)
     return false;
 }
 
-export function isLicenseAllowed(license, allowedLicenses)
+export function parseLicense(license)
 {
     try {
-        return isParsedLicenseAllowed(parseSpdxExpression(license), allowedLicenses);
+        return parseSpdxExpression(license);
     }
     catch {
-        return false;
+        return undefined;
     }
 }
+
+export function isLicenseAllowed(license, allowedLicenses)
+{
+    const expression = parseLicense(license);
+    return expression ? isParsedLicenseAllowed(expression, allowedLicenses) : false;
+}
+
+
 // Read package manifests because pnpm-lock.yaml does not record licenses.
 function packageJsonFiles()
 {
@@ -121,15 +120,7 @@ function packageJsonFiles()
         .filter((packageJsonPath) => fs.existsSync(packageJsonPath));
 }
 
-function parseLicense(license)
-{
-    try {
-        return parseSpdxExpression(license);
-    }
-    catch {
-        return undefined;
-    }
-}
+
 
 function checkLicenses()
 {

--- a/webapp/scripts/check-licenses.js
+++ b/webapp/scripts/check-licenses.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
+import parseSpdxExpression from 'spdx-expression-parse';
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const webappDirectory = path.resolve(scriptDirectory, '..');
@@ -15,10 +16,15 @@ function readAllowedLicenses()
         .filter((line) => line && !line.startsWith('#')));
 }
 
-function packageLicense(packageJson)
+export function packageLicense(packageJson)
 {
     if (typeof packageJson.license === 'string' && packageJson.license.trim()) {
         return packageJson.license.trim();
+    }
+
+    if (packageJson.license && typeof packageJson.license === 'object' &&
+        typeof packageJson.license.type === 'string' && packageJson.license.type.trim()) {
+        return packageJson.license.type.trim();
     }
 
     if (Array.isArray(packageJson.licenses)) {
@@ -33,6 +39,38 @@ function packageLicense(packageJson)
     }
 
     return undefined;
+}
+
+function isParsedLicenseAllowed(expression, allowedLicenses)
+{
+    if (expression.license) {
+        const license = expression.exception
+            ? `${expression.license} WITH ${expression.exception}`
+            : expression.license;
+        return allowedLicenses.has(license);
+    }
+
+    if (expression.conjunction === 'or') {
+        return isParsedLicenseAllowed(expression.left, allowedLicenses) ||
+            isParsedLicenseAllowed(expression.right, allowedLicenses);
+    }
+
+    if (expression.conjunction === 'and') {
+        return isParsedLicenseAllowed(expression.left, allowedLicenses) &&
+            isParsedLicenseAllowed(expression.right, allowedLicenses);
+    }
+
+    return false;
+}
+
+export function isLicenseAllowed(license, allowedLicenses)
+{
+    try {
+        return isParsedLicenseAllowed(parseSpdxExpression(license), allowedLicenses);
+    }
+    catch {
+        return false;
+    }
 }
 // Read package manifests because pnpm-lock.yaml does not record licenses.
 function packageJsonFiles()
@@ -82,7 +120,7 @@ function checkLicenses()
         if (!license) {
             missingLicenses.push(packageName);
         }
-        else if (!allowedLicenses.has(license)) {
+        else if (!isLicenseAllowed(license, allowedLicenses)) {
             disallowedLicenses.push(`${packageName}: ${license}`);
         }
     }
@@ -102,4 +140,6 @@ function checkLicenses()
     console.log(`Verified licenses for ${packages.size} Web UI dependencies.`);
 }
 
-checkLicenses();
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    checkLicenses();
+}

--- a/webapp/scripts/check-licenses.js
+++ b/webapp/scripts/check-licenses.js
@@ -9,11 +9,29 @@ const nodeModulesDirectory = path.join(webappDirectory, 'node_modules', '.pnpm')
 const allowedLicensesPath = path.join(webappDirectory, 'allowed-licenses.txt');
 
 function readAllowedLicenses()
-{
-    return new Set(fs.readFileSync(allowedLicensesPath, 'utf8')
+    {//allowlist validation once read
+    const licenses = fs.readFileSync(allowedLicensesPath, 'utf8')
         .split(/\r?\n/)
         .map((line) => line.trim())
-        .filter((line) => line && !line.startsWith('#')));
+        .filter((line) => line && !line.startsWith('#'));
+
+    const invalid = licenses.filter((license) => {
+        try {
+            parseSpdxExpression(license);
+            return false;
+        }
+        catch {
+            return true;
+        }
+    });
+    //throws if allowlist entry invalid
+    if (invalid.length) {
+        throw new Error(
+            `Invalid SPDX identifiers in allowed-licenses.txt: ${invalid.join(', ')}`
+        );
+    }
+
+    return new Set(licenses);
 }
 
 export function packageLicense(packageJson)

--- a/webapp/scripts/check-licenses.test.js
+++ b/webapp/scripts/check-licenses.test.js
@@ -16,10 +16,10 @@ test('allows valid SPDX expressions composed of allowed licenses', () => {
     assert.equal(isLicenseAllowed('MIT OR ISC', allowedLicenses), true);
     assert.equal(isLicenseAllowed('Apache-2.0 AND MIT', allowedLicenses), true);
     assert.equal(isLicenseAllowed('(MIT OR CC0-1.0)', allowedLicenses), true);
+    assert.equal(isLicenseAllowed('Zlib OR ISC', allowedLicenses), true);
 });
 
 test('rejects expressions containing required disallowed licenses', () => {
     assert.equal(isLicenseAllowed('MIT AND Zlib', allowedLicenses), false);
-    assert.equal(isLicenseAllowed('Zlib OR ISC', allowedLicenses), true);
     assert.equal(isLicenseAllowed('not an SPDX expression', allowedLicenses), false);
 });

--- a/webapp/scripts/check-licenses.test.js
+++ b/webapp/scripts/check-licenses.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {isLicenseAllowed, packageLicense} from './check-licenses.js';
+
+const allowedLicenses = new Set(['Apache-2.0', 'CC0-1.0', 'ISC', 'MIT']);
+
+test('reads current and historic package license formats', () => {
+    assert.equal(packageLicense({license: 'MIT'}), 'MIT');
+    assert.equal(packageLicense({license: {type: 'MIT', url: 'https://example.com'}}), 'MIT');
+    assert.equal(packageLicense({licenses: [{type: 'MIT'}, 'ISC']}), 'MIT OR ISC');
+    assert.equal(packageLicense({}), undefined);
+});
+
+test('allows valid SPDX expressions composed of allowed licenses', () => {
+    assert.equal(isLicenseAllowed('MIT OR ISC', allowedLicenses), true);
+    assert.equal(isLicenseAllowed('Apache-2.0 AND MIT', allowedLicenses), true);
+    assert.equal(isLicenseAllowed('(MIT OR CC0-1.0)', allowedLicenses), true);
+});
+
+test('rejects expressions containing required disallowed licenses', () => {
+    assert.equal(isLicenseAllowed('MIT AND Zlib', allowedLicenses), false);
+    assert.equal(isLicenseAllowed('Zlib OR ISC', allowedLicenses), true);
+    assert.equal(isLicenseAllowed('not an SPDX expression', allowedLicenses), false);
+});


### PR DESCRIPTION
## Description

Add Web UI dependency license verification for Trino Gateway.

This adds an allowlist of accepted Web UI dependency licenses and a `check:licenses` script that validates the `license` fields from installed package `package.json` files. The Web UI `build` script now runs this check before `tsc && vite build`, so the existing frontend build path verifies licenses automatically.

## Additional context and related issues

Closes #984.

This follows the same general approach as trinodb/trino#27832. `pnpm-lock.yaml` does not record license metadata, so the checker reads installed package manifests under `webapp/node_modules/.pnpm` after `pnpm install`.

Validation performed:

```text
corepack pnpm@10.27.0 --dir webapp run check:licenses
Verified licenses for 477 Web UI dependencies.
```


I also temporarily removed MIT from `webapp/allowed-licenses.txt` and confirmed the check fails with a list of disallowed packages.



## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```