### PR TITLE
Clear Sass deprecation warnings in webapp build

### DIFF
--- a/webapp/src/styles/globals.scss
+++ b/webapp/src/styles/globals.scss
@@ -1,4 +1,4 @@
-@import "./animation.scss";
+@use "./animation.scss";
 
 // If you need to customize the theme, you have to open this line of code.
 // see: https://semi.design/en-US/start/customize-theme

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -12,6 +12,13 @@ export default defineConfig((mode: ConfigEnv) => {
   return {
     base: `/trino-gateway/`,
     plugins: [react(), svgr()],
+    css: {
+      preprocessorOptions: {
+        scss: {
+          api: 'modern-compiler',
+        },
+      },
+    },
     server: {
       proxy: {
         [proxyPath]: {


### PR DESCRIPTION
## Description

The webapp build emitted two Dart Sass deprecation warnings. Address both without changing the produced CSS:

- Opt Vite into the modern Sass compiler API via css.preprocessorOptions.scss.api, silencing the legacy-js-api warning. Vite 5 still defaults to the legacy JS API, which Dart Sass 2.0.0 will remove.
- Replace the deprecated @import of animation.scss with @use in globals.scss. Sass @import is deprecated and will be removed in Dart Sass 3.0.0.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
