### PR TITLE
Return 404 instead of 502 when proxying to intentionally scaled-down clusters

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
@@ -20,6 +20,7 @@ import io.trino.gateway.ha.config.HaGatewayConfiguration;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 import io.trino.gateway.ha.handler.schema.RoutingDestination;
 import io.trino.gateway.ha.handler.schema.RoutingTargetResponse;
+import io.trino.gateway.ha.router.GatewayBackendManager;
 import io.trino.gateway.ha.router.GatewayCookie;
 import io.trino.gateway.ha.router.RoutingGroupSelector;
 import io.trino.gateway.ha.router.RoutingManager;
@@ -46,6 +47,7 @@ public class RoutingTargetHandler
     private static final Logger log = Logger.get(RoutingTargetHandler.class);
     private final RoutingManager routingManager;
     private final RoutingGroupSelector routingGroupSelector;
+    private final GatewayBackendManager gatewayBackendManager;
     private final String defaultRoutingGroup;
     private final List<String> statementPaths;
     private final boolean requestAnalyserClientsUseV2Format;
@@ -56,10 +58,12 @@ public class RoutingTargetHandler
     public RoutingTargetHandler(
             RoutingManager routingManager,
             RoutingGroupSelector routingGroupSelector,
+            GatewayBackendManager gatewayBackendManager,
             HaGatewayConfiguration haGatewayConfiguration)
     {
         this.routingManager = requireNonNull(routingManager);
         this.routingGroupSelector = requireNonNull(routingGroupSelector);
+        this.gatewayBackendManager = requireNonNull(gatewayBackendManager, "gatewayBackendManager is null");
         this.defaultRoutingGroup = haGatewayConfiguration.getRouting().getDefaultRoutingGroup();
         statementPaths = requireNonNull(haGatewayConfiguration.getStatementPaths());
         requestAnalyserClientsUseV2Format = haGatewayConfiguration.getRequestAnalyzerConfig().isClientsUseV2Format();
@@ -77,8 +81,13 @@ public class RoutingTargetHandler
                     .orElse(defaultRoutingGroup);
             String externalUrl = queryId.map(routingManager::findExternalUrlForQueryId)
                     .orElse(cluster);
+            String clusterName = gatewayBackendManager.getAllBackends().stream()
+                    .filter(b -> b.getProxyTo().equals(cluster))
+                    .findFirst()
+                    .map(ProxyBackendConfiguration::getName)
+                    .orElse(null);
             return new RoutingTargetResponse(
-                    new RoutingDestination(routingGroup, cluster, buildUriWithNewCluster(cluster, request), externalUrl),
+                    new RoutingDestination(routingGroup, cluster, buildUriWithNewCluster(cluster, request), externalUrl, clusterName),
                     request);
         }).orElseGet(() -> getRoutingTargetResponse(request));
 
@@ -104,7 +113,7 @@ public class RoutingTargetHandler
             modifiedRequest = new HeaderModifyingRequestWrapper(request, routingDestination.externalHeaders());
         }
         return new RoutingTargetResponse(
-                new RoutingDestination(routingGroup, clusterHost, buildUriWithNewCluster(clusterHost, request), externalUrl),
+                new RoutingDestination(routingGroup, clusterHost, buildUriWithNewCluster(clusterHost, request), externalUrl, backendConfiguration.getName()),
                 modifiedRequest);
     }
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/schema/RoutingDestination.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/schema/RoutingDestination.java
@@ -15,4 +15,4 @@ package io.trino.gateway.ha.handler.schema;
 
 import java.net.URI;
 
-public record RoutingDestination(String routingGroup, String clusterHost, URI clusterUri, String externalUrl) {}
+public record RoutingDestination(String routingGroup, String clusterHost, URI clusterUri, String externalUrl, String clusterName) {}

--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
@@ -14,6 +14,7 @@
 package io.trino.gateway.proxyserver;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.FluentFuture;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -24,10 +25,13 @@ import io.airlift.http.client.Request;
 import io.airlift.http.client.StaticBodyGenerator;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
+import io.trino.gateway.ha.clustermonitor.TrinoStatus;
 import io.trino.gateway.ha.config.GatewayCookieConfigurationPropertiesProvider;
 import io.trino.gateway.ha.config.HaGatewayConfiguration;
 import io.trino.gateway.ha.config.ProxyResponseConfiguration;
 import io.trino.gateway.ha.handler.schema.RoutingDestination;
+import io.trino.gateway.ha.router.BackendStateManager;
+import io.trino.gateway.ha.router.GatewayBackendManager;
 import io.trino.gateway.ha.router.GatewayCookie;
 import io.trino.gateway.ha.router.OAuth2GatewayCookie;
 import io.trino.gateway.ha.router.QueryHistoryManager;
@@ -69,6 +73,7 @@ import static io.trino.gateway.ha.handler.HttpUtils.TRINO_REQUEST_USER;
 import static io.trino.gateway.ha.handler.ProxyUtils.SOURCE_HEADER;
 import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import static jakarta.ws.rs.core.Response.Status.BAD_GATEWAY;
+import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static jakarta.ws.rs.core.Response.Status.OK;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.list;
@@ -88,6 +93,8 @@ public class ProxyRequestHandler
     private final HttpClient httpClient;
     private final RoutingManager routingManager;
     private final QueryHistoryManager queryHistoryManager;
+    private final GatewayBackendManager gatewayBackendManager;
+    private final BackendStateManager backendStateManager;
     private final boolean cookiesEnabled;
     private final boolean forwardedHeadersEnabled;
     private final List<String> statementPaths;
@@ -99,11 +106,15 @@ public class ProxyRequestHandler
             @ForProxy HttpClient httpClient,
             RoutingManager routingManager,
             QueryHistoryManager queryHistoryManager,
+            GatewayBackendManager gatewayBackendManager,
+            BackendStateManager backendStateManager,
             HaGatewayConfiguration haGatewayConfiguration)
     {
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.routingManager = requireNonNull(routingManager, "routingManager is null");
         this.queryHistoryManager = requireNonNull(queryHistoryManager, "queryHistoryManager is null");
+        this.gatewayBackendManager = requireNonNull(gatewayBackendManager, "gatewayBackendManager is null");
+        this.backendStateManager = requireNonNull(backendStateManager, "backendStateManager is null");
         cookiesEnabled = GatewayCookieConfigurationPropertiesProvider.getInstance().isEnabled();
         asyncTimeout = haGatewayConfiguration.getRouting().getAsyncTimeout();
         forwardedHeadersEnabled = haGatewayConfiguration.getRouting().isForwardedHeadersEnabled();
@@ -198,7 +209,7 @@ public class ProxyRequestHandler
         setupAsyncResponse(
                 asyncResponse,
                 future.transform(response -> buildResponse(response, cookieBuilder.build()), executor)
-                        .catching(ProxyException.class, e -> handleProxyException(request, e), directExecutor()));
+                        .catching(ProxyException.class, e -> handleProxyException(request, e, routingDestination), directExecutor()));
     }
 
     private ImmutableList<NewCookie> getOAuth2GatewayCookie(URI remoteUri, HttpServletRequest servletRequest)
@@ -251,10 +262,31 @@ public class ProxyRequestHandler
         return FluentFuture.from(httpClient.executeAsync(request, new ProxyResponseHandler(proxyResponseConfiguration)));
     }
 
-    private static Response handleProxyException(Request request, ProxyException e)
+    private Response handleProxyException(Request request, ProxyException e, RoutingDestination routingDestination)
     {
+        if (isExpectedlyUnavailable(routingDestination.clusterName(), gatewayBackendManager, backendStateManager)) {
+            log.info("Proxy request failed (backend inactive and unreachable): %s %s",
+                    request.getMethod(), request.getUri());
+            throw new WebApplicationException(
+                    Response.status(NOT_FOUND)
+                            .type(TEXT_PLAIN_TYPE)
+                            .entity("Backend cluster is unreachable.")
+                            .build());
+        }
         log.warn(e, "Proxy request failed: %s %s", request.getMethod(), request.getUri());
         throw badRequest(e.getMessage());
+    }
+
+    @VisibleForTesting
+    static boolean isExpectedlyUnavailable(String clusterName, GatewayBackendManager backendManager, BackendStateManager stateManager)
+    {
+        if (clusterName == null) {
+            log.warn("isExpectedlyUnavailable called with null clusterName");
+            return false;
+        }
+        return backendManager.getBackendByName(clusterName)
+                .map(b -> !b.isActive() && stateManager.getBackendState(b).trinoStatus() != TrinoStatus.HEALTHY)
+                .orElse(false);
     }
 
     private static WebApplicationException badRequest(String message)

