### PR TITLE
Add LDAP referral policy support

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -170,7 +170,12 @@ The LDAP config file should have the following contents:
   poolMaxTotal: 8
   poolMinIdle: 0
   poolTestOnBorrow: true
+  ldapReferralPolicy: THROW
 ```
+
+The `ldapReferralPolicy` setting controls how LDAP search referrals are handled.
+Supported values are `THROW`, `FOLLOW`, and `IGNORE`. The default is `THROW`,
+which preserves the previous behavior.
 
 ## Web page permissions
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/LdapConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/LdapConfiguration.java
@@ -22,6 +22,13 @@ import java.nio.file.Path;
 
 public class LdapConfiguration
 {
+    public enum LdapReferralPolicy
+    {
+        THROW,
+        FOLLOW,
+        IGNORE,
+    }
+
     private static final Logger log = Logger.get(LdapConfiguration.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
     private String ldapHost;
@@ -39,6 +46,7 @@ public class LdapConfiguration
     private Integer poolMaxTotal;
     private Integer poolMinIdle;
     private boolean poolTestOnBorrow;
+    private LdapReferralPolicy ldapReferralPolicy = LdapReferralPolicy.THROW;
 
     public LdapConfiguration(
             String ldapHost,
@@ -237,5 +245,15 @@ public class LdapConfiguration
     public void setPoolTestOnBorrow(boolean poolTestOnBorrow)
     {
         this.poolTestOnBorrow = poolTestOnBorrow;
+    }
+
+    public LdapReferralPolicy getLdapReferralPolicy()
+    {
+        return ldapReferralPolicy;
+    }
+
+    public void setLdapReferralPolicy(LdapReferralPolicy ldapReferralPolicy)
+    {
+        this.ldapReferralPolicy = ldapReferralPolicy;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbLdapClient.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbLdapClient.java
@@ -18,6 +18,7 @@ import io.trino.gateway.ha.config.LdapConfiguration;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.message.SearchRequest;
 import org.apache.directory.api.ldap.model.message.SearchScope;
 import org.apache.directory.ldap.client.api.DefaultLdapConnectionFactory;
 import org.apache.directory.ldap.client.api.LdapClientTrustStoreManager;
@@ -79,12 +80,9 @@ public class LbLdapClient
     {
         try {
             String filter = config.getLdapUserSearch().replace("${USER}", user);
+            SearchRequest searchRequest = newUserSearchRequest(filter);
             PasswordWarning passwordWarning =
-                    ldapConnectionTemplate.authenticate(
-                            config.getLdapUserBaseDn(),
-                            filter,
-                            SearchScope.SUBTREE,
-                            password.toCharArray());
+                    ldapConnectionTemplate.authenticate(searchRequest, password.toCharArray());
 
             if (passwordWarning != null) {
                 log.warn("password warning %s", passwordWarning);
@@ -104,12 +102,8 @@ public class LbLdapClient
         String filter = config.getLdapUserSearch().replace("${USER}", user);
 
         String[] attributes = new String[] {config.getLdapGroupMemberAttribute()};
-        List<UserRecord> list = ldapConnectionTemplate.search(
-                config.getLdapUserBaseDn(),
-                filter,
-                SearchScope.SUBTREE,
-                attributes,
-                userRecordEntryMapper);
+        SearchRequest searchRequest = newUserSearchRequest(filter, attributes);
+        List<UserRecord> list = ldapConnectionTemplate.search(searchRequest, userRecordEntryMapper);
 
         String memberOf = "";
         if (list != null && !list.isEmpty()) {
@@ -117,6 +111,23 @@ public class LbLdapClient
             log.debug("Member of %s", memberOf);
         }
         return memberOf;
+    }
+
+    private SearchRequest newUserSearchRequest(String filter, String... attributes)
+    {
+        SearchRequest searchRequest = ldapConnectionTemplate.newSearchRequest(
+                config.getLdapUserBaseDn(),
+                filter,
+                SearchScope.SUBTREE,
+                attributes);
+
+        switch (config.getLdapReferralPolicy()) {
+            case FOLLOW -> searchRequest.followReferrals();
+            case IGNORE -> searchRequest.ignoreReferrals();
+            case THROW -> {}
+        }
+
+        return searchRequest;
     }
 
     public static class UserRecord

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbLdapClient.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbLdapClient.java
@@ -15,6 +15,8 @@ package io.trino.gateway.ha.security;
 
 import io.airlift.log.Logger;
 import io.trino.gateway.ha.config.LdapConfiguration;
+import org.apache.directory.api.ldap.model.message.SearchRequest;
+import org.apache.directory.api.ldap.model.message.SearchRequestImpl;
 import org.apache.directory.api.ldap.model.message.SearchScope;
 import org.apache.directory.ldap.client.template.LdapConnectionTemplate;
 import org.apache.directory.ldap.client.template.exception.PasswordException;
@@ -29,7 +31,6 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 
@@ -69,13 +70,20 @@ final class TestLbLdapClient
         String password = "pass1";
 
         String filter = ldapConfig.getLdapUserSearch().replace("${USER}", user);
+        SearchRequest searchRequest = new SearchRequestImpl();
+
+        Mockito
+                .when(ldapConnectionTemplate.newSearchRequest(
+                        eq(ldapConfig.getLdapUserBaseDn()),
+                        eq(filter),
+                        eq(SearchScope.SUBTREE),
+                        any(String[].class)))
+                .thenReturn(searchRequest);
 
         Mockito
                 .when(ldapConnectionTemplate.authenticate(
-                        ldapConfig.getLdapUserBaseDn(),
-                        filter,
-                        SearchScope.SUBTREE,
-                        password.toCharArray()))
+                        eq(searchRequest),
+                        any(char[].class)))
                 .thenReturn(null);
 
         // Success case
@@ -83,10 +91,8 @@ final class TestLbLdapClient
 
         Mockito
                 .when(ldapConnectionTemplate.authenticate(
-                        ldapConfig.getLdapUserBaseDn(),
-                        filter,
-                        SearchScope.SUBTREE,
-                        password.toCharArray()))
+                        eq(searchRequest),
+                        any(char[].class)))
                 .thenReturn(new TestLbLdapClient.DummyPasswordWarning());
 
         // Warning case
@@ -94,23 +100,12 @@ final class TestLbLdapClient
 
         Mockito
                 .when(ldapConnectionTemplate.authenticate(
-                        ldapConfig.getLdapUserBaseDn(),
-                        filter,
-                        SearchScope.SUBTREE,
-                        password.toCharArray()))
+                        eq(searchRequest),
+                        any(char[].class)))
                 .thenThrow(PasswordException.class);
 
         // failure case
         assertThat(lbLdapClient.authenticate(user, password)).isFalse();
-
-        assertThatThrownBy(() -> Mockito
-                .when(ldapConnectionTemplate.authenticate(
-                        ldapConfig.getLdapUserBaseDn(),
-                        filter,
-                        SearchScope.SUBTREE,
-                        password.toCharArray()))
-                .thenReturn(null))
-                .isInstanceOf(PasswordException.class);
     }
 
     @Test
@@ -119,16 +114,22 @@ final class TestLbLdapClient
         String user = "user1";
         String[] attributes = new String[] {"memberOf"};
         String filter = ldapConfig.getLdapUserSearch().replace("${USER}", user);
+        SearchRequest searchRequest = new SearchRequestImpl();
+
+        Mockito
+                .when(ldapConnectionTemplate.newSearchRequest(
+                        eq(ldapConfig.getLdapUserBaseDn()),
+                        eq(filter),
+                        eq(SearchScope.SUBTREE),
+                        eq(attributes)))
+                .thenReturn(searchRequest);
 
         java.util.ArrayList users = new java.util.ArrayList();
         users.add(new LbLdapClient.UserRecord("Admin,User"));
 
         Mockito
                 .when(ldapConnectionTemplate.search(
-                        eq(ldapConfig.getLdapUserBaseDn()),
-                        eq(filter),
-                        eq(SearchScope.SUBTREE),
-                        eq(attributes),
+                        eq(searchRequest),
                         any(LbLdapClient.UserEntryMapper.class)))
                 .thenReturn(users);
 
@@ -140,15 +141,55 @@ final class TestLbLdapClient
 
         org.mockito.Mockito
                 .when(ldapConnectionTemplate.search(
-                        eq(ldapConfig.getLdapUserBaseDn()),
-                        eq(filter),
-                        eq(SearchScope.SUBTREE),
-                        eq(attributes),
+                        eq(searchRequest),
                         any(LbLdapClient.UserEntryMapper.class)))
                 .thenReturn(null);
 
         // failure case
         assertThat(lbLdapClient.getMemberOf(user)).isNotEqualTo("Admin,User");
+    }
+
+    @Test
+    void testReferralPolicy()
+    {
+        String user = "user1";
+        String[] attributes = new String[] {"memberOf"};
+        String filter = ldapConfig.getLdapUserSearch().replace("${USER}", user);
+
+        SearchRequest defaultSearchRequest = getMemberOfSearchRequest(filter, attributes);
+        assertThat(defaultSearchRequest.isFollowReferrals()).isFalse();
+        assertThat(defaultSearchRequest.isIgnoreReferrals()).isFalse();
+
+        ldapConfig.setLdapReferralPolicy(LdapConfiguration.LdapReferralPolicy.FOLLOW);
+        SearchRequest followSearchRequest = getMemberOfSearchRequest(filter, attributes);
+        assertThat(followSearchRequest.isFollowReferrals()).isTrue();
+        assertThat(followSearchRequest.isIgnoreReferrals()).isFalse();
+
+        ldapConfig.setLdapReferralPolicy(LdapConfiguration.LdapReferralPolicy.IGNORE);
+        SearchRequest ignoreSearchRequest = getMemberOfSearchRequest(filter, attributes);
+        assertThat(ignoreSearchRequest.isFollowReferrals()).isFalse();
+        assertThat(ignoreSearchRequest.isIgnoreReferrals()).isTrue();
+    }
+
+    private SearchRequest getMemberOfSearchRequest(String filter, String[] attributes)
+    {
+        SearchRequest searchRequest = new SearchRequestImpl();
+        Mockito
+                .when(ldapConnectionTemplate.newSearchRequest(
+                        eq(ldapConfig.getLdapUserBaseDn()),
+                        eq(filter),
+                        eq(SearchScope.SUBTREE),
+                        eq(attributes)))
+                .thenReturn(searchRequest);
+        Mockito
+                .when(ldapConnectionTemplate.search(
+                        eq(searchRequest),
+                        any(LbLdapClient.UserEntryMapper.class)))
+                .thenReturn(null);
+
+        lbLdapClient.getMemberOf("user1");
+
+        return searchRequest;
     }
 
     static class DummyPasswordWarning


### PR DESCRIPTION
## Description

Adds configurable LDAP referral handling for Gateway LDAP authentication and authorization lookups.

Previously, Gateway relied on Apache Directory `LdapConnectionTemplate` convenience search methods, which internally construct the LDAP `SearchRequest` and always use the default referral behavior. In Active Directory environments with broader search base DNs, LDAP searches may encounter referrals, causing authentication or group lookup to fail with `CursorLdapReferralException`.

This change introduces a new `ldapReferralPolicy` configuration option, allowing administrators to control how LDAP referrals are handled during authentication and authorization searches.

Supported values are:

```text
THROW
FOLLOW
IGNORE
```

The default is `THROW`, preserving the existing behavior unless users explicitly configure a different policy.

## Additional context and related issues

This change:
- Adds `LdapReferralPolicy` to `LdapConfiguration`.
- Builds explicit `SearchRequest` objects in `LbLdapClient` so the referral policy can be applied.
- Uses request-based `LdapConnectionTemplate` overloads for user authentication and group lookup.
- Adds unit tests covering the different referral policies.
- Documents the new `ldapReferralPolicy` configuration option.

Closes #1173.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.

(x) Release notes are required, with the following suggested text:

```markdown
* Add support for configuring LDAP referral handling during Gateway LDAP authentication and authorization using the `ldapReferralPolicy` setting.
```