### PR TITLE
Improve StatementUtils drift-guard test failure message

### DIFF
--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStatementUtils.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStatementUtils.java
@@ -25,7 +25,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Modifier;
+import java.util.Comparator;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static io.trino.gateway.ha.router.StatementUtils.getResourceGroupQueryType;
@@ -103,10 +105,22 @@ final class TestStatementUtils
         Set<Class<?>> unmapped = discovered.stream()
                 .filter(clazz -> !StatementUtils.statementsWithKnownQueryType().contains(clazz))
                 .filter(clazz -> !UNMAPPED_BY_DESIGN.contains(clazz))
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(Class::getName))));
 
         assertThat(unmapped)
-                .as("Statement types missing from StatementUtils.STATEMENT_QUERY_TYPES (add them, or to UNMAPPED_BY_DESIGN if intentionally special-cased)")
+                .as(
+                        """
+                        io.trino.gateway.ha.router.StatementUtils is a hand-maintained copy of io.trino.util.StatementUtils, \
+                        kept in sync manually against dep.trino.version in gateway-ha/pom.xml. The Statement types below exist \
+                        in io.trino.sql.tree but StatementUtils doesn't classify them, so getResourceGroupQueryType() returns \
+                        "UNKNOWN" and routing rules matching on query type (e.g. "DATA_DEFINITION") silently miss them.
+
+                        This usually means dep.trino.version was bumped and Trino added new statements. For each type, copy the \
+                        query type from upstream io.trino.util.StatementUtils into StatementUtils.STATEMENT_QUERY_TYPES, or add \
+                        it to UNMAPPED_BY_DESIGN if it's intentionally special-cased.
+
+                        Unmapped types: %s""",
+                        unmapped)
                 .isEmpty();
     }
 


### PR DESCRIPTION
## Description
Follow-up to #1121. The `testEveryStatementTypeIsClassified` drift guard in `TestStatementUtils` fails when `dep.trino.version` is bumped and Trino adds a `Statement` type that `StatementUtils` doesn't classify. The previous failure message was terse, so this makes it self-explanatory: it names the hand-maintained copy, where it's kept in sync (`dep.trino.version` in `gateway-ha/pom.xml`), why the gap matters (routing rules silently miss the statements), and exactly what to do (copy the query type from upstream `io.trino.util.StatementUtils`, or add it to `UNMAPPED_BY_DESIGN`).

Wording per the discussion in https://github.com/trinodb/trino-gateway/pull/1121#issuecomment-4786127552.

## Additional context and related issues
Test-only change. See https://github.com/trinodb/trino-gateway/pull/1121#issuecomment-4792249589.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text: