### PR TITLE
requestAnalyzerConfig fails to parse SQL body when Media-Type is not set

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/TrinoQueryProperties.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/TrinoQueryProperties.java
@@ -266,16 +266,13 @@ public class TrinoQueryProperties
         }
 
         MediaType mediaType = requestContext.getMediaType();
-        if (mediaType == null) {
-            return;
-        }
 
-        String charset = mediaType.getParameters().get("charset");
-        if (charset == null) {
-            // RFC 7231 leaves the default charset to the recipient; Trino's coordinator
-            // decodes statement bodies as UTF-8, and most Trino clients omit the parameter.
-            charset = UTF_8.name();
-        }
+        // RFC 7231 leaves the default charset to the recipient; Trino's coordinator
+        // decodes statement bodies as UTF-8, and most Trino clients omit the parameter.
+        String charset = (mediaType == null)
+                ? UTF_8.name()
+                : mediaType.getParameters().getOrDefault("charset", UTF_8.name());
+
         if (!UTF_8.name().equalsIgnoreCase(charset)) {
             log.debug("Request charset is not UTF-8 (%s), skipping query parsing", charset);
             return;

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestTrinoQueryProperties.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestTrinoQueryProperties.java
@@ -16,6 +16,7 @@ package io.trino.gateway.ha.router;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.json.JsonCodec;
+import io.trino.sql.tree.QualifiedName;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.core.MediaType;
@@ -519,6 +520,21 @@ final class TestTrinoQueryProperties
         assertThat(trinoQueryProperties.getCatalogs()).isEmpty();
         assertThat(trinoQueryProperties.getSchemas()).isEmpty();
         assertThat(trinoQueryProperties.getTables()).isEmpty();
+    }
+
+    @Test
+    void testWithoutMediaType()
+    {
+        String query = "SELECT * FROM mycatalog.myschema.mytable";
+        ContainerRequestContext mockRequest = prepareMockRequest(query, null);
+
+        TrinoQueryProperties trinoQueryProperties = new TrinoQueryProperties(mockRequest, false, 1024 * 1024);
+
+        // Some Trino clients (e.g. dbt-trino) omit the media type
+        assertThat(trinoQueryProperties.getCatalogs()).containsExactly("mycatalog");
+        assertThat(trinoQueryProperties.getSchemas()).containsExactly("myschema");
+        assertThat(trinoQueryProperties.getTables()).containsExactly(QualifiedName.of("mycatalog", "myschema", "mytable"));
+        assertThat(trinoQueryProperties.isQueryParsingSuccessful()).isTrue();
     }
 
     private ContainerRequestContext prepareMockRequest(String query)


### PR DESCRIPTION
requestAnalyzerConfig fails to parse SQL body when Media-Type is not set fix: https://github.com/trinodb/trino-gateway/issues/1164