--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
@@ -14,6 +14,7 @@
 package io.trino.gateway.proxyserver;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.FluentFuture;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -24,10 +25,13 @@ import io.airlift.http.client.Request;
 import io.airlift.http.client.StaticBodyGenerator;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
+import io.trino.gateway.ha.clustermonitor.TrinoStatus;
 import io.trino.gateway.ha.config.GatewayCookieConfigurationPropertiesProvider;
 import io.trino.gateway.ha.config.HaGatewayConfiguration;
 import io.trino.gateway.ha.config.ProxyResponseConfiguration;
 import io.trino.gateway.ha.handler.schema.RoutingDestination;
+import io.trino.gateway.ha.router.BackendStateManager;
+import io.trino.gateway.ha.router.GatewayBackendManager;
 import io.trino.gateway.ha.router.GatewayCookie;
 import io.trino.gateway.ha.router.OAuth2GatewayCookie;
 import io.trino.gateway.ha.router.QueryHistoryManager;
@@ -69,6 +73,7 @@ import static io.trino.gateway.ha.handler.HttpUtils.TRINO_REQUEST_USER;
 import static io.trino.gateway.ha.handler.ProxyUtils.SOURCE_HEADER;
 import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import static jakarta.ws.rs.core.Response.Status.BAD_GATEWAY;
+import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static jakarta.ws.rs.core.Response.Status.OK;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.list;
@@ -88,6 +93,8 @@ public class ProxyRequestHandler
     private final HttpClient httpClient;
     private final RoutingManager routingManager;
     private final QueryHistoryManager queryHistoryManager;
+    private final GatewayBackendManager gatewayBackendManager;
+    private final BackendStateManager backendStateManager;
     private final boolean cookiesEnabled;
     private final boolean forwardedHeadersEnabled;
     private final List<String> statementPaths;
@@ -99,11 +106,15 @@ public class ProxyRequestHandler
             @ForProxy HttpClient httpClient,
             RoutingManager routingManager,
             QueryHistoryManager queryHistoryManager,
+            GatewayBackendManager gatewayBackendManager,
+            BackendStateManager backendStateManager,
             HaGatewayConfiguration haGatewayConfiguration)
     {
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.routingManager = requireNonNull(routingManager, "routingManager is null");
         this.queryHistoryManager = requireNonNull(queryHistoryManager, "queryHistoryManager is null");
+        this.gatewayBackendManager = requireNonNull(gatewayBackendManager, "gatewayBackendManager is null");
+        this.backendStateManager = requireNonNull(backendStateManager, "backendStateManager is null");
         cookiesEnabled = GatewayCookieConfigurationPropertiesProvider.getInstance().isEnabled();
         asyncTimeout = haGatewayConfiguration.getRouting().getAsyncTimeout();
         forwardedHeadersEnabled = haGatewayConfiguration.getRouting().isForwardedHeadersEnabled();
@@ -198,7 +209,7 @@ public class ProxyRequestHandler
         setupAsyncResponse(
                 asyncResponse,
                 future.transform(response -> buildResponse(response, cookieBuilder.build()), executor)
-                        .catching(ProxyException.class, e -> handleProxyException(request, e), directExecutor()));
+                        .catching(ProxyException.class, e -> handleProxyException(request, e, routingDestination), directExecutor()));
     }
 
     private ImmutableList<NewCookie> getOAuth2GatewayCookie(URI remoteUri, HttpServletRequest servletRequest)
@@ -251,10 +262,32 @@ public class ProxyRequestHandler
         return FluentFuture.from(httpClient.executeAsync(request, new ProxyResponseHandler(proxyResponseConfiguration)));
     }
 
