### PR TITLE
Add /v1/spooled/* to default path whitelist

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/HttpUtils.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/HttpUtils.java
@@ -17,6 +17,7 @@ public class HttpUtils
 {
     public static final String V1_STATEMENT_PATH = "/v1/statement";
     public static final String V1_QUERY_PATH = "/v1/query";
+    public static final String V1_SPOOLED_PATH = "/v1/spooled";
     public static final String V1_INFO_PATH = "/v1/info";
     public static final String V1_NODE_PATH = "/v1/node";
     public static final String UI_API_STATS_PATH = "/ui/api/stats";

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/PathFilter.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/PathFilter.java
@@ -29,6 +29,7 @@ import static io.trino.gateway.ha.handler.HttpUtils.UI_API_STATS_PATH;
 import static io.trino.gateway.ha.handler.HttpUtils.V1_INFO_PATH;
 import static io.trino.gateway.ha.handler.HttpUtils.V1_NODE_PATH;
 import static io.trino.gateway.ha.handler.HttpUtils.V1_QUERY_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.V1_SPOOLED_PATH;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -72,6 +73,7 @@ public class PathFilter
     {
         return statementPaths.stream().anyMatch(path::startsWith)
                 || path.startsWith(V1_QUERY_PATH)
+                || path.startsWith(V1_SPOOLED_PATH)
                 || path.startsWith(TRINO_UI_PATH)
                 || path.startsWith(V1_INFO_PATH)
                 || path.startsWith(V1_NODE_PATH)

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestPathFilter.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestPathFilter.java
@@ -25,6 +25,7 @@ import static io.trino.gateway.ha.handler.HttpUtils.UI_API_STATS_PATH;
 import static io.trino.gateway.ha.handler.HttpUtils.V1_INFO_PATH;
 import static io.trino.gateway.ha.handler.HttpUtils.V1_NODE_PATH;
 import static io.trino.gateway.ha.handler.HttpUtils.V1_QUERY_PATH;
+import static io.trino.gateway.ha.handler.HttpUtils.V1_SPOOLED_PATH;
 import static io.trino.gateway.ha.handler.HttpUtils.V1_STATEMENT_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -99,6 +100,15 @@ class TestPathFilter
     }
 
     @Test
+    void testSpooledPaths()
+    {
+        // Spooled segment paths must be forwarded to the backend coordinator.
+        assertThat(pathFilter.isPathWhiteListed(V1_SPOOLED_PATH)).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(V1_SPOOLED_PATH + "/ack/k57HZQqycuX7B_5QQnFtvR9yZ6zxt-SyPySruC9HMHI=")).isTrue();
+        assertThat(pathFilter.isPathWhiteListed(V1_SPOOLED_PATH + "/download/BknNfrjG9rI6GsNoAlSOKB9yZ6zxt-SyPySruC9HMHI=")).isTrue();
+    }
+
+    @Test
     void testNonWhitelistedPaths()
     {
         assertThat(pathFilter.isPathWhiteListed("/v3/statement")).isFalse(); // Not in our statement paths
@@ -145,6 +155,8 @@ class TestPathFilter
 
         // Should still allow hardcoded paths
         assertThat(emptyFilter.isPathWhiteListed(V1_QUERY_PATH)).isTrue();
+        assertThat(emptyFilter.isPathWhiteListed(V1_SPOOLED_PATH + "/ack/sometoken")).isTrue();
+        assertThat(emptyFilter.isPathWhiteListed(V1_SPOOLED_PATH + "/download/sometoken")).isTrue();
         assertThat(emptyFilter.isPathWhiteListed(TRINO_UI_PATH)).isTrue();
         assertThat(emptyFilter.isPathWhiteListed(V1_INFO_PATH)).isTrue();
         assertThat(emptyFilter.isPathWhiteListed(OAUTH_PATH)).isTrue();
@@ -199,6 +211,8 @@ class TestPathFilter
         assertThat(filter.isPathWhiteListed(V1_STATEMENT_PATH + "/executing")).isTrue();
         assertThat(filter.isPathWhiteListed(V1_STATEMENT_PATH + "/queued")).isTrue();
         assertThat(filter.isPathWhiteListed(V1_QUERY_PATH)).isTrue();
+        assertThat(filter.isPathWhiteListed(V1_SPOOLED_PATH + "/ack/k57HZQqycuX7B_5QQnFtvR9yZ6zxt-SyPySruC9HMHI=")).isTrue();
+        assertThat(filter.isPathWhiteListed(V1_SPOOLED_PATH + "/download/BknNfrjG9rI6GsNoAlSOKB9yZ6zxt-SyPySruC9HMHI=")).isTrue();
         assertThat(filter.isPathWhiteListed(TRINO_UI_PATH)).isTrue();
         assertThat(filter.isPathWhiteListed(OAUTH_PATH)).isTrue();
 


### PR DESCRIPTION
Requests to /v1/spooled/ack/* and /v1/spooled/download/* were not forwarded to backend coordinators because the path was absent from PathFilter's default whitelist. The RouterPreMatchContainerRequestFilter only rewrites the request URI to ROUTE_TO_BACKEND when isPathWhiteListed returns true; unrecognized paths fall through to the Gateway's own JAX-RS resources and receive a 404 without ever reaching a coordinator.

Ack is stateless with respect to coordinator-local state: the opaque token in the URL is AES-encrypted with the shared secret key, and FileSystemSpoolingManager.acknowledge() delegates to a pure fileSystem.deleteFile call whose path is derived entirely from the deserialized handle. Verified empirically on Trino 477:
- same coordinator, restarted between issuing and acking: segment deleted
- ack issued against a different coordinator than the one that produced the segment: segment deleted

Any coordinator with the same protocol.spooling.shared-secret-key and fs.location can process any ack or download request.

Fixes #1033
Related: #926, #670

<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
