### PR TITLE
Update pnpm from 10.27.0 to 11.13.1

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -560,7 +560,7 @@
                         </goals>
                         <configuration>
                             <nodeVersion>v24.12.0</nodeVersion>
-                            <pnpmVersion>10.27.0</pnpmVersion>
+                            <pnpmVersion>11.13.1</pnpmVersion>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
## Description

Bump the pnpm version pinned for the `frontend-maven-plugin` build of the `webapp` module from 10.27.0 to 11.13.1.

The webapp build produces identical output and `pnpm-lock.yaml` is unchanged, since pnpm 11 keeps `lockfileVersion 9.0`. Verified with a full frontend build (install + `pnpm run build`).

Note for local development

pnpm 11 refuses to purge a `node_modules` directory created by an older pnpm when there is no TTY, and the `frontend-maven-plugin` runs pnpm without one. An incremental build against an existing pnpm 10 `node_modules` therefore fails once with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`.

Fix (any one, one-time only):

- run a build with `mvnw clean`, which removes `webapp/node` and `webapp/node_modules`, or
- delete `webapp/node_modules` once.

CI is unaffected, since `CI=true` suppresses the prompt.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.