-    private static Response handleProxyException(Request request, ProxyException e)
+    private Response handleProxyException(Request request, ProxyException e, RoutingDestination routingDestination)
     {
+        if (isExpectedlyUnavailable(routingDestination.clusterName(), gatewayBackendManager, backendStateManager)) {
+            log.info("Proxy request failed (backend inactive and unreachable): %s %s",
+                    request.getMethod(),
+                    request.getUri());
+            throw new WebApplicationException(
+                    Response.status(NOT_FOUND)
+                            .type(TEXT_PLAIN_TYPE)
+                            .entity("Backend cluster is unreachable.")
+                            .build());
+        }
         log.warn(e, "Proxy request failed: %s %s", request.getMethod(), request.getUri());
         throw badRequest(e.getMessage());
+    }
+
+    @VisibleForTesting
+    static boolean isExpectedlyUnavailable(String clusterName, GatewayBackendManager backendManager, BackendStateManager stateManager)
+    {
+        if (clusterName == null) {
+            log.warn("isExpectedlyUnavailable called with null clusterName");
+            return false;
+        }
+        return backendManager.getBackendByName(clusterName)
+                .map(b -> !b.isActive() && stateManager.getBackendState(b).trinoStatus() != TrinoStatus.HEALTHY)
+                .orElse(false);
     }
 
     private static WebApplicationException badRequest(String message)

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandler.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandler.java
@@ -22,6 +22,7 @@ import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 import io.trino.gateway.ha.config.RequestAnalyzerConfig;
 import io.trino.gateway.ha.config.RulesExternalConfiguration;
 import io.trino.gateway.ha.handler.schema.RoutingTargetResponse;
+import io.trino.gateway.ha.router.GatewayBackendManager;
 import io.trino.gateway.ha.router.RoutingGroupSelector;
 import io.trino.gateway.ha.router.RoutingManager;
 import io.trino.gateway.ha.router.schema.ExternalRouterResponse;
@@ -115,6 +116,7 @@ class TestRoutingTargetHandler
         handler = new RoutingTargetHandler(
                 routingManager,
                 RoutingGroupSelector.byRoutingExternal(httpClient, config.getRoutingRules().getRulesExternalConfiguration(), config.getRequestAnalyzerConfig()),
+                Mockito.mock(GatewayBackendManager.class),
                 config);
     }
 
@@ -344,6 +346,7 @@ class TestRoutingTargetHandler
         return new RoutingTargetHandler(
                 routingManager,
                 RoutingGroupSelector.byRoutingExternal(httpClient, config.getRoutingRules().getRulesExternalConfiguration(), config.getRequestAnalyzerConfig()),
+                Mockito.mock(GatewayBackendManager.class),
                 config);
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/proxyserver/TestProxyRequestHandler.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/proxyserver/TestProxyRequestHandler.java
@@ -14,6 +14,11 @@
 package io.trino.gateway.proxyserver;
 
 import io.trino.gateway.ha.HaGatewayLauncher;
+import io.trino.gateway.ha.clustermonitor.ClusterStats;
+import io.trino.gateway.ha.clustermonitor.TrinoStatus;
+import io.trino.gateway.ha.config.ProxyBackendConfiguration;
+import io.trino.gateway.ha.router.BackendStateManager;
+import io.trino.gateway.ha.router.GatewayBackendManager;
 import io.trino.gateway.ha.router.QueryHistoryManager;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -47,6 +52,8 @@ import static io.trino.gateway.ha.util.TestcontainersUtils.createPostgreSqlConta
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @TestInstance(PER_CLASS)
 final class TestProxyRequestHandler
@@ -184,5 +191,79 @@ final class TestProxyRequestHandler
         assertThat(queryDetail.getUser()).isEqualTo(username.get());
         assertThat(queryDetail.getSource()).isEqualTo("trino-cli");
         assertThat(queryDetail.getBackendUrl()).isEqualTo("http://localhost:" + routerPort);
