### PR TITLE
Pin Trino OAuth2 token-exchange handshakes to the minting coordinator

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -159,6 +159,58 @@ dataStore:
 
 Find more information in the [routing rules documentation](routing-rules.md).
 
+### Configure OAuth2 token-exchange routing
+
+Trino's OAuth2 token-exchange handshake spans two HTTP clients that share only
+an `authId`: the driver/CLI poll loop (`GET /oauth2/token/{authId}`) and the
+browser (`GET /oauth2/token/initiate/{authIdHash}`, returning from the identity
+provider to `GET /oauth2/callback`). Only the coordinator that issued the
+original `401` challenge holds the in-memory exchange state for that `authId`,
+so in a multi-coordinator deployment normal routing can send these requests to
+a different backend and stall the login. This is separate from the existing
+cookie-based browser routing (see
+[Routing logic](routing-logic.md#routing-based-on-cookies)), which cannot help
+on its own since the driver and browser are different HTTP clients.
+
+Enable pinning of OAuth2 token-exchange requests to the coordinator that
+minted the `authId` with:
+
+```yaml
+routing:
+  oauth2RoutingEnabled: true   # default false
+```
+
+Pins are recorded in the `oauth2_routing` table so they are shared across
+gateway instances. This table is created automatically by the database
+migrations run on startup (see [Backend database](#backend-database)), so no
+separate database or manual setup is required as long as migrations are enabled.
+If you have set `runMigrationsEnabled` to `false`, the table is not created for
+you: you must provision it manually using the DDL below, otherwise pins cannot
+be persisted and OAuth2 routing silently falls back to normal routing. For
+reference, the DDL (identical for MySQL and PostgreSQL; Oracle uses `NUMBER` for
+the `created` column) is:
+
+```sql
+CREATE TABLE IF NOT EXISTS oauth2_routing (
+oauth_id VARCHAR(256) PRIMARY KEY,
+backend_url VARCHAR (256),
+created bigint
+);
+CREATE INDEX oauth2_routing_created_idx ON oauth2_routing(created);
+```
+
+If the pinned coordinator becomes unhealthy or inactive, the pin is dropped
+and the client is forced to re-authenticate, since the handshake cannot be
+recovered on another backend.
+
+Stored pins are retained for 1 hour by default, and are pruned automatically.
+The retention period can be adjusted with:
+
+```yaml
+dataStore:
+  oauth2RoutingHoursRetention: 1
+```
+
 ### Configure logging <a name="logging">
 
 To configure the logging level for various classes, specify the path to the 

--- a/docs/routing-logic.md
+++ b/docs/routing-logic.md
@@ -77,6 +77,44 @@ oauth2GatewayCookieConfiguration:
   lifetime: "5m"
 ```
 
+### Routing based on OAuth2 token-exchange pinning (opt-in)
+
+Trino's OAuth2 token-exchange handshake for the CLI/driver spans two HTTP
+clients that only share an internal identifier (`authId`, and its hash):
+
+* the driver/CLI polls `GET /oauth2/token/{authId}` until the login completes
+* the browser is redirected to `GET /oauth2/token/initiate/{authIdHash}`, and
+  then returns from the identity provider to `GET /oauth2/callback` (which
+  carries the `authIdHash` inside its signed `state` parameter)
+
+Only the Trino coordinator that issued the original `401` challenge holds the
+in-memory state for that handshake. In a deployment with multiple
+coordinators, Trino Gateway's normal routing may send the poll loop, the
+initiate redirect, or the callback to a different coordinator than the one
+that started the handshake, causing the login to stall. The cookie-based
+routing above cannot solve this on its own: the CLI/driver poll loop does not
+carry cookies.
+
+When `routing.oauth2RoutingEnabled` is set to true, Trino Gateway records the
+`authId`/`authIdHash` advertised in the `401` challenge together with the
+coordinator that issued it, and pins every later request of that handshake —
+the poll loop, the initiate redirect, and the callback — back to the same
+coordinator:
+
+```yaml
+routing:
+  oauth2RoutingEnabled: true
+```
+
+Pins are stored in the gateway's database so they are visible across every
+Trino Gateway instance, and are cleaned up automatically; see
+`dataStore.oauth2RoutingHoursRetention` (default 1 hour) to change how long a
+pin is kept. If the pinned coordinator becomes unavailable before the
+handshake completes, Trino Gateway drops the pin and asks the client to
+re-authenticate, since the handshake cannot be resumed on another coordinator.
+
+This feature is off by default.
+
 ## Routing URLs
 
 Each Trino cluster configured with the Trino Gateway includes both a `proxyTo` 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/DataStoreConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/DataStoreConfiguration.java
@@ -22,6 +22,8 @@ public class DataStoreConfiguration
     private boolean queryHistoryEnabled = true;
     private Integer queryHistoryHoursRetention = 4;
     private boolean runMigrationsEnabled = true;
+    // OAuth2 pins only need to outlive an in-flight handshake (minutes); keep them an hour.
+    private Integer oauth2RoutingHoursRetention = 1;
 
     public DataStoreConfiguration(String jdbcUrl, String user, String password, String driver, boolean queryHistoryEnabled, Integer queryHistoryHoursRetention, boolean runMigrationsEnabled)
     {
@@ -104,5 +106,15 @@ public class DataStoreConfiguration
     public void setRunMigrationsEnabled(boolean runMigrationsEnabled)
     {
         this.runMigrationsEnabled = runMigrationsEnabled;
+    }
+
+    public Integer getOauth2RoutingHoursRetention()
+    {
+        return this.oauth2RoutingHoursRetention;
+    }
+
+    public void setOauth2RoutingHoursRetention(Integer oauth2RoutingHoursRetention)
+    {
+        this.oauth2RoutingHoursRetention = oauth2RoutingHoursRetention;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/RoutingConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/RoutingConfiguration.java
@@ -25,6 +25,14 @@ public class RoutingConfiguration
 
     private String defaultRoutingGroup = "adhoc";
 
+    // Off (default, opt-in dark launch): when on, the gateway pins every request of a Trino
+    // OAuth2 token-exchange handshake (the driver's /oauth2/token/{authId} poll loop and the
+    // browser's /oauth2/token/initiate/{authIdHash} redirect) to the coordinator that minted the
+    // authId. Only that coordinator holds the in-memory token-exchange state, so without pinning a
+    // multi-coordinator deployment routes the poll loop stochastically and the handshake stalls.
+    // See OAuth2RoutingUtils.
+    private boolean oauth2RoutingEnabled;
+
     public Duration getAsyncTimeout()
     {
         return asyncTimeout;
@@ -53,5 +61,15 @@ public class RoutingConfiguration
     public void setDefaultRoutingGroup(String defaultRoutingGroup)
     {
         this.defaultRoutingGroup = defaultRoutingGroup;
+    }
+
+    public boolean isOauth2RoutingEnabled()
+    {
+        return oauth2RoutingEnabled;
+    }
+
+    public void setOauth2RoutingEnabled(boolean oauth2RoutingEnabled)
+    {
+        this.oauth2RoutingEnabled = oauth2RoutingEnabled;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/RoutingTargetHandler.java
@@ -21,11 +21,14 @@ import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 import io.trino.gateway.ha.handler.schema.RoutingDestination;
 import io.trino.gateway.ha.handler.schema.RoutingTargetResponse;
 import io.trino.gateway.ha.router.GatewayCookie;
+import io.trino.gateway.ha.router.OAuth2RoutingStore;
+import io.trino.gateway.ha.router.OAuth2RoutingUtils;
 import io.trino.gateway.ha.router.RoutingGroupSelector;
 import io.trino.gateway.ha.router.RoutingManager;
 import io.trino.gateway.ha.router.schema.RoutingSelectorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.ws.rs.WebApplicationException;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -45,26 +48,31 @@ public class RoutingTargetHandler
 {
     private static final Logger log = Logger.get(RoutingTargetHandler.class);
     private final RoutingManager routingManager;
+    private final OAuth2RoutingStore oauth2RoutingStore;
     private final RoutingGroupSelector routingGroupSelector;
     private final String defaultRoutingGroup;
     private final List<String> statementPaths;
     private final boolean requestAnalyserClientsUseV2Format;
     private final int requestAnalyserMaxBodySize;
     private final boolean cookiesEnabled;
+    private final boolean oauth2RoutingEnabled;
 
     @Inject
     public RoutingTargetHandler(
             RoutingManager routingManager,
+            OAuth2RoutingStore oauth2RoutingStore,
             RoutingGroupSelector routingGroupSelector,
             HaGatewayConfiguration haGatewayConfiguration)
     {
         this.routingManager = requireNonNull(routingManager);
+        this.oauth2RoutingStore = requireNonNull(oauth2RoutingStore);
         this.routingGroupSelector = requireNonNull(routingGroupSelector);
         this.defaultRoutingGroup = haGatewayConfiguration.getRouting().getDefaultRoutingGroup();
         statementPaths = requireNonNull(haGatewayConfiguration.getStatementPaths());
         requestAnalyserClientsUseV2Format = haGatewayConfiguration.getRequestAnalyzerConfig().isClientsUseV2Format();
         requestAnalyserMaxBodySize = haGatewayConfiguration.getRequestAnalyzerConfig().getMaxBodySize();
         cookiesEnabled = GatewayCookieConfigurationPropertiesProvider.getInstance().isEnabled();
+        oauth2RoutingEnabled = haGatewayConfiguration.getRouting().isOauth2RoutingEnabled();
     }
 
     public RoutingTargetResponse resolveRouting(HttpServletRequest request)
@@ -152,6 +160,12 @@ public class RoutingTargetHandler
 
     private Optional<String> getPreviousCluster(Optional<String> queryId, HttpServletRequest request)
     {
+        if (oauth2RoutingEnabled) {
+            Optional<String> oauthBackend = getOAuth2StickyBackend(request);
+            if (oauthBackend.isPresent()) {
+                return oauthBackend;
+            }
+        }
         if (queryId.isPresent()) {
             return queryId.map(routingManager::findBackendForQueryId);
         }
@@ -169,6 +183,61 @@ public class RoutingTargetHandler
             }
         }
         return Optional.empty();
+    }
+
+    /**
+     * Pins an in-flight Trino OAuth2 token-exchange request to the coordinator that minted its
+     * {@code authId}. Covers all three gateway legs of the handshake — the driver poll, the browser
+     * initiate, and the browser callback (keyed by the {@code authIdHash} inside its {@code state}).
+     * Returns:
+     * <ul>
+     *   <li>a present backend — route the request there (the sticky coordinator is active and healthy);</li>
+     *   <li>empty — not a pinnable token-exchange request, or no pin recorded yet on this gateway
+     *       (fall through to normal routing; the 401 challenge handler records the pin).</li>
+     * </ul>
+     * If a pin exists but its coordinator is no longer active and healthy — deactivated, unhealthy, or
+     * removed from the fleet — the pin is dropped and the client is forced to re-authenticate, since
+     * only the minting coordinator holds the exchange state and the handshake cannot be recovered on
+     * another backend.
+     */
+    private Optional<String> getOAuth2StickyBackend(HttpServletRequest request)
+    {
+        String oauthId = oauth2RoutingId(request).orElse(null);
+        if (oauthId == null) {
+            return Optional.empty();
+        }
+        String pinnedBackend = oauth2RoutingStore.findBackend(oauthId).orElse(null);
+        if (pinnedBackend == null) {
+            return Optional.empty();
+        }
+        // Route to the pinned coordinator only while it is still active and healthy. Deactivation is a
+        // deliberate operator signal to stop sending it traffic, so an inactive coordinator is treated
+        // as unavailable even if it is otherwise healthy; an unhealthy or removed coordinator is
+        // likewise unavailable. Only the minting coordinator holds this handshake's in-memory exchange
+        // state, so when it is unavailable the pin cannot be recovered on another backend — drop it and
+        // force re-auth.
+        if (routingManager.isBackendActiveAndHealthy(pinnedBackend)) {
+            return Optional.of(pinnedBackend);
+        }
+        oauth2RoutingStore.removeBackend(oauthId);
+        log.warn("OAuth2 pinned backend [%s] is unavailable for [%s]; forcing re-auth", pinnedBackend, request.getRequestURI());
+        throw new WebApplicationException(OAuth2RoutingUtils.forceReAuthResponse(request.getRequestURI()));
+    }
+
+    /**
+     * The pin key for an in-flight token-exchange request: from the path for the driver poll
+     * ({@code /oauth2/token/{authId}}) and the browser initiate
+     * ({@code /oauth2/token/initiate/{authIdHash}}), or from the {@code state} parameter for the
+     * browser callback ({@code /oauth2/callback}). Empty for anything else.
+     */
+    private Optional<String> oauth2RoutingId(HttpServletRequest request)
+    {
+        String path = request.getRequestURI();
+        Optional<String> callbackId = OAuth2RoutingUtils.oauthIdFromCallback(path, request.getQueryString());
+        if (callbackId.isPresent()) {
+            return callbackId;
+        }
+        return OAuth2RoutingUtils.oauthIdFromRequestPath(path);
     }
 
     private void logRewrite(String newBackend, HttpServletRequest request)

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/module/HaGatewayProviderModule.java
@@ -46,7 +46,9 @@ import io.trino.gateway.ha.router.BackendStateManager;
 import io.trino.gateway.ha.router.ForRouter;
 import io.trino.gateway.ha.router.GatewayBackendManager;
 import io.trino.gateway.ha.router.HaGatewayManager;
+import io.trino.gateway.ha.router.HaOAuth2RoutingStore;
 import io.trino.gateway.ha.router.HaQueryHistoryManager;
+import io.trino.gateway.ha.router.OAuth2RoutingStore;
 import io.trino.gateway.ha.router.PathFilter;
 import io.trino.gateway.ha.router.QueryHistoryManager;
 import io.trino.gateway.ha.router.RoutingGroupSelector;
@@ -80,6 +82,7 @@ public class HaGatewayProviderModule
         jaxrsBinder(binder()).bind(ResourceSecurityDynamicFeature.class);
         binder().bind(GatewayBackendManager.class).to(HaGatewayManager.class).in(Scopes.SINGLETON);
         binder().bind(QueryHistoryManager.class).to(HaQueryHistoryManager.class).in(Scopes.SINGLETON);
+        binder().bind(OAuth2RoutingStore.class).to(HaOAuth2RoutingStore.class).in(Scopes.SINGLETON);
         binder().bind(BackendStateManager.class).in(Scopes.SINGLETON);
         binder().bind(JdbcConnectionManager.class).in(Scopes.SINGLETON);
         binder().bind(AuthorizationManager.class).in(Scopes.SINGLETON);

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/JdbcConnectionManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/JdbcConnectionManager.java
@@ -17,6 +17,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.trino.gateway.ha.config.DataStoreConfiguration;
+import io.trino.gateway.ha.persistence.dao.OAuth2RoutingDao;
 import io.trino.gateway.ha.persistence.dao.QueryHistoryDao;
 import jakarta.annotation.Nullable;
 import org.jdbi.v3.core.Jdbi;
@@ -32,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import static java.util.Objects.requireNonNull;
 
 public class JdbcConnectionManager
+        implements AutoCloseable
 {
     private static final Logger log = Logger.get(JdbcConnectionManager.class);
 
@@ -106,12 +108,36 @@ public class JdbcConnectionManager
     {
         executorService.scheduleWithFixedDelay(
                 () -> {
-                    log.info("Performing query history cleanup task");
-                    long created = System.currentTimeMillis() - TimeUnit.HOURS.toMillis(this.configuration.getQueryHistoryHoursRetention());
-                    jdbi.onDemand(QueryHistoryDao.class).deleteOldHistory(created);
+                    // Each cleanup is isolated in its own try-catch: scheduleWithFixedDelay silently
+                    // suppresses all future runs once a task throws, so a failure in one cleanup (e.g. a
+                    // table not yet created during a rolling deploy) must neither skip the other cleanup
+                    // nor propagate out of the scheduled task.
+                    try {
+                        log.info("Performing query history cleanup task");
+                        long created = System.currentTimeMillis() - TimeUnit.HOURS.toMillis(this.configuration.getQueryHistoryHoursRetention());
+                        jdbi.onDemand(QueryHistoryDao.class).deleteOldHistory(created);
+                    }
+                    catch (RuntimeException e) {
+                        log.warn(e, "Query history cleanup failed; will retry on next run");
+                    }
+
+                    try {
+                        log.info("Performing OAuth2 routing cleanup task");
+                        long oauthCutoff = System.currentTimeMillis() - TimeUnit.HOURS.toMillis(this.configuration.getOauth2RoutingHoursRetention());
+                        jdbi.onDemand(OAuth2RoutingDao.class).deleteOldOAuth2Pins(oauthCutoff);
+                    }
+                    catch (RuntimeException e) {
+                        log.warn(e, "OAuth2 routing cleanup failed; will retry on next run");
+                    }
                 },
                 1,
                 120,
                 TimeUnit.MINUTES);
+    }
+
+    @Override
+    public void close()
+    {
+        executorService.shutdownNow();
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/OAuth2RoutingDao.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/persistence/dao/OAuth2RoutingDao.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.persistence.dao;
+
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+public interface OAuth2RoutingDao
+{
+    @SqlQuery(
+            """
+            SELECT backend_url FROM oauth2_routing
+            WHERE oauth_id = :oauthId
+            """)
+    String findBackendByOAuthId(String oauthId);
+
+    @SqlUpdate(
+            """
+            INSERT INTO oauth2_routing (oauth_id, backend_url, created)
+            VALUES (:oauthId, :backendUrl, :created)
+            """)
+    void insert(String oauthId, String backendUrl, long created);
+
+    @SqlUpdate(
+            """
+            DELETE FROM oauth2_routing
+            WHERE oauth_id = :oauthId
+            """)
+    void delete(String oauthId);
+
+    @SqlUpdate(
+            """
+            DELETE FROM oauth2_routing
+            WHERE created < :created
+            """)
+    void deleteOldOAuth2Pins(long created);
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
@@ -109,6 +109,14 @@ public abstract class BaseRoutingManager
         return selectBackend(backends, user).orElseGet(() -> provideDefaultBackendConfiguration(user));
     }
 
+    @Override
+    public boolean isBackendActiveAndHealthy(String backendUrl)
+    {
+        return gatewayBackendManager.getAllActiveBackends().stream()
+                .filter(backend -> backend.getProxyTo().equals(backendUrl))
+                .anyMatch(backend -> isBackendHealthy(backend.getName()));
+    }
+
     /**
      * Performs cache look up, if a backend not found, it checks with all backends and tries to find
      * out which backend has info about given query id.

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaOAuth2RoutingStore.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/HaOAuth2RoutingStore.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.trino.gateway.ha.persistence.dao.OAuth2RoutingDao;
+import org.jdbi.v3.core.Jdbi;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Shared, cross-pod {@link OAuth2RoutingStore} backed by the {@code oauth2_routing} table.
+ * <p>
+ * The DB is the single source of truth — there is no cache. Pins are written once per handshake and
+ * read only a handful of times, so the DB load is negligible and a cache would only add staleness.
+ * Every DB call is wrapped so that if the DB is unreadable for any reason, {@link #findBackend}
+ * returns empty and the request falls back to normal (non-pinned) routing.
+ */
+public class HaOAuth2RoutingStore
+        implements OAuth2RoutingStore
+{
+    private static final Logger log = Logger.get(HaOAuth2RoutingStore.class);
+
+    private final Jdbi jdbi;
+    private final OAuth2RoutingDao dao;
+
+    @Inject
+    public HaOAuth2RoutingStore(Jdbi jdbi)
+    {
+        this.jdbi = requireNonNull(jdbi, "jdbi is null");
+        this.dao = jdbi.onDemand(OAuth2RoutingDao.class);
+    }
+
+    @Override
+    public void setBackend(String oauthId, String backend)
+    {
+        try {
+            // Idempotent upsert without dialect-specific syntax: a repeated challenge for the same
+            // id (or a re-pin) replaces the row rather than failing on the primary key. Run as one
+            // transaction on a single connection so the delete+insert is atomic and concurrent pins
+            // of the same id serialize instead of racing into a primary-key violation.
+            jdbi.useTransaction(handle -> {
+                OAuth2RoutingDao txDao = handle.attach(OAuth2RoutingDao.class);
+                txDao.delete(oauthId);
+                txDao.insert(oauthId, backend, System.currentTimeMillis());
+            });
+        }
+        catch (RuntimeException e) {
+            log.warn(e, "Failed to persist OAuth2 pin [%s]", oauthId);
+        }
+    }
+
+    @Override
+    public Optional<String> findBackend(String oauthId)
+    {
+        try {
+            return Optional.ofNullable(dao.findBackendByOAuthId(oauthId));
+        }
+        catch (RuntimeException e) {
+            // DB unreadable: fall back to normal (non-pinned) routing rather than failing the request.
+            log.warn(e, "Failed to load OAuth2 pin [%s]; falling back to normal routing", oauthId);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void removeBackend(String oauthId)
+    {
+        try {
+            dao.delete(oauthId);
+        }
+        catch (RuntimeException e) {
+            log.warn(e, "Failed to remove OAuth2 pin [%s]", oauthId);
+        }
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/OAuth2RoutingStore.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/OAuth2RoutingStore.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import java.util.Optional;
+
+/**
+ * Shared, cross-pod store of Trino OAuth2 token-exchange pins ({@code authId}/{@code authIdHash} →
+ * minting coordinator). A pin is recorded by whichever gateway pod proxies the {@code 401}
+ * challenge, but the matching poll/initiate request may land on a different pod, so the pin must be
+ * visible to every pod. See {@link OAuth2RoutingUtils}.
+ */
+public interface OAuth2RoutingStore
+{
+    /**
+     * Pins an OAuth2 identifier to the coordinator that minted it.
+     */
+    void setBackend(String oauthId, String backend);
+
+    /**
+     * The pinned backend for an OAuth2 identifier, or empty if none is recorded.
+     */
+    Optional<String> findBackend(String oauthId);
+
+    /**
+     * Drops a pin (e.g. once its backend is gone and the client must re-authenticate).
+     */
+    void removeBackend(String oauthId);
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/OAuth2RoutingUtils.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/OAuth2RoutingUtils.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import jakarta.ws.rs.core.Response;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
+
+/**
+ * Wire-format knowledge for Trino's OAuth2 token-exchange handshake, kept in one place so the
+ * coupling to Trino server internals is explicit and easy to adjust per Trino version.
+ * <p>
+ * The handshake spans two HTTP clients that share only an {@code authId} (and its hash):
+ * <ul>
+ *   <li>the driver/CLI poll loop: {@code GET /oauth2/token/{authId}}</li>
+ *   <li>the browser: {@code GET /oauth2/token/initiate/{authIdHash}} → IdP → {@code /oauth2/callback}</li>
+ * </ul>
+ * The {@code authId} is minted by the coordinator that issues the {@code 401} challenge, and only
+ * that coordinator holds the in-memory exchange state for it. So every request carrying that
+ * {@code authId}/hash must be routed back to the minting coordinator.
+ * <p>
+ * The minting coordinator advertises both identifiers in the {@code WWW-Authenticate} challenge it
+ * returns on the unauthenticated request:
+ * <pre>
+ *   WWW-Authenticate: Bearer x_redirect_server="https://host/oauth2/token/initiate/{authIdHash}",
+ *                            x_token_server="https://host/oauth2/token/{authId}"
+ * </pre>
+ * Recording both identifiers from that single challenge lets the gateway pin the poll loop
+ * ({@code authId}) and the browser initiate redirect ({@code authIdHash}) without ever having to
+ * reproduce Trino's hashing of {@code authId}.
+ * <p>
+ * NOTE: the path and challenge-parameter constants below mirror Trino's token-exchange flow
+ * (verified shape as of Trino 446). They are intentionally isolated here; if a future Trino version
+ * changes them, this is the only file that needs to change.
+ */
+public final class OAuth2RoutingUtils
+{
+    private OAuth2RoutingUtils() {}
+
+    // Trino's token-exchange endpoints. The initiate endpoint is a sub-path of the token endpoint,
+    // so the more specific prefix must be checked first.
+    public static final String OAUTH2_TOKEN_PATH_PREFIX = "/oauth2/token/";
+    public static final String OAUTH2_INITIATE_PATH_PREFIX = "/oauth2/token/initiate/";
+    // Trino's OAuth2 callback (the browser leg returning from the IdP). Unlike the token/initiate
+    // legs it carries no id in its path — the id rides through the IdP inside the state parameter.
+    public static final String OAUTH2_CALLBACK_PATH = "/oauth2/callback";
+
+    // Parameters Trino places in the WWW-Authenticate challenge for the token-exchange flow.
+    private static final String TOKEN_SERVER_PARAM = "x_token_server";
+    private static final String REDIRECT_SERVER_PARAM = "x_redirect_server";
+
+    // Trino round-trips the id through the IdP inside the "state" query parameter (a signed JWT); its
+    // "handler_state" claim is the authIdHash the initiate/poll legs are already pinned by.
+    private static final String STATE_PARAM = "state";
+    private static final String HANDLER_STATE_CLAIM = "handler_state";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final Pattern TOKEN_SERVER_PATTERN = challengeParamPattern(TOKEN_SERVER_PARAM);
+    private static final Pattern REDIRECT_SERVER_PATTERN = challengeParamPattern(REDIRECT_SERVER_PARAM);
+
+    static final String REAUTH_MESSAGE =
+            "Trino Gateway: the Trino coordinator handling this OAuth2 login is no longer available. Please reconnect to re-authenticate.";
+    // Trino's token-poll failure contract: HttpTokenPoller maps a 200 response whose JSON body has an
+    // "error" field to TokenPollResult.failed(error) — the same response a coordinator returns for a
+    // failed exchange. It surfaces our message and ends the poll loop cleanly, so the next connection
+    // re-authenticates against a healthy coordinator. A non-2xx status would not carry the message.
+    private static final String REAUTH_TOKEN_POLL_BODY = "{\"error\":\"" + REAUTH_MESSAGE + "\"}";
+
+    private static Pattern challengeParamPattern(String param)
+    {
+        // matches:  param="<value>"   (value is the advertised server URL)
+        return Pattern.compile(Pattern.quote(param) + "\\s*=\\s*\"([^\"]+)\"");
+    }
+
+    /**
+     * The stable routing key for an in-flight handshake request carried in the request <em>path</em>:
+     * the driver poll ({@code /oauth2/token/{authId}}) and the browser initiate
+     * ({@code /oauth2/token/initiate/{authIdHash}}). Empty if {@code path} is neither. The browser
+     * callback ({@code /oauth2/callback}) carries its id in the {@code state} parameter instead — see
+     * {@link #oauthIdFromCallback}.
+     */
+    public static Optional<String> oauthIdFromRequestPath(String path)
+    {
+        if (isNullOrEmpty(path)) {
+            return Optional.empty();
+        }
+        if (path.startsWith(OAUTH2_INITIATE_PATH_PREFIX)) {
+            return firstSegmentAfter(path, OAUTH2_INITIATE_PATH_PREFIX);
+        }
+        if (path.startsWith(OAUTH2_TOKEN_PATH_PREFIX)) {
+            return firstSegmentAfter(path, OAUTH2_TOKEN_PATH_PREFIX);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * The routing key for an OAuth2 callback request ({@code /oauth2/callback?state=...&code=...}).
+     * The callback is the browser leg returning from the IdP; unlike the token/initiate legs it
+     * carries no id in its path. Trino round-trips the id through the IdP inside the signed
+     * {@code state} JWT, as the {@code handler_state} claim — which is exactly the {@code authIdHash}
+     * the initiate and poll legs are already pinned by. We decode the JWT payload (base64url, without
+     * verifying the signature — this only selects a backend; the coordinator still verifies it) and
+     * return that {@code authIdHash} so the callback is pinned to the same coordinator that minted the
+     * handshake, without depending on {@link OAuth2GatewayCookie}. Empty if this is not a callback,
+     * the {@code state} is absent, it is a browser-UI login (no {@code handler_state}), or the state
+     * cannot be parsed — in which case the caller falls back to normal (cookie/stochastic) routing.
+     */
+    public static Optional<String> oauthIdFromCallback(String path, String queryString)
+    {
+        if (isNullOrEmpty(path) || !path.startsWith(OAUTH2_CALLBACK_PATH)) {
+            return Optional.empty();
+        }
+        return stateParam(queryString).flatMap(OAuth2RoutingUtils::handlerStateClaim);
+    }
+
+    /**
+     * Both routing keys ({@code authId} and {@code authIdHash}) advertised in a {@code 401}
+     * token-exchange challenge, or empty if {@code wwwAuthenticate} is not such a challenge.
+     */
+    public static Set<String> oauthIdsFromChallenge(String wwwAuthenticate)
+    {
+        if (isNullOrEmpty(wwwAuthenticate) || !wwwAuthenticate.contains(OAUTH2_TOKEN_PATH_PREFIX)) {
+            return ImmutableSet.of();
+        }
+        ImmutableSet.Builder<String> ids = ImmutableSet.builder();
+        addIdFromServerUrl(ids, TOKEN_SERVER_PATTERN.matcher(wwwAuthenticate));
+        addIdFromServerUrl(ids, REDIRECT_SERVER_PATTERN.matcher(wwwAuthenticate));
+        return ids.build();
+    }
+
+    /**
+     * The response to return when an in-flight handshake's pinned coordinator is gone, so the client
+     * fails the dead handshake cleanly and re-authenticates on its next attempt. The browser legs (the
+     * initiate redirect and the IdP callback) get a plain {@code 401}; only the driver poll loop gets
+     * Trino's token-poll failure contract (HTTP 200 with an {@code error} body).
+     */
+    public static Response forceReAuthResponse(String requestPath)
+    {
+        if (requestPath != null
+                && (requestPath.startsWith(OAUTH2_INITIATE_PATH_PREFIX) || requestPath.startsWith(OAUTH2_CALLBACK_PATH))) {
+            return Response.status(UNAUTHORIZED).entity(REAUTH_MESSAGE).build();
+        }
+        return Response.ok(REAUTH_TOKEN_POLL_BODY).type(APPLICATION_JSON).build();
+    }
+
+    private static void addIdFromServerUrl(ImmutableSet.Builder<String> ids, Matcher matcher)
+    {
+        if (!matcher.find()) {
+            return;
+        }
+        String serverUrl = matcher.group(1);
+        int tokenPathStart = serverUrl.indexOf(OAUTH2_TOKEN_PATH_PREFIX);
+        if (tokenPathStart < 0) {
+            return;
+        }
+        // Reuse the request-path logic on the path portion of the advertised URL.
+        oauthIdFromRequestPath(serverUrl.substring(tokenPathStart)).ifPresent(ids::add);
+    }
+
+    private static Optional<String> firstSegmentAfter(String path, String prefix)
+    {
+        String remainder = path.substring(prefix.length());
+        int nextSlash = remainder.indexOf('/');
+        if (nextSlash >= 0) {
+            remainder = remainder.substring(0, nextSlash);
+        }
+        return remainder.isEmpty() ? Optional.empty() : Optional.of(remainder);
+    }
+
+    private static Optional<String> stateParam(String queryString)
+    {
+        if (isNullOrEmpty(queryString)) {
+            return Optional.empty();
+        }
+        for (String pair : queryString.split("&")) {
+            int eq = pair.indexOf('=');
+            if (eq > 0 && pair.substring(0, eq).equals(STATE_PARAM)) {
+                String value = pair.substring(eq + 1);
+                if (value.isEmpty()) {
+                    return Optional.empty();
+                }
+                try {
+                    return Optional.of(URLDecoder.decode(value, StandardCharsets.UTF_8));
+                }
+                catch (IllegalArgumentException e) {
+                    // Malformed percent-encoding: treat as unparseable and fall back to normal routing.
+                    return Optional.empty();
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<String> handlerStateClaim(String state)
+    {
+        // A compact JWS is header.payload.signature; decode the payload and read handler_state.
+        int firstDot = state.indexOf('.');
+        int secondDot = firstDot < 0 ? -1 : state.indexOf('.', firstDot + 1);
+        if (secondDot < 0) {
+            return Optional.empty();
+        }
+        try {
+            byte[] payload = Base64.getUrlDecoder().decode(state.substring(firstDot + 1, secondDot));
+            JsonNode claim = OBJECT_MAPPER.readTree(payload).get(HANDLER_STATE_CLAIM);
+            if (claim == null || claim.isNull() || isNullOrEmpty(claim.asText())) {
+                return Optional.empty();
+            }
+            return Optional.of(claim.asText());
+        }
+        catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/RoutingManager.java
@@ -92,4 +92,12 @@ public interface RoutingManager
      * @return the backend configuration for the selected cluster
      */
     ProxyBackendConfiguration provideBackendConfiguration(String routingGroup, String user);
+
+    /**
+     * Whether {@code backendUrl} currently maps to an active, healthy backend.
+     *
+     * @param backendUrl the backend's proxy-to URL
+     * @return true if a backend with this URL is active and healthy
+     */
+    boolean isBackendActiveAndHealthy(String backendUrl);
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/proxyserver/ProxyRequestHandler.java
@@ -30,6 +30,8 @@ import io.trino.gateway.ha.config.ProxyResponseConfiguration;
 import io.trino.gateway.ha.handler.schema.RoutingDestination;
 import io.trino.gateway.ha.router.GatewayCookie;
 import io.trino.gateway.ha.router.OAuth2GatewayCookie;
+import io.trino.gateway.ha.router.OAuth2RoutingStore;
+import io.trino.gateway.ha.router.OAuth2RoutingUtils;
 import io.trino.gateway.ha.router.QueryHistoryManager;
 import io.trino.gateway.ha.router.RoutingManager;
 import io.trino.gateway.ha.router.TrinoRequestUser;
@@ -47,10 +49,12 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.net.HttpHeaders.WWW_AUTHENTICATE;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.http.client.HeaderNames.VIA;
@@ -70,6 +74,7 @@ import static io.trino.gateway.ha.handler.ProxyUtils.SOURCE_HEADER;
 import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import static jakarta.ws.rs.core.Response.Status.BAD_GATEWAY;
 import static jakarta.ws.rs.core.Response.Status.OK;
+import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.list;
 import static java.util.Objects.requireNonNull;
@@ -88,7 +93,9 @@ public class ProxyRequestHandler
     private final HttpClient httpClient;
     private final RoutingManager routingManager;
     private final QueryHistoryManager queryHistoryManager;
+    private final OAuth2RoutingStore oauth2RoutingStore;
     private final boolean cookiesEnabled;
+    private final boolean oauth2RoutingEnabled;
     private final boolean forwardedHeadersEnabled;
     private final List<String> statementPaths;
     private final boolean includeClusterInfoInResponse;
@@ -99,12 +106,15 @@ public class ProxyRequestHandler
             @ForProxy HttpClient httpClient,
             RoutingManager routingManager,
             QueryHistoryManager queryHistoryManager,
+            OAuth2RoutingStore oauth2RoutingStore,
             HaGatewayConfiguration haGatewayConfiguration)
     {
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.routingManager = requireNonNull(routingManager, "routingManager is null");
         this.queryHistoryManager = requireNonNull(queryHistoryManager, "queryHistoryManager is null");
+        this.oauth2RoutingStore = requireNonNull(oauth2RoutingStore, "oauth2RoutingStore is null");
         cookiesEnabled = GatewayCookieConfigurationPropertiesProvider.getInstance().isEnabled();
+        oauth2RoutingEnabled = haGatewayConfiguration.getRouting().isOauth2RoutingEnabled();
         asyncTimeout = haGatewayConfiguration.getRouting().getAsyncTimeout();
         forwardedHeadersEnabled = haGatewayConfiguration.getRouting().isForwardedHeadersEnabled();
         statementPaths = haGatewayConfiguration.getStatementPaths();
@@ -186,6 +196,10 @@ public class ProxyRequestHandler
                 .build();
 
         FluentFuture<ProxyResponse> future = executeHttp(request);
+
+        if (oauth2RoutingEnabled) {
+            future = future.transform(response -> recordOAuth2Challenge(remoteUri, response), executor);
+        }
 
         if (statementPaths.stream().anyMatch(request.getUri().getPath()::startsWith) && request.getMethod().equals(HttpMethod.POST)) {
             Optional<String> username = ((TrinoRequestUser) servletRequest.getAttribute(TRINO_REQUEST_USER)).getUser();
@@ -297,6 +311,29 @@ public class ProxyRequestHandler
         queryDetail.setRoutingGroup(routingDestination.routingGroup());
         queryDetail.setExternalUrl(routingDestination.externalUrl());
         queryHistoryManager.submitQueryDetail(queryDetail);
+        return response;
+    }
+
+    /**
+     * Pins the Trino OAuth2 token-exchange handshake to this backend. The minting coordinator
+     * advertises the {@code authId} (poll loop) and {@code authIdHash} (browser initiate) inside the
+     * {@code WWW-Authenticate} challenge of its {@code 401}; recording both here lets every later
+     * request of the handshake be routed back here. See {@link OAuth2RoutingUtils}.
+     */
+    private ProxyResponse recordOAuth2Challenge(URI remoteUri, ProxyResponse response)
+    {
+        if (response.statusCode() != UNAUTHORIZED.getStatusCode()) {
+            return response;
+        }
+        String backend = getRemoteTarget(remoteUri);
+        response.headers().entries().stream()
+                .filter(entry -> entry.getKey().toString().equalsIgnoreCase(WWW_AUTHENTICATE))
+                .map(Map.Entry::getValue)
+                .flatMap(header -> OAuth2RoutingUtils.oauthIdsFromChallenge(header).stream())
+                .forEach(oauthId -> {
+                    oauth2RoutingStore.setBackend(oauthId, backend);
+                    log.debug("Pinned OAuth2 id [%s] to backend [%s]", oauthId, backend);
+                });
         return response;
     }
 

--- a/gateway-ha/src/main/resources/gateway-ha-persistence-mysql.sql
+++ b/gateway-ha/src/main/resources/gateway-ha-persistence-mysql.sql
@@ -16,6 +16,13 @@ source VARCHAR(256)
 );
 CREATE INDEX query_history_created_idx ON query_history(created);
 
+CREATE TABLE IF NOT EXISTS oauth2_routing (
+oauth_id VARCHAR(256) PRIMARY KEY,
+backend_url VARCHAR (256),
+created bigint
+);
+CREATE INDEX oauth2_routing_created_idx ON oauth2_routing(created);
+
 CREATE TABLE IF NOT EXISTS resource_groups (
     resource_group_id BIGINT NOT NULL AUTO_INCREMENT,
     name VARCHAR(250) NOT NULL UNIQUE,

--- a/gateway-ha/src/main/resources/gateway-ha-persistence-postgres.sql
+++ b/gateway-ha/src/main/resources/gateway-ha-persistence-postgres.sql
@@ -16,6 +16,13 @@ source VARCHAR(256)
 );
 CREATE INDEX query_history_created_idx ON query_history(created);
 
+CREATE TABLE IF NOT EXISTS oauth2_routing (
+oauth_id VARCHAR(256) PRIMARY KEY,
+backend_url VARCHAR (256),
+created bigint
+);
+CREATE INDEX oauth2_routing_created_idx ON oauth2_routing(created);
+
 CREATE TABLE IF NOT EXISTS resource_groups (
     resource_group_id SERIAL,
     name VARCHAR(250) NOT NULL UNIQUE,

--- a/gateway-ha/src/main/resources/mysql/V5__add_oauth2_routing.sql
+++ b/gateway-ha/src/main/resources/mysql/V5__add_oauth2_routing.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS oauth2_routing (
+oauth_id VARCHAR(256) PRIMARY KEY,
+backend_url VARCHAR (256),
+created bigint
+);
+CREATE INDEX oauth2_routing_created_idx ON oauth2_routing(created);

--- a/gateway-ha/src/main/resources/oracle/V5__add_oauth2_routing.sql
+++ b/gateway-ha/src/main/resources/oracle/V5__add_oauth2_routing.sql
@@ -1,0 +1,6 @@
+CREATE TABLE oauth2_routing (
+    oauth_id VARCHAR(256) PRIMARY KEY,
+    backend_url VARCHAR (256),
+    created NUMBER
+);
+CREATE INDEX oauth2_routing_created_idx ON oauth2_routing(created);

--- a/gateway-ha/src/main/resources/postgresql/V5__add_oauth2_routing.sql
+++ b/gateway-ha/src/main/resources/postgresql/V5__add_oauth2_routing.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS oauth2_routing (
+oauth_id VARCHAR(256) PRIMARY KEY,
+backend_url VARCHAR (256),
+created bigint
+);
+CREATE INDEX IF NOT EXISTS oauth2_routing_created_idx ON oauth2_routing(created);

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandler.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandler.java
@@ -22,6 +22,7 @@ import io.trino.gateway.ha.config.ProxyBackendConfiguration;
 import io.trino.gateway.ha.config.RequestAnalyzerConfig;
 import io.trino.gateway.ha.config.RulesExternalConfiguration;
 import io.trino.gateway.ha.handler.schema.RoutingTargetResponse;
+import io.trino.gateway.ha.router.OAuth2RoutingStore;
 import io.trino.gateway.ha.router.RoutingGroupSelector;
 import io.trino.gateway.ha.router.RoutingManager;
 import io.trino.gateway.ha.router.schema.ExternalRouterResponse;
@@ -114,6 +115,7 @@ class TestRoutingTargetHandler
         // Initialize the handler with the configuration
         handler = new RoutingTargetHandler(
                 routingManager,
+                Mockito.mock(OAuth2RoutingStore.class),
                 RoutingGroupSelector.byRoutingExternal(httpClient, config.getRoutingRules().getRulesExternalConfiguration(), config.getRequestAnalyzerConfig()),
                 config);
     }
@@ -343,6 +345,7 @@ class TestRoutingTargetHandler
         config.getRoutingRules().getRulesExternalConfiguration().setPropagateErrors(true);
         return new RoutingTargetHandler(
                 routingManager,
+                Mockito.mock(OAuth2RoutingStore.class),
                 RoutingGroupSelector.byRoutingExternal(httpClient, config.getRoutingRules().getRulesExternalConfiguration(), config.getRequestAnalyzerConfig()),
                 config);
     }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandlerOAuth2.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/handler/TestRoutingTargetHandlerOAuth2.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.handler;
+
+import io.trino.gateway.ha.config.GatewayCookieConfiguration;
+import io.trino.gateway.ha.config.GatewayCookieConfigurationPropertiesProvider;
+import io.trino.gateway.ha.config.HaGatewayConfiguration;
+import io.trino.gateway.ha.handler.schema.RoutingTargetResponse;
+import io.trino.gateway.ha.router.OAuth2RoutingStore;
+import io.trino.gateway.ha.router.RoutingGroupSelector;
+import io.trino.gateway.ha.router.RoutingManager;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.WebApplicationException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@TestInstance(Lifecycle.PER_CLASS)
+final class TestRoutingTargetHandlerOAuth2
+{
+    @BeforeAll
+    void initCookieSingleton()
+    {
+        // RoutingTargetHandler reads the (disabled-by-default) cookie singleton in its constructor.
+        GatewayCookieConfigurationPropertiesProvider.getInstance().initialize(new GatewayCookieConfiguration());
+    }
+
+    private static RoutingTargetHandler handler(RoutingManager routingManager, OAuth2RoutingStore store)
+    {
+        HaGatewayConfiguration config = new HaGatewayConfiguration();
+        config.getRouting().setOauth2RoutingEnabled(true);
+        return new RoutingTargetHandler(routingManager, store, mock(RoutingGroupSelector.class), config);
+    }
+
+    private static HttpServletRequest oauthRequest(String path)
+    {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn(HttpMethod.GET);
+        when(request.getRequestURI()).thenReturn(path);
+        return request;
+    }
+
+    @Test
+    void testForcesReAuthAndDropsPinWhenPinnedBackendUnavailable()
+    {
+        RoutingManager routingManager = mock(RoutingManager.class);
+        OAuth2RoutingStore store = mock(OAuth2RoutingStore.class);
+        when(store.findBackend("authABC")).thenReturn(Optional.of("http://dead:8080"));
+        // No longer active and healthy (deactivated, unhealthy, or removed from the fleet).
+        when(routingManager.isBackendActiveAndHealthy("http://dead:8080")).thenReturn(false);
+
+        HttpServletRequest request = oauthRequest("/oauth2/token/authABC");
+
+        assertThatThrownBy(() -> handler(routingManager, store).resolveRouting(request))
+                .isInstanceOfSatisfying(WebApplicationException.class, e -> {
+                    // Trino token-poll failure contract: 200 with a JSON error body.
+                    assertThat(e.getResponse().getStatus()).isEqualTo(200);
+                    assertThat((String) e.getResponse().getEntity()).contains("\"error\"");
+                });
+
+        // The stale pin is dropped so the client's next attempt re-authenticates.
+        verify(store).removeBackend("authABC");
+    }
+
+    @Test
+    void testForcesReAuthWithUnauthorizedForInitiateLegWhenPinnedBackendUnavailable()
+    {
+        RoutingManager routingManager = mock(RoutingManager.class);
+        OAuth2RoutingStore store = mock(OAuth2RoutingStore.class);
+        when(store.findBackend("hashABC")).thenReturn(Optional.of("http://dead:8080"));
+        // No longer active and healthy (deactivated, unhealthy, or removed from the fleet).
+        when(routingManager.isBackendActiveAndHealthy("http://dead:8080")).thenReturn(false);
+
+        HttpServletRequest request = oauthRequest("/oauth2/token/initiate/hashABC");
+
+        assertThatThrownBy(() -> handler(routingManager, store).resolveRouting(request))
+                .isInstanceOfSatisfying(WebApplicationException.class, e ->
+                        // The browser initiate leg has no token-poll contract to satisfy: a plain 401
+                        // ends it, unlike the driver poll leg's 200-with-error-body contract.
+                        assertThat(e.getResponse().getStatus()).isEqualTo(401));
+
+        // The stale pin is dropped so the client's next attempt re-authenticates.
+        verify(store).removeBackend("hashABC");
+    }
+
+    @Test
+    void testRoutesToPinnedBackendWhenActiveAndHealthy()
+    {
+        RoutingManager routingManager = mock(RoutingManager.class);
+        OAuth2RoutingStore store = mock(OAuth2RoutingStore.class);
+        when(store.findBackend("authXYZ")).thenReturn(Optional.of("http://live:8080"));
+        // Active and healthy -> route the in-flight handshake there.
+        when(routingManager.isBackendActiveAndHealthy("http://live:8080")).thenReturn(true);
+
+        HttpServletRequest request = oauthRequest("/oauth2/token/authXYZ");
+
+        RoutingTargetResponse response = handler(routingManager, store).resolveRouting(request);
+
+        assertThat(response.routingDestination().clusterHost()).isEqualTo("http://live:8080");
+        verify(store, never()).removeBackend("authXYZ");
+    }
+
+    @Test
+    void testRoutesCallbackToMintingBackendViaState()
+    {
+        RoutingManager routingManager = mock(RoutingManager.class);
+        OAuth2RoutingStore store = mock(OAuth2RoutingStore.class);
+        // The callback carries no id in its path; it is pinned by the authIdHash inside the state JWT,
+        // reusing the pin recorded for the initiate leg.
+        when(store.findBackend("hashHHH")).thenReturn(Optional.of("http://minting:8080"));
+        when(routingManager.isBackendActiveAndHealthy("http://minting:8080")).thenReturn(true);
+
+        HttpServletRequest request = oauthRequest("/oauth2/callback");
+        when(request.getQueryString()).thenReturn("code=abc&state=" + stateJwt("hashHHH"));
+
+        RoutingTargetResponse response = handler(routingManager, store).resolveRouting(request);
+
+        assertThat(response.routingDestination().clusterHost()).isEqualTo("http://minting:8080");
+        verify(store, never()).removeBackend("hashHHH");
+    }
+
+    private static String stateJwt(String handlerState)
+    {
+        String header = base64Url("{\"alg\":\"HS256\"}");
+        String payload = base64Url("{\"aud\":\"trino_oauth_ui\",\"handler_state\":\"" + handlerState + "\"}");
+        return header + "." + payload + ".signature";
+    }
+
+    private static String base64Url(String value)
+    {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/BaseTestDatabaseMigrations.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/BaseTestDatabaseMigrations.java
@@ -99,6 +99,7 @@ public abstract class BaseTestDatabaseMigrations
     {
         verifyResultSetCount("SELECT name FROM gateway_backend", 0);
         verifyResultSetCount("SELECT query_id FROM query_history", 0);
+        verifyResultSetCount("SELECT oauth_id FROM oauth2_routing", 0);
     }
 
     protected void verifyResultSetCount(String sql, int expectedCount)
@@ -112,12 +113,14 @@ public abstract class BaseTestDatabaseMigrations
     {
         String gatewayBackendTable = "DROP TABLE IF EXISTS gateway_backend";
         String queryHistoryTable = "DROP TABLE IF EXISTS query_history";
+        String oauth2RoutingTable = "DROP TABLE IF EXISTS oauth2_routing";
         String flywayHistoryTable = "DROP TABLE IF EXISTS flyway_schema_history";
         Handle jdbiHandle = jdbi.open();
         String sql = "SELECT 1 FROM information_schema.tables WHERE table_schema = '%s'".formatted(schema);
-        verifyResultSetCount(sql, 3);
+        verifyResultSetCount(sql, 4);
         jdbiHandle.execute(gatewayBackendTable);
         jdbiHandle.execute(queryHistoryTable);
+        jdbiHandle.execute(oauth2RoutingTable);
         jdbiHandle.execute(flywayHistoryTable);
         verifyResultSetCount(sql, 0);
         jdbiHandle.close();

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestDatabaseMigrationsOracle.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestDatabaseMigrationsOracle.java
@@ -47,10 +47,10 @@ final class TestDatabaseMigrationsOracle
          * For this reason, if you remove the double quotes on flyway_schema_history,
          * you will get a table not found error.
          */
-        List<String> tables = ImmutableList.of("gateway_backend", "query_history", "\"flyway_schema_history\"");
+        List<String> tables = ImmutableList.of("gateway_backend", "query_history", "oauth2_routing", "\"flyway_schema_history\"");
         Handle jdbiHandle = jdbi.open();
         String sql = "SELECT 1 FROM all_tables WHERE owner = '%s'".formatted(schema);
-        verifyResultSetCount(sql, 3);
+        verifyResultSetCount(sql, 4);
         tables.forEach(table -> jdbiHandle.execute("DROP TABLE " + table));
         verifyResultSetCount(sql, 0);
         jdbiHandle.close();

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestHaOAuth2RoutingStore.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestHaOAuth2RoutingStore.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import io.trino.gateway.ha.config.DataStoreConfiguration;
+import io.trino.gateway.ha.persistence.JdbcConnectionManager;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+import static io.trino.gateway.ha.TestingJdbcConnectionManager.createTestingJdbcConnectionManager;
+import static io.trino.gateway.ha.TestingJdbcConnectionManager.dataStoreConfig;
+import static io.trino.gateway.ha.TestingJdbcConnectionManager.destroyTestingDatabase;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(Lifecycle.PER_CLASS)
+final class TestHaOAuth2RoutingStore
+{
+    private DataStoreConfiguration dataStoreConfig;
+    private JdbcConnectionManager connectionManager;
+    private JdbcConnectionManager otherPodConnectionManager;
+    private OAuth2RoutingStore store;
+
+    @BeforeAll
+    void setUp()
+    {
+        dataStoreConfig = dataStoreConfig();
+        connectionManager = createTestingJdbcConnectionManager(dataStoreConfig);
+        store = new HaOAuth2RoutingStore(connectionManager.getJdbi());
+    }
+
+    @AfterAll
+    void tearDown()
+    {
+        // Each JdbcConnectionManager starts a non-daemon scheduled-cleanup thread in its constructor;
+        // shut them down so they do not outlive the test and keep the JVM alive.
+        if (connectionManager != null) {
+            connectionManager.close();
+        }
+        if (otherPodConnectionManager != null) {
+            otherPodConnectionManager.close();
+        }
+        destroyTestingDatabase(dataStoreConfig);
+    }
+
+    @Test
+    void testSetFindRemove()
+    {
+        assertThat(store.findBackend("auth-x")).isEmpty();
+
+        store.setBackend("auth-x", "http://coord-a:8080");
+        assertThat(store.findBackend("auth-x")).hasValue("http://coord-a:8080");
+
+        // Idempotent re-pin replaces the row rather than failing on the primary key.
+        store.setBackend("auth-x", "http://coord-b:8080");
+        assertThat(store.findBackend("auth-x")).hasValue("http://coord-b:8080");
+
+        // A forced re-auth drops the pin.
+        store.removeBackend("auth-x");
+        assertThat(store.findBackend("auth-x")).isEmpty();
+    }
+
+    @Test
+    void testPinIsVisibleAcrossPods()
+    {
+        // A pin written by one pod must be readable by another pod sharing the DB.
+        store.setBackend("auth-shared", "http://coord-c:8080");
+
+        otherPodConnectionManager = createTestingJdbcConnectionManager(dataStoreConfig);
+        OAuth2RoutingStore otherPod = new HaOAuth2RoutingStore(otherPodConnectionManager.getJdbi());
+        assertThat(otherPod.findBackend("auth-shared")).hasValue("http://coord-c:8080");
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestOAuth2RoutingUtils.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestOAuth2RoutingUtils.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestOAuth2RoutingUtils
+{
+    @Test
+    void testOauthIdFromRequestPath()
+    {
+        // Driver poll loop: key is the authId.
+        assertThat(OAuth2RoutingUtils.oauthIdFromRequestPath("/oauth2/token/abc123")).hasValue("abc123");
+        // Browser initiate redirect: key is the authIdHash (more specific prefix wins).
+        assertThat(OAuth2RoutingUtils.oauthIdFromRequestPath("/oauth2/token/initiate/hashXYZ")).hasValue("hashXYZ");
+        // Only the first segment after the prefix is the id.
+        assertThat(OAuth2RoutingUtils.oauthIdFromRequestPath("/oauth2/token/abc123/extra")).hasValue("abc123");
+
+        // Not pinnable here (callback carries its id only inside the signed state token).
+        assertThat(OAuth2RoutingUtils.oauthIdFromRequestPath("/oauth2/callback")).isEmpty();
+        assertThat(OAuth2RoutingUtils.oauthIdFromRequestPath("/oauth2/token/")).isEmpty();
+        assertThat(OAuth2RoutingUtils.oauthIdFromRequestPath("/v1/statement")).isEmpty();
+        assertThat(OAuth2RoutingUtils.oauthIdFromRequestPath(null)).isEmpty();
+    }
+
+    @Test
+    void testOauthIdsFromChallenge()
+    {
+        // A single 401 challenge advertises both ids; recording both pins the poll loop and the
+        // browser initiate to the minting coordinator without reproducing Trino's authId hashing.
+        String challenge = "Bearer x_redirect_server=\"https://coord-a:8443/oauth2/token/initiate/HASH9\", "
+                + "x_token_server=\"https://coord-a:8443/oauth2/token/AUTH9\"";
+        assertThat(OAuth2RoutingUtils.oauthIdsFromChallenge(challenge))
+                .containsExactlyInAnyOrder("HASH9", "AUTH9");
+    }
+
+    @Test
+    void testOauthIdsFromChallengeWithSingleParameter()
+    {
+        // A challenge may advertise only one of the two server URLs; the id present is still recorded.
+        String tokenServerOnly = "Bearer x_token_server=\"https://coord-a:8443/oauth2/token/AUTH9\"";
+        assertThat(OAuth2RoutingUtils.oauthIdsFromChallenge(tokenServerOnly)).containsExactly("AUTH9");
+
+        String redirectServerOnly = "Bearer x_redirect_server=\"https://coord-a:8443/oauth2/token/initiate/HASH9\"";
+        assertThat(OAuth2RoutingUtils.oauthIdsFromChallenge(redirectServerOnly)).containsExactly("HASH9");
+    }
+
+    @Test
+    void testOauthIdsFromChallengeIgnoresNonTokenExchange()
+    {
+        assertThat(OAuth2RoutingUtils.oauthIdsFromChallenge("Bearer realm=\"trino\", error=\"invalid_token\"")).isEmpty();
+        assertThat(OAuth2RoutingUtils.oauthIdsFromChallenge(null)).isEmpty();
+        assertThat(OAuth2RoutingUtils.oauthIdsFromChallenge("")).isEmpty();
+    }
+
+    @Test
+    void testForceReAuthResponseForPollLeg()
+    {
+        // Trino's HttpTokenPoller maps a 200 body with an "error" field to TokenPollResult.failed,
+        // ending the poll cleanly (rather than a generic non-2xx failure) so the client re-auths.
+        Response response = OAuth2RoutingUtils.forceReAuthResponse("/oauth2/token/abc123");
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+        assertThat((String) response.getEntity()).contains("\"error\"");
+    }
+
+    @Test
+    void testForceReAuthResponseForBrowserLegs()
+    {
+        // The browser initiate and callback legs have no poll contract to satisfy; a plain 401 ends
+        // them (a 200 token-poll body is meaningless to a browser).
+        assertThat(OAuth2RoutingUtils.forceReAuthResponse("/oauth2/token/initiate/hash9").getStatus()).isEqualTo(401);
+        assertThat(OAuth2RoutingUtils.forceReAuthResponse("/oauth2/callback").getStatus()).isEqualTo(401);
+    }
+
+    @Test
+    void testOauthIdFromCallback()
+    {
+        // The callback is pinned by the authIdHash carried in the state JWT's handler_state claim,
+        // so it routes to the same coordinator as the matching initiate/poll legs.
+        String state = jwt("{\"aud\":\"trino_oauth_ui\",\"handler_state\":\"HASH9\"}");
+        assertThat(OAuth2RoutingUtils.oauthIdFromCallback("/oauth2/callback", "code=xyz&state=" + state))
+                .hasValue("HASH9");
+        // Order of query params does not matter.
+        assertThat(OAuth2RoutingUtils.oauthIdFromCallback("/oauth2/callback", "state=" + state + "&code=xyz"))
+                .hasValue("HASH9");
+    }
+
+    @Test
+    void testOauthIdFromCallbackNotPinnable()
+    {
+        String uiLoginState = jwt("{\"aud\":\"trino_oauth_ui\"}");
+        // Browser-UI login (no handler_state) is stateless via the nonce cookie -> not pinned here.
+        assertThat(OAuth2RoutingUtils.oauthIdFromCallback("/oauth2/callback", "code=xyz&state=" + uiLoginState)).isEmpty();
+        // handler_state present but empty.
+        assertThat(OAuth2RoutingUtils.oauthIdFromCallback("/oauth2/callback", "state=" + jwt("{\"handler_state\":\"\"}"))).isEmpty();
+        // Missing / unparseable state, and non-callback paths.
+        assertThat(OAuth2RoutingUtils.oauthIdFromCallback("/oauth2/callback", "code=xyz")).isEmpty();
+        assertThat(OAuth2RoutingUtils.oauthIdFromCallback("/oauth2/callback", "state=not-a-jwt")).isEmpty();
+        // Malformed percent-encoding in state must fall back gracefully, not throw a 500.
+        assertThat(OAuth2RoutingUtils.oauthIdFromCallback("/oauth2/callback", "state=%")).isEmpty();
+        assertThat(OAuth2RoutingUtils.oauthIdFromCallback("/oauth2/callback", "state=%zz")).isEmpty();
+        assertThat(OAuth2RoutingUtils.oauthIdFromCallback("/oauth2/callback", null)).isEmpty();
+        assertThat(OAuth2RoutingUtils.oauthIdFromCallback("/oauth2/token/abc123", "state=" + jwt("{\"handler_state\":\"HASH9\"}"))).isEmpty();
+        assertThat(OAuth2RoutingUtils.oauthIdFromCallback(null, null)).isEmpty();
+    }
+
+    private static String jwt(String payloadJson)
+    {
+        String header = base64Url("{\"alg\":\"HS256\"}");
+        String payload = base64Url(payloadJson);
+        return header + "." + payload + ".signature";
+    }
+
+    private static String base64Url(String value)
+    {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestStochasticRoutingManager.java
@@ -76,4 +76,36 @@ final class TestStochasticRoutingManager
         assertThat(haRoutingManager.provideBackendConfiguration(groupName, "").getProxyTo())
                 .isEqualTo("test_group0.trino.example.com");
     }
+
+    @Test
+    void testIsBackendActiveAndHealthy()
+    {
+        ProxyBackendConfiguration healthy = new ProxyBackendConfiguration();
+        healthy.setActive(true);
+        healthy.setRoutingGroup("oauth-group");
+        healthy.setName("oauth-healthy");
+        healthy.setProxyTo("http://oauth-healthy:8080");
+        healthy.setExternalUrl("https://ext.example");
+        backendManager.addBackend(healthy);
+        haRoutingManager.updateBackEndHealth(healthy.getName(), TrinoStatus.HEALTHY);
+        assertThat(haRoutingManager.isBackendActiveAndHealthy("http://oauth-healthy:8080")).isTrue();
+
+        // Unhealthy -> not available (the client must re-auth).
+        haRoutingManager.updateBackEndHealth(healthy.getName(), TrinoStatus.UNHEALTHY);
+        assertThat(haRoutingManager.isBackendActiveAndHealthy("http://oauth-healthy:8080")).isFalse();
+
+        // Configured but inactive -> not available.
+        ProxyBackendConfiguration inactive = new ProxyBackendConfiguration();
+        inactive.setActive(false);
+        inactive.setRoutingGroup("oauth-group");
+        inactive.setName("oauth-inactive");
+        inactive.setProxyTo("http://oauth-inactive:8080");
+        inactive.setExternalUrl("https://ext.example");
+        backendManager.addBackend(inactive);
+        haRoutingManager.updateBackEndHealth(inactive.getName(), TrinoStatus.HEALTHY);
+        assertThat(haRoutingManager.isBackendActiveAndHealthy("http://oauth-inactive:8080")).isFalse();
+
+        // Unknown / removed backend -> not available.
+        assertThat(haRoutingManager.isBackendActiveAndHealthy("http://does-not-exist:8080")).isFalse();
+    }
 }


### PR DESCRIPTION
## Description

Trino OAuth2 SSO logins via the CLI/JDBC driver are slow and unreliable behind a multi-coordinator gateway: most logins complete in ~30–90s, but a meaningful minority time out after 2+ minutes and must be retried. The browser Web-UI login is unaffected. This PR adds an opt-in, dark-launch flag `routing.oauth2RoutingEnabled` (default **off**) that pins every leg of an in-flight OAuth2 handshake to the coordinator that minted it, fixing the slowness deterministically.

### Root cause

Trino's OAuth2 token-exchange handshake spans two independent HTTP clients that share only an `authId` (and its `authIdHash`), across these gateway legs:

1. **401 challenge** — the CLI's unauthenticated `POST /v1/statement` hits some coordinator, which mints a fresh `authId` and returns `WWW-Authenticate: Bearer x_redirect_server=".../oauth2/token/initiate/{authIdHash}", x_token_server=".../oauth2/token/{authId}"`.
2. **driver/CLI poll loop** — `GET /oauth2/token/{authId}` (a long-poll that blocks server-side up to ~10s per request).
3. **browser initiate redirect** — `GET /oauth2/token/initiate/{authIdHash}` → IdP.
4. **browser IdP callback** — `GET /oauth2/callback?state=…&code=…`; the `authIdHash` rides back through the IdP inside the signed `state` JWT (the `handler_state` claim).

Each coordinator keeps the token-exchange result in a **per-JVM in-memory cache** with no cross-coordinator propagation (`OAuth2TokenExchange`'s `LoadingCache`). The coordinator that processes the callback calls `setAccessToken(authIdHash, …)` on **its own** cache only (`OAuth2Service`), so only a poll that happens to land on that same coordinator wakes up and receives the token (`OAuth2TokenExchangeResource`). With round-robin load-balancing across multiple coordinators, the callback and the poll loop routinely land on different coordinators, the long-poll times out at ~10s, and the server returns a "keep polling" response — indefinitely.

The reason logins *eventually* succeed rather than hanging forever is accidental: each client re-rolls onto a different backend over time (cookie loss on retries for the OkHttp-based CLI; a cookieless poll path in the OSS Python client, whose `_OAuth2TokenBearer` sends `Request(...).prepare()` with an empty cookie jar, so `HTTPAdapter.send()` never attaches the sticky `TG.OAUTH2` cookie). Without that re-rolling, a poll would stay stuck on the wrong coordinator and fail `(N-1)/N` of the time. The slow tail is just the geometric distribution of how many polls it takes to randomly hit the right coordinator.

### This change

When `routing.oauth2RoutingEnabled` is on, the gateway records the `authId`/`authIdHash` advertised in the `401` `WWW-Authenticate` challenge against the responding backend (`ProxyRequestHandler` → `OAuth2RoutingStore`, a shared, cross-pod `oauth2_routing` table), then pins all three later legs — poll, initiate, and callback — back to that coordinator (`RoutingTargetHandler`):

- The callback is pinned by decoding the `state` JWT's `handler_state` claim (base64url, **without** verifying the signature — the gateway only selects a backend; the coordinator still validates the token, so a forged `state` can at worst mis-route, never bypass auth), so it's cookie-independent and works cross-pod.
- The pin is honored only while the coordinator is **active and healthy** — deactivation (an operator drain signal), an unhealthy verdict, or removal from the fleet drops the pin and forces re-auth, since only the minting coordinator holds the exchange state. The browser legs get a plain `401`; the driver poll loop gets Trino's token-poll failure contract (HTTP 200 + JSON `error`) so `HttpTokenPoller` ends cleanly.

Pins are pruned automatically; retention is configurable via `dataStore.oauth2RoutingRetention` (a duration, default `1h`). No new database is required — the `oauth2_routing` table ships in the existing Flyway migrations (MySQL/PostgreSQL/Oracle).

This mirrors the gateway's existing query-id sticky routing (`RoutingManager.findBackendForQueryId`) and reuses the same shared-datastore infrastructure, eliminating the routing mismatch deterministically while keeping the auth path load-balanced across coordinators — with no coordinator-side changes.

## Additional context and related issues

### Prior art and why it doesn't fully solve this

- **[#165](https://github.com/trinodb/trino-gateway/issues/165) (closed) + [#188](https://github.com/trinodb/trino-gateway/pull/188) (merged):** #165 reported that the **browser** OAuth2 handshake to the Web UI fails with multiple backends. #188 fixed it by adding cookie-based sticky routing (the `TG.OAUTH2` cookie / `OAuth2GatewayCookie`) for configurable `cookiePaths` such as `/oauth2/callback`, at lower precedence than query-id routing. That solves the **browser-only** flow, where a single browser session carries the cookie across the initiate → callback legs. It does **not** solve the CLI/JDBC token-exchange flow this PR targets: the CLI poll loop and the browser are separate processes with separate cookie jars, so the poll requests never carry the `TG.OAUTH2` cookie and still land on a different coordinator than the callback. This PR builds on #188, adding the cookie-independent, id-based pinning the CLI flow needs — and pinning the callback by the `state` JWT's `handler_state` instead of by cookie.
- **[#631](https://github.com/trinodb/trino-gateway/issues/631) (open):** intermittent `OAuth2 authentication failed: Authentication response could not be verified` through the gateway, never seen when connecting to a coordinator directly. This is the same multi-coordinator state mismatch — the callback/verification landing on a coordinator that doesn't hold the initiating handshake state — and cookie routing alone doesn't cover it consistently. Deterministically pinning every leg by `authId`/`authIdHash` (this PR) removes the mismatch that produces those inconsistent failures.
- **[#892](https://github.com/trinodb/trino-gateway/issues/892) (open):** JDBC OAuth2 to a non-default cluster (selected via client tags) loops the auth window indefinitely, with the gateway logs showing it routing to the correct cluster. This is exactly the failure this PR fixes when the target routing group has more than one coordinator: the cookieless JDBC poll loop never lands on the coordinator that minted and stores the token, so it polls forever. Pinning the poll and callback to the minting coordinator ends the loop.

### Other notes

- **Alternatives considered:** (a) routing all `/oauth2/*` to a single dedicated coordinator or small group — trivial, but makes that group a SPOF for SSO; (b) terminating OAuth2 at the gateway entirely so coordinators only validate the resulting bearer token — architecturally cleanest long-term, but a much larger change spanning both gateway and coordinator; (c) backing the coordinator's token cache with a shared store — adds an infra dependency in a security-critical path with awkward long-poll semantics. This PR takes the smallest deterministic fix that lives entirely in the gateway.
- Trino wire-format coupling (paths, challenge params, `state`/`handler_state`) is isolated in `OAuth2RoutingUtils`, verified against Trino 446 (`OAuth2Service`, `OAuth2CallbackResource`, `OAuth2TokenExchange.hashAuthId`).
- Fully behind `routing.oauth2RoutingEnabled`; when off, routing is unchanged. On any DB error the store falls back to normal (non-pinned) routing rather than failing the request.
- OSS code references: `OAuth2TokenExchange` (per-coordinator in-memory cache), `OAuth2TokenExchangeResource` (poll long-poll), `OAuth2Service` (`setAccessToken` on callback), `OAuth2GatewayCookie`, `RoutingTargetHandler`, `ProxyRequestHandler`.
- Docs: `docs/installation.md` (how to enable + DDL + retention) and `docs/routing-logic.md` (routing behavior for all three legs).
- Tests: `TestOAuth2RoutingUtils`, `TestProxyRequestHandlerOAuth2`, `TestRoutingTargetHandlerOAuth2`, `TestHaOAuth2RoutingStore`, `TestStochasticRoutingManager`, and the DB-migration tests all pass.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required, with the following suggested text:

* Add opt-in `routing.oauth2RoutingEnabled` configuration that pins Trino OAuth2 token-exchange requests (CLI/JDBC poll, browser initiate, and IdP callback) to the coordinator that minted the handshake, fixing slow and unreliable OAuth2 logins behind a multi-coordinator deployment. Pin retention is configurable via `dataStore.oauth2RoutingRetention` (a duration, default `1h`). ({issue}`631`, {issue}`892`)

Also credits to : @xkrogen for helping ideate this solution!