+    }
+
+    @Test
+    void testInactiveUnhealthyBackendIsExpectedlyUnavailable()
+    {
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("dead-cluster");
+        backend.setProxyTo("http://dead-cluster.trino:8889");
+        backend.setActive(false);
+
+        GatewayBackendManager mockBackendManager = mock(GatewayBackendManager.class);
+        when(mockBackendManager.getBackendByName("dead-cluster")).thenReturn(Optional.of(backend));
+
+        BackendStateManager mockStateManager = mock(BackendStateManager.class);
+        when(mockStateManager.getBackendState(backend))
+                .thenReturn(ClusterStats.builder("dead-cluster").trinoStatus(TrinoStatus.UNHEALTHY).build());
+
+        assertThat(ProxyRequestHandler.isExpectedlyUnavailable("dead-cluster", mockBackendManager, mockStateManager)).isTrue();
+    }
+
+    @Test
+    void testActiveBackendIsNotExpectedlyUnavailable()
+    {
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("active-cluster");
+        backend.setProxyTo("http://active-cluster.trino:8889");
+        backend.setActive(true);
+
+        GatewayBackendManager mockBackendManager = mock(GatewayBackendManager.class);
+        when(mockBackendManager.getBackendByName("active-cluster")).thenReturn(Optional.of(backend));
+
+        BackendStateManager mockStateManager = mock(BackendStateManager.class);
+        when(mockStateManager.getBackendState(backend))
+                .thenReturn(ClusterStats.builder("active-cluster").trinoStatus(TrinoStatus.HEALTHY).build());
+
+        assertThat(ProxyRequestHandler.isExpectedlyUnavailable("active-cluster", mockBackendManager, mockStateManager)).isFalse();
+    }
+
+    @Test
+    void testInactiveUnknownBackendIsExpectedlyUnavailable()
+    {
+        // UNKNOWN is the default state before any health check runs (e.g. after gateway restart)
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("dead-cluster");
+        backend.setProxyTo("http://dead-cluster.trino:8889");
+        backend.setActive(false);
+
+        GatewayBackendManager mockBackendManager = mock(GatewayBackendManager.class);
+        when(mockBackendManager.getBackendByName("dead-cluster")).thenReturn(Optional.of(backend));
+
+        BackendStateManager mockStateManager = mock(BackendStateManager.class);
+        when(mockStateManager.getBackendState(backend))
+                .thenReturn(ClusterStats.builder("dead-cluster").trinoStatus(TrinoStatus.UNKNOWN).build());
+
+        assertThat(ProxyRequestHandler.isExpectedlyUnavailable("dead-cluster", mockBackendManager, mockStateManager)).isTrue();
+    }
+
+    @Test
+    void testInactiveButStillHealthyBackendIsNotExpectedlyUnavailable()
+    {
+        // Transition window: cluster deactivated but health check hasn't caught up yet → still 502
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setName("transitioning-cluster");
+        backend.setProxyTo("http://transitioning-cluster.trino:8889");
+        backend.setActive(false);
+
+        GatewayBackendManager mockBackendManager = mock(GatewayBackendManager.class);
+        when(mockBackendManager.getBackendByName("transitioning-cluster")).thenReturn(Optional.of(backend));
+
+        BackendStateManager mockStateManager = mock(BackendStateManager.class);
+        when(mockStateManager.getBackendState(backend))
+                .thenReturn(ClusterStats.builder("transitioning-cluster").trinoStatus(TrinoStatus.HEALTHY).build());
+
+        assertThat(ProxyRequestHandler.isExpectedlyUnavailable("transitioning-cluster", mockBackendManager, mockStateManager)).isFalse();
     }
 }


### PR DESCRIPTION
## Description

When a backend is intentionally deactivated (e.g. scaled to zero) but health checks still report it, proxy requests to those backends return `502 Bad Gateway` which suggests a transient error that will self-resolve. This is misleading, the cluster is unreachable by design.
This change returns `404 Not Found` instead when the target backend is inactive and not reporting as healthy, making the response correctly signal that the cluster is intentionally unavailable.

## Release notes
( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required, with the following suggested text:
```markdown
* Return 404 instead of 502 when proxying to intentionally scaled-down clusters.