### PR TITLE
Add support for Active Directory LDAP Domain Scope control

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -170,7 +170,13 @@ The LDAP config file should have the following contents:
   poolMaxTotal: 8
   poolMinIdle: 0
   poolTestOnBorrow: true
+  ldapAdDomainScopeControl: false
 ```
+
+Set `ldapAdDomainScopeControl` to `true` when searching an Active Directory
+domain root such as `DC=example,DC=com` and you want to suppress subordinate
+referrals like `DomainDnsZones` and `ForestDnsZones` while still searching all
+users in the domain. The default is `false`.
 
 ## Web page permissions
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -171,7 +171,13 @@ The LDAP config file should have the following contents:
   poolMaxTotal: 8
   poolMinIdle: 0
   poolTestOnBorrow: true
+  ldapAdDomainScopeControl: false
 ```
+
+Set `ldapAdDomainScopeControl` to `true` when searching an Active Directory
+domain root such as `DC=example,DC=com` and you want to suppress subordinate
+referrals like `DomainDnsZones` and `ForestDnsZones` while still searching all
+users in the domain. The default is `false`.
 
 ### Direct bind
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/LdapConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/LdapConfiguration.java
@@ -39,6 +39,7 @@ public class LdapConfiguration
     private Integer poolMaxTotal;
     private Integer poolMinIdle;
     private boolean poolTestOnBorrow;
+    private boolean ldapAdDomainScopeControl;
 
     public LdapConfiguration(
             String ldapHost,
@@ -237,5 +238,15 @@ public class LdapConfiguration
     public void setPoolTestOnBorrow(boolean poolTestOnBorrow)
     {
         this.poolTestOnBorrow = poolTestOnBorrow;
+    }
+
+    public boolean isLdapAdDomainScopeControl()
+    {
+        return ldapAdDomainScopeControl;
+    }
+
+    public void setLdapAdDomainScopeControl(boolean ldapAdDomainScopeControl)
+    {
+        this.ldapAdDomainScopeControl = ldapAdDomainScopeControl;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/LdapConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/LdapConfiguration.java
@@ -48,6 +48,7 @@ public class LdapConfiguration
     private Integer poolMaxTotal;
     private Integer poolMinIdle;
     private boolean poolTestOnBorrow;
+    private boolean ldapAdDomainScopeControl;
 
     public LdapConfiguration(
             String ldapHost,
@@ -291,5 +292,15 @@ public class LdapConfiguration
     public void setPoolTestOnBorrow(boolean poolTestOnBorrow)
     {
         this.poolTestOnBorrow = poolTestOnBorrow;
+    }
+
+    public boolean isLdapAdDomainScopeControl()
+    {
+        return ldapAdDomainScopeControl;
+    }
+
+    public void setLdapAdDomainScopeControl(boolean ldapAdDomainScopeControl)
+    {
+        this.ldapAdDomainScopeControl = ldapAdDomainScopeControl;
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbLdapClient.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbLdapClient.java
@@ -18,6 +18,7 @@ import io.trino.gateway.ha.config.LdapConfiguration;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.message.SearchRequest;
 import org.apache.directory.api.ldap.model.message.SearchScope;
 import org.apache.directory.ldap.client.api.DefaultLdapConnectionFactory;
 import org.apache.directory.ldap.client.api.LdapClientTrustStoreManager;
@@ -34,13 +35,24 @@ import java.util.List;
 public class LbLdapClient
 {
     private static final Logger log = Logger.get(LbLdapClient.class);
-    private LdapConnectionTemplate ldapConnectionTemplate;
-    private LdapConfiguration config;
-    private UserEntryMapper userRecordEntryMapper;
+    private final LdapConnectionTemplate ldapConnectionTemplate;
+    private final LdapConfiguration config;
+    private final UserEntryMapper userRecordEntryMapper;
 
     public LbLdapClient(LdapConfiguration ldapConfig)
     {
+        this(ldapConfig, createLdapConnectionTemplate(ldapConfig));
+    }
+
+    LbLdapClient(LdapConfiguration ldapConfig, LdapConnectionTemplate ldapConnectionTemplate)
+    {
         config = ldapConfig;
+        this.ldapConnectionTemplate = ldapConnectionTemplate;
+        userRecordEntryMapper = new UserEntryMapper(config.getLdapGroupMemberAttribute());
+    }
+
+    private static LdapConnectionTemplate createLdapConnectionTemplate(LdapConfiguration ldapConfig)
+    {
         LdapConnectionConfig connectionConfig = new LdapConnectionConfig();
         connectionConfig.setLdapHost(ldapConfig.getLdapHost());
         connectionConfig.setLdapPort(ldapConfig.getLdapPort());
@@ -61,7 +73,7 @@ public class LbLdapClient
         DefaultLdapConnectionFactory defaultFactory =
                 new DefaultLdapConnectionFactory(connectionConfig);
 
-        // A single connection and keep it alive
+        // Configure the LDAP connection pool.
         GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
         poolConfig.setMaxIdle(ldapConfig.getPoolMaxIdle());
         poolConfig.setMaxTotal(ldapConfig.getPoolMaxTotal());
@@ -71,20 +83,16 @@ public class LbLdapClient
         ValidatingPoolableLdapConnectionFactory validatingFactory =
                 new ValidatingPoolableLdapConnectionFactory(defaultFactory);
         LdapConnectionPool connectionPool = new LdapConnectionPool(validatingFactory, poolConfig);
-        ldapConnectionTemplate = new LdapConnectionTemplate(connectionPool);
-        userRecordEntryMapper = new UserEntryMapper(config.getLdapGroupMemberAttribute());
+        return new LdapConnectionTemplate(connectionPool);
     }
 
     public boolean authenticate(String user, String password)
     {
         try {
             String filter = config.getLdapUserSearch().replace("${USER}", user);
+            SearchRequest searchRequest = newUserSearchRequest(filter);
             PasswordWarning passwordWarning =
-                    ldapConnectionTemplate.authenticate(
-                            config.getLdapUserBaseDn(),
-                            filter,
-                            SearchScope.SUBTREE,
-                            password.toCharArray());
+                    ldapConnectionTemplate.authenticate(searchRequest, password.toCharArray());
 
             if (passwordWarning != null) {
                 log.warn("password warning %s", passwordWarning);
@@ -104,24 +112,31 @@ public class LbLdapClient
         String filter = config.getLdapUserSearch().replace("${USER}", user);
 
         String[] attributes = new String[] {config.getLdapGroupMemberAttribute()};
-        List<UserRecord> list = ldapConnectionTemplate.search(
-                config.getLdapUserBaseDn(),
-                filter,
-                SearchScope.SUBTREE,
-                attributes,
-                userRecordEntryMapper);
+        SearchRequest searchRequest = newUserSearchRequest(filter, attributes);
+        List<UserRecord> list = ldapConnectionTemplate.search(searchRequest, userRecordEntryMapper);
 
         String memberOf = "";
         if (list != null && !list.isEmpty()) {
-            memberOf = list.listIterator().next().getMemberOf();
+            memberOf = list.getFirst().getMemberOf();
             log.debug("Member of %s", memberOf);
         }
         return memberOf;
     }
 
+    private SearchRequest newUserSearchRequest(String filter, String... attributes)
+    {
+        SearchRequest searchRequest = ldapConnectionTemplate.newSearchRequest(
+                config.getLdapUserBaseDn(),
+                filter,
+                SearchScope.SUBTREE,
+                attributes);
+
+        return searchRequest;
+    }
+
     public static class UserRecord
     {
-        String memberOf;
+        private final String memberOf;
 
         public UserRecord(String memberOf)
         {
@@ -137,18 +152,18 @@ public class LbLdapClient
     public static class UserEntryMapper
             implements EntryMapper<UserRecord>
     {
-        String memberOf;
+        private final String memberOfAttribute;
 
-        public UserEntryMapper(String memberOfAttr)
+        public UserEntryMapper(String memberOfAttribute)
         {
-            memberOf = memberOfAttr;
+            this.memberOfAttribute = memberOfAttribute;
         }
 
         @Override
         public UserRecord map(Entry entry)
                 throws LdapException
         {
-            return new UserRecord(entry.get(memberOf).toString());
+            return new UserRecord(entry.get(memberOfAttribute).toString());
         }
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbLdapClient.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbLdapClient.java
@@ -19,6 +19,7 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.exception.LdapException;
 import org.apache.directory.api.ldap.model.exception.LdapInvalidDnException;
+import org.apache.directory.api.ldap.model.message.SearchRequest;
 import org.apache.directory.api.ldap.model.message.SearchScope;
 import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.api.ldap.model.name.Rdn;
@@ -34,16 +35,33 @@ import org.apache.directory.ldap.client.template.exception.PasswordException;
 
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
+
 public class LbLdapClient
 {
     private static final Logger log = Logger.get(LbLdapClient.class);
-    private LdapConnectionTemplate ldapConnectionTemplate;
-    private LdapConfiguration config;
-    private UserEntryMapper userRecordEntryMapper;
+    private final LdapConnectionTemplate ldapConnectionTemplate;
+    private final LdapConfiguration config;
+    private final UserEntryMapper userRecordEntryMapper;
 
     public LbLdapClient(LdapConfiguration ldapConfig)
     {
-        config = ldapConfig;
+        this(ldapConfig, createLdapConnectionTemplate(ldapConfig));
+    }
+
+    LbLdapClient(LdapConfiguration ldapConfig, LdapConnectionTemplate ldapConnectionTemplate)
+    {
+        config = requireNonNull(ldapConfig, "ldapConfig is null");
+        this.ldapConnectionTemplate = requireNonNull(
+                ldapConnectionTemplate,
+                "ldapConnectionTemplate is null");
+        userRecordEntryMapper = new UserEntryMapper(config.getLdapGroupMemberAttribute());
+    }
+
+    private static LdapConnectionTemplate createLdapConnectionTemplate(LdapConfiguration ldapConfig)
+    {
+        requireNonNull(ldapConfig, "ldapConfig is null");
+
         LdapConnectionConfig connectionConfig = new LdapConnectionConfig();
         connectionConfig.setLdapHost(ldapConfig.getLdapHost());
         connectionConfig.setLdapPort(ldapConfig.getLdapPort());
@@ -64,7 +82,7 @@ public class LbLdapClient
         DefaultLdapConnectionFactory defaultFactory =
                 new DefaultLdapConnectionFactory(connectionConfig);
 
-        // A single connection and keep it alive
+        // Configure the LDAP connection pool.
         GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
         poolConfig.setMaxIdle(ldapConfig.getPoolMaxIdle());
         poolConfig.setMaxTotal(ldapConfig.getPoolMaxTotal());
@@ -74,8 +92,7 @@ public class LbLdapClient
         ValidatingPoolableLdapConnectionFactory validatingFactory =
                 new ValidatingPoolableLdapConnectionFactory(defaultFactory);
         LdapConnectionPool connectionPool = new LdapConnectionPool(validatingFactory, poolConfig);
-        ldapConnectionTemplate = new LdapConnectionTemplate(connectionPool);
-        userRecordEntryMapper = new UserEntryMapper(config.getLdapGroupMemberAttribute());
+        return new LdapConnectionTemplate(connectionPool);
     }
 
     public boolean authenticate(String user, String password)
@@ -101,12 +118,9 @@ public class LbLdapClient
             }
             else {
                 String filter = config.getLdapUserSearch().replace("${USER}", user);
+                SearchRequest searchRequest = newUserSearchRequest(filter);
                 passwordWarning =
-                        ldapConnectionTemplate.authenticate(
-                                config.getLdapUserBaseDn(),
-                                filter,
-                                SearchScope.SUBTREE,
-                                password.toCharArray());
+                        ldapConnectionTemplate.authenticate(searchRequest, password.toCharArray());
             }
 
             if (passwordWarning != null) {
@@ -130,25 +144,33 @@ public class LbLdapClient
     {
         String filter = config.getLdapUserSearch().replace("${USER}", user);
 
-        String[] attributes = new String[] {config.getLdapGroupMemberAttribute()};
-        List<UserRecord> list = ldapConnectionTemplate.search(
-                config.getLdapUserBaseDn(),
+        SearchRequest searchRequest = newUserSearchRequest(
                 filter,
-                SearchScope.SUBTREE,
-                attributes,
-                userRecordEntryMapper);
+                config.getLdapGroupMemberAttribute());
+        List<UserRecord> list = ldapConnectionTemplate.search(searchRequest, userRecordEntryMapper);
 
         String memberOf = "";
         if (list != null && !list.isEmpty()) {
-            memberOf = list.listIterator().next().getMemberOf();
+            memberOf = list.getFirst().getMemberOf();
             log.debug("Member of %s", memberOf);
         }
         return memberOf;
     }
 
+    private SearchRequest newUserSearchRequest(String filter, String... attributes)
+    {
+        SearchRequest searchRequest = ldapConnectionTemplate.newSearchRequest(
+                config.getLdapUserBaseDn(),
+                filter,
+                SearchScope.SUBTREE,
+                attributes);
+
+        return searchRequest;
+    }
+
     public static class UserRecord
     {
-        String memberOf;
+        private final String memberOf;
 
         public UserRecord(String memberOf)
         {
@@ -164,18 +186,20 @@ public class LbLdapClient
     public static class UserEntryMapper
             implements EntryMapper<UserRecord>
     {
-        String memberOf;
+        private final String memberOfAttribute;
 
-        public UserEntryMapper(String memberOfAttr)
+        public UserEntryMapper(String memberOfAttribute)
         {
-            memberOf = memberOfAttr;
+            this.memberOfAttribute = requireNonNull(
+                    memberOfAttribute,
+                    "memberOfAttribute is null");
         }
 
         @Override
         public UserRecord map(Entry entry)
                 throws LdapException
         {
-            return new UserRecord(entry.get(memberOf).toString());
+            return new UserRecord(entry.get(memberOfAttribute).toString());
         }
     }
 }

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbLdapClient.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbLdapClient.java
@@ -16,10 +16,16 @@ package io.trino.gateway.ha.security;
 import io.airlift.log.Logger;
 import io.trino.gateway.ha.config.LdapConfiguration;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.apache.directory.api.ldap.codec.api.LdapApiService;
+import org.apache.directory.api.ldap.codec.controls.OpaqueControlFactory;
+import org.apache.directory.api.ldap.codec.standalone.StandaloneLdapApiService;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.filter.FilterEncoder;
 import org.apache.directory.api.ldap.model.message.SearchRequest;
 import org.apache.directory.api.ldap.model.message.SearchScope;
+import org.apache.directory.api.ldap.model.message.controls.OpaqueControl;
+import org.apache.directory.api.util.Strings;
 import org.apache.directory.ldap.client.api.DefaultLdapConnectionFactory;
 import org.apache.directory.ldap.client.api.LdapClientTrustStoreManager;
 import org.apache.directory.ldap.client.api.LdapConnectionConfig;
@@ -32,8 +38,12 @@ import org.apache.directory.ldap.client.template.exception.PasswordException;
 
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
+
 public class LbLdapClient
 {
+    private static final String AD_DOMAIN_SCOPE_CONTROL_OID = "1.2.840.113556.1.4.1339";
+
     private static final Logger log = Logger.get(LbLdapClient.class);
     private final LdapConnectionTemplate ldapConnectionTemplate;
     private final LdapConfiguration config;
@@ -46,13 +56,17 @@ public class LbLdapClient
 
     LbLdapClient(LdapConfiguration ldapConfig, LdapConnectionTemplate ldapConnectionTemplate)
     {
-        config = ldapConfig;
-        this.ldapConnectionTemplate = ldapConnectionTemplate;
+        config = requireNonNull(ldapConfig, "ldapConfig is null");
+        this.ldapConnectionTemplate = requireNonNull(
+                ldapConnectionTemplate,
+                "ldapConnectionTemplate is null");
         userRecordEntryMapper = new UserEntryMapper(config.getLdapGroupMemberAttribute());
     }
 
     private static LdapConnectionTemplate createLdapConnectionTemplate(LdapConfiguration ldapConfig)
     {
+        requireNonNull(ldapConfig, "ldapConfig is null");
+
         LdapConnectionConfig connectionConfig = new LdapConnectionConfig();
         connectionConfig.setLdapHost(ldapConfig.getLdapHost());
         connectionConfig.setLdapPort(ldapConfig.getLdapPort());
@@ -70,10 +84,18 @@ public class LbLdapClient
                     true));
         }
 
+        LdapApiService ldapApiService;
+        try {
+            ldapApiService = createLdapApiService();
+        }
+        catch (Exception exception) {
+            throw new IllegalStateException("Failed to initialize LDAP client", exception);
+        }
+        connectionConfig.setLdapApiService(ldapApiService);
         DefaultLdapConnectionFactory defaultFactory =
                 new DefaultLdapConnectionFactory(connectionConfig);
+        defaultFactory.setLdapApiService(ldapApiService);
 
-        // Configure the LDAP connection pool.
         GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
         poolConfig.setMaxIdle(ldapConfig.getPoolMaxIdle());
         poolConfig.setMaxTotal(ldapConfig.getPoolMaxTotal());
@@ -89,7 +111,7 @@ public class LbLdapClient
     public boolean authenticate(String user, String password)
     {
         try {
-            String filter = config.getLdapUserSearch().replace("${USER}", user);
+            String filter = createUserSearchFilter(user);
             SearchRequest searchRequest = newUserSearchRequest(filter);
             PasswordWarning passwordWarning =
                     ldapConnectionTemplate.authenticate(searchRequest, password.toCharArray());
@@ -109,10 +131,11 @@ public class LbLdapClient
 
     public String getMemberOf(String user)
     {
-        String filter = config.getLdapUserSearch().replace("${USER}", user);
+        String filter = createUserSearchFilter(user);
 
-        String[] attributes = new String[] {config.getLdapGroupMemberAttribute()};
-        SearchRequest searchRequest = newUserSearchRequest(filter, attributes);
+        SearchRequest searchRequest = newUserSearchRequest(
+                filter,
+                config.getLdapGroupMemberAttribute());
         List<UserRecord> list = ldapConnectionTemplate.search(searchRequest, userRecordEntryMapper);
 
         String memberOf = "";
@@ -123,6 +146,12 @@ public class LbLdapClient
         return memberOf;
     }
 
+    private String createUserSearchFilter(String user)
+    {
+        return config.getLdapUserSearch()
+                .replace("${USER}", FilterEncoder.encodeFilterValue(user));
+    }
+
     private SearchRequest newUserSearchRequest(String filter, String... attributes)
     {
         SearchRequest searchRequest = ldapConnectionTemplate.newSearchRequest(
@@ -131,7 +160,29 @@ public class LbLdapClient
                 SearchScope.SUBTREE,
                 attributes);
 
+        if (config.isLdapAdDomainScopeControl()) {
+            searchRequest.addControl(createAdDomainScopeControl());
+        }
+
         return searchRequest;
+    }
+
+    private static OpaqueControl createAdDomainScopeControl()
+    {
+        OpaqueControl control = new OpaqueControl(AD_DOMAIN_SCOPE_CONTROL_OID, false);
+        // Apache Directory's opaque control encoder requires an encoded value,
+        // while the Active Directory Domain Scope control has no payload.
+        control.setEncodedValue(Strings.EMPTY_BYTES);
+        return control;
+    }
+
+    static LdapApiService createLdapApiService()
+            throws Exception
+    {
+        LdapApiService ldapApiService = new StandaloneLdapApiService();
+        ldapApiService.registerRequestControl(
+                new OpaqueControlFactory(ldapApiService, AD_DOMAIN_SCOPE_CONTROL_OID));
+        return ldapApiService;
     }
 
     public static class UserRecord
@@ -156,7 +207,9 @@ public class LbLdapClient
 
         public UserEntryMapper(String memberOfAttribute)
         {
-            this.memberOfAttribute = memberOfAttribute;
+            this.memberOfAttribute = requireNonNull(
+                    memberOfAttribute,
+                    "memberOfAttribute is null");
         }
 
         @Override

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbLdapClient.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbLdapClient.java
@@ -16,14 +16,19 @@ package io.trino.gateway.ha.security;
 import io.airlift.log.Logger;
 import io.trino.gateway.ha.config.LdapConfiguration;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.apache.directory.api.ldap.codec.api.LdapApiService;
+import org.apache.directory.api.ldap.codec.controls.OpaqueControlFactory;
+import org.apache.directory.api.ldap.codec.standalone.StandaloneLdapApiService;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.exception.LdapException;
 import org.apache.directory.api.ldap.model.exception.LdapInvalidDnException;
 import org.apache.directory.api.ldap.model.filter.FilterEncoder;
 import org.apache.directory.api.ldap.model.message.SearchRequest;
 import org.apache.directory.api.ldap.model.message.SearchScope;
+import org.apache.directory.api.ldap.model.message.controls.OpaqueControl;
 import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.api.ldap.model.name.Rdn;
+import org.apache.directory.api.util.Strings;
 import org.apache.directory.ldap.client.api.DefaultLdapConnectionFactory;
 import org.apache.directory.ldap.client.api.LdapClientTrustStoreManager;
 import org.apache.directory.ldap.client.api.LdapConnectionConfig;
@@ -40,6 +45,8 @@ import static java.util.Objects.requireNonNull;
 
 public class LbLdapClient
 {
+    static final String AD_DOMAIN_SCOPE_CONTROL_OID = "1.2.840.113556.1.4.1339";
+
     private static final Logger log = Logger.get(LbLdapClient.class);
     private final LdapConnectionTemplate ldapConnectionTemplate;
     private final LdapConfiguration config;
@@ -80,10 +87,18 @@ public class LbLdapClient
                     true));
         }
 
+        LdapApiService ldapApiService;
+        try {
+            ldapApiService = createLdapApiService();
+        }
+        catch (Exception exception) {
+            throw new IllegalStateException("Failed to initialize LDAP client", exception);
+        }
+        connectionConfig.setLdapApiService(ldapApiService);
         DefaultLdapConnectionFactory defaultFactory =
                 new DefaultLdapConnectionFactory(connectionConfig);
+        defaultFactory.setLdapApiService(ldapApiService);
 
-        // Configure the LDAP connection pool.
         GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
         poolConfig.setMaxIdle(ldapConfig.getPoolMaxIdle());
         poolConfig.setMaxTotal(ldapConfig.getPoolMaxTotal());
@@ -172,7 +187,29 @@ public class LbLdapClient
                 SearchScope.SUBTREE,
                 attributes);
 
+        if (config.isLdapAdDomainScopeControl()) {
+            searchRequest.addControl(createAdDomainScopeControl());
+        }
+
         return searchRequest;
+    }
+
+    private static OpaqueControl createAdDomainScopeControl()
+    {
+        OpaqueControl control = new OpaqueControl(AD_DOMAIN_SCOPE_CONTROL_OID, false);
+        // Apache Directory's opaque control encoder requires an encoded value,
+        // while the Active Directory Domain Scope control has no payload.
+        control.setEncodedValue(Strings.EMPTY_BYTES);
+        return control;
+    }
+
+    static LdapApiService createLdapApiService()
+            throws Exception
+    {
+        LdapApiService ldapApiService = new StandaloneLdapApiService();
+        ldapApiService.registerRequestControl(
+                new OpaqueControlFactory(ldapApiService, AD_DOMAIN_SCOPE_CONTROL_OID));
+        return ldapApiService;
     }
 
     public static class UserRecord

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbLdapClient.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbLdapClient.java
@@ -19,6 +19,7 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.exception.LdapException;
 import org.apache.directory.api.ldap.model.exception.LdapInvalidDnException;
+import org.apache.directory.api.ldap.model.filter.FilterEncoder;
 import org.apache.directory.api.ldap.model.message.SearchRequest;
 import org.apache.directory.api.ldap.model.message.SearchScope;
 import org.apache.directory.api.ldap.model.name.Dn;
@@ -117,7 +118,7 @@ public class LbLdapClient
                         ldapConnectionTemplate.authenticate(userDn, password.toCharArray());
             }
             else {
-                String filter = config.getLdapUserSearch().replace("${USER}", user);
+                String filter = createUserSearchFilter(user);
                 SearchRequest searchRequest = newUserSearchRequest(filter);
                 passwordWarning =
                         ldapConnectionTemplate.authenticate(searchRequest, password.toCharArray());
@@ -142,7 +143,7 @@ public class LbLdapClient
 
     public String getMemberOf(String user)
     {
-        String filter = config.getLdapUserSearch().replace("${USER}", user);
+        String filter = createUserSearchFilter(user);
 
         SearchRequest searchRequest = newUserSearchRequest(
                 filter,
@@ -155,6 +156,12 @@ public class LbLdapClient
             log.debug("Member of %s", memberOf);
         }
         return memberOf;
+    }
+
+    private String createUserSearchFilter(String user)
+    {
+        return config.getLdapUserSearch()
+                .replace("${USER}", FilterEncoder.encodeFilterValue(user));
     }
 
     private SearchRequest newUserSearchRequest(String filter, String... attributes)

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbLdapClient.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbLdapClient.java
@@ -13,52 +13,39 @@
  */
 package io.trino.gateway.ha.security;
 
-import io.airlift.log.Logger;
 import io.trino.gateway.ha.config.LdapConfiguration;
+import org.apache.directory.api.ldap.model.message.SearchRequest;
+import org.apache.directory.api.ldap.model.message.SearchRequestImpl;
 import org.apache.directory.api.ldap.model.message.SearchScope;
 import org.apache.directory.ldap.client.template.LdapConnectionTemplate;
 import org.apache.directory.ldap.client.template.exception.PasswordException;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 final class TestLbLdapClient
 {
-    private static final Logger log = Logger.get(TestLbLdapClient.class);
     @Mock
-    LdapConnectionTemplate ldapConnectionTemplate;
-    @Spy
-    LdapConfiguration ldapConfig =
-            LdapConfiguration.load("src/test/resources/auth/ldapTestConfig.yml");
-    @InjectMocks
-    LbLdapClient lbLdapClient =
-            new LbLdapClient(LdapConfiguration.load("src/test/resources/auth/ldapTestConfig.yml"));
+    private LdapConnectionTemplate ldapConnectionTemplate;
+
+    private LdapConfiguration ldapConfig;
+    private LbLdapClient lbLdapClient;
 
     @BeforeEach
-    public void initMocks()
+    void setUp()
     {
-        log.info("initializing test");
-        org.mockito.MockitoAnnotations.openMocks(this);
-    }
-
-    @AfterEach
-    public void resetMocks()
-    {
-        log.info("resetting mocks");
-        Mockito.reset(ldapConnectionTemplate);
-        Mockito.reset(ldapConfig);
+        ldapConfig = LdapConfiguration.load("src/test/resources/auth/ldapTestConfig.yml");
+        lbLdapClient = new LbLdapClient(ldapConfig, ldapConnectionTemplate);
     }
 
     @Test
@@ -67,88 +54,62 @@ final class TestLbLdapClient
     {
         String user = "user1";
         String password = "pass1";
-
         String filter = ldapConfig.getLdapUserSearch().replace("${USER}", user);
+        SearchRequest searchRequest = new SearchRequestImpl();
 
-        Mockito
-                .when(ldapConnectionTemplate.authenticate(
-                        ldapConfig.getLdapUserBaseDn(),
-                        filter,
-                        SearchScope.SUBTREE,
-                        password.toCharArray()))
+        when(ldapConnectionTemplate.newSearchRequest(
+                eq(ldapConfig.getLdapUserBaseDn()),
+                eq(filter),
+                eq(SearchScope.SUBTREE),
+                any(String[].class)))
+                .thenReturn(searchRequest);
+
+        when(ldapConnectionTemplate.authenticate(eq(searchRequest), any(char[].class)))
                 .thenReturn(null);
-
-        // Success case
         assertThat(lbLdapClient.authenticate(user, password)).isTrue();
 
-        Mockito
-                .when(ldapConnectionTemplate.authenticate(
-                        ldapConfig.getLdapUserBaseDn(),
-                        filter,
-                        SearchScope.SUBTREE,
-                        password.toCharArray()))
-                .thenReturn(new TestLbLdapClient.DummyPasswordWarning());
-
-        // Warning case
+        when(ldapConnectionTemplate.authenticate(eq(searchRequest), any(char[].class)))
+                .thenReturn(new DummyPasswordWarning());
         assertThat(lbLdapClient.authenticate(user, password)).isTrue();
 
-        Mockito
-                .when(ldapConnectionTemplate.authenticate(
-                        ldapConfig.getLdapUserBaseDn(),
-                        filter,
-                        SearchScope.SUBTREE,
-                        password.toCharArray()))
+        when(ldapConnectionTemplate.authenticate(eq(searchRequest), any(char[].class)))
                 .thenThrow(PasswordException.class);
-
-        // failure case
         assertThat(lbLdapClient.authenticate(user, password)).isFalse();
-
-        assertThatThrownBy(() -> Mockito
-                .when(ldapConnectionTemplate.authenticate(
-                        ldapConfig.getLdapUserBaseDn(),
-                        filter,
-                        SearchScope.SUBTREE,
-                        password.toCharArray()))
-                .thenReturn(null))
-                .isInstanceOf(PasswordException.class);
     }
 
     @Test
-    void testMemberof()
+    void testGetMemberOf()
     {
         String user = "user1";
         String[] attributes = new String[] {"memberOf"};
         String filter = ldapConfig.getLdapUserSearch().replace("${USER}", user);
+        SearchRequest searchRequest = new SearchRequestImpl();
 
-        java.util.ArrayList users = new java.util.ArrayList();
-        users.add(new LbLdapClient.UserRecord("Admin,User"));
+        when(ldapConnectionTemplate.newSearchRequest(
+                eq(ldapConfig.getLdapUserBaseDn()),
+                eq(filter),
+                eq(SearchScope.SUBTREE),
+                eq(attributes)))
+                .thenReturn(searchRequest);
 
-        Mockito
-                .when(ldapConnectionTemplate.search(
-                        eq(ldapConfig.getLdapUserBaseDn()),
-                        eq(filter),
-                        eq(SearchScope.SUBTREE),
-                        eq(attributes),
-                        any(LbLdapClient.UserEntryMapper.class)))
-                .thenReturn(users);
+        when(ldapConnectionTemplate.search(
+                eq(searchRequest),
+                any(LbLdapClient.UserEntryMapper.class)))
+                .thenReturn(List.of(new LbLdapClient.UserRecord("Admin,User")));
 
-        // Success case
-        String ret = lbLdapClient.getMemberOf(user);
+        assertThat(lbLdapClient.getMemberOf(user)).isEqualTo("Admin,User");
 
-        log.info("ret is %s", ret);
-        assertThat(ret).isEqualTo("Admin,User");
-
-        org.mockito.Mockito
-                .when(ldapConnectionTemplate.search(
-                        eq(ldapConfig.getLdapUserBaseDn()),
-                        eq(filter),
-                        eq(SearchScope.SUBTREE),
-                        eq(attributes),
-                        any(LbLdapClient.UserEntryMapper.class)))
+        when(ldapConnectionTemplate.search(
+                eq(searchRequest),
+                any(LbLdapClient.UserEntryMapper.class)))
                 .thenReturn(null);
+        assertThat(lbLdapClient.getMemberOf(user)).isEmpty();
 
-        // failure case
-        assertThat(lbLdapClient.getMemberOf(user)).isNotEqualTo("Admin,User");
+        when(ldapConnectionTemplate.search(
+                eq(searchRequest),
+                any(LbLdapClient.UserEntryMapper.class)))
+                .thenReturn(List.of());
+        assertThat(lbLdapClient.getMemberOf(user)).isEmpty();
     }
 
     static class DummyPasswordWarning

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbLdapClient.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbLdapClient.java
@@ -14,9 +14,13 @@
 package io.trino.gateway.ha.security;
 
 import io.trino.gateway.ha.config.LdapConfiguration;
+import org.apache.directory.api.asn1.util.Asn1Buffer;
+import org.apache.directory.api.ldap.codec.api.LdapApiService;
+import org.apache.directory.api.ldap.codec.api.LdapEncoder;
 import org.apache.directory.api.ldap.model.message.SearchRequest;
 import org.apache.directory.api.ldap.model.message.SearchRequestImpl;
 import org.apache.directory.api.ldap.model.message.SearchScope;
+import org.apache.directory.api.ldap.model.message.controls.OpaqueControl;
 import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.ldap.client.template.LdapConnectionTemplate;
 import org.apache.directory.ldap.client.template.exception.PasswordException;
@@ -28,8 +32,10 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
+import static io.trino.gateway.ha.security.LbLdapClient.AD_DOMAIN_SCOPE_CONTROL_OID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
@@ -260,6 +266,81 @@ final class TestLbLdapClient
                 eq(SPECIAL_USER_FILTER),
                 eq(SearchScope.SUBTREE),
                 eq(attributes));
+    }
+
+    @Test
+    void testDomainScopeControlIsAddedWhenEnabled()
+    {
+        String user = "user1";
+        String[] attributes = new String[] {"memberOf"};
+        String filter = ldapConfig.getLdapUserSearch().replace("${USER}", user);
+
+        ldapConfig.setLdapAdDomainScopeControl(false);
+        SearchRequest disabledRequest = getMemberOfSearchRequest(filter, attributes);
+        assertThat(disabledRequest.hasControl(AD_DOMAIN_SCOPE_CONTROL_OID)).isFalse();
+
+        ldapConfig.setLdapAdDomainScopeControl(true);
+        SearchRequest enabledRequest = getMemberOfSearchRequest(filter, attributes);
+        assertThat(enabledRequest.hasControl(AD_DOMAIN_SCOPE_CONTROL_OID)).isTrue();
+        assertThat(enabledRequest.getBase().toString()).isEqualTo(ldapConfig.getLdapUserBaseDn());
+        assertThat(enabledRequest.getFilter().toString()).isEqualTo(filter);
+        assertThat(enabledRequest.getScope()).isEqualTo(SearchScope.SUBTREE);
+        assertThat(enabledRequest.getAttributes()).containsExactly("memberOf");
+
+        OpaqueControl control = (OpaqueControl) enabledRequest.getControl(AD_DOMAIN_SCOPE_CONTROL_OID);
+        assertThat(control).isNotNull();
+        assertThat(control.getOid()).isEqualTo("1.2.840.113556.1.4.1339");
+        assertThat(control.isCritical()).isFalse();
+        assertThat(control.hasEncodedValue()).isTrue();
+        assertThat(control.getEncodedValue()).isEmpty();
+    }
+
+    @Test
+    void testDomainScopeControlCanBeEncoded()
+            throws Exception
+    {
+        ldapConfig.setLdapAdDomainScopeControl(true);
+
+        String filter = ldapConfig.getLdapUserSearch().replace("${USER}", "user1");
+        SearchRequest searchRequest = getMemberOfSearchRequest(
+                filter,
+                new String[] {"memberOf"});
+        searchRequest.setMessageId(1);
+
+        LdapApiService ldapApiService = LbLdapClient.createLdapApiService();
+        assertThat(ldapApiService.isControlRegistered(AD_DOMAIN_SCOPE_CONTROL_OID)).isTrue();
+
+        ByteBuffer encoded = LdapEncoder.encodeMessage(
+                new Asn1Buffer(),
+                ldapApiService,
+                searchRequest);
+        assertThat(encoded.remaining()).isGreaterThan(0);
+    }
+
+    private SearchRequest getMemberOfSearchRequest(String filter, String[] attributes)
+    {
+        ArgumentCaptor<SearchRequest> searchRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        SearchRequest searchRequest = new SearchRequestImpl();
+
+        when(ldapConnectionTemplate.newSearchRequest(
+                eq(ldapConfig.getLdapUserBaseDn()),
+                eq(filter),
+                eq(SearchScope.SUBTREE),
+                eq(attributes)))
+                .thenAnswer(invocation -> {
+                    searchRequest.setBase(new Dn(new String[] {invocation.getArgument(0)}));
+                    searchRequest.setFilter((String) invocation.getArgument(1));
+                    searchRequest.setScope(invocation.getArgument(2));
+                    searchRequest.addAttributes(attributes);
+                    return searchRequest;
+                });
+        when(ldapConnectionTemplate.search(
+                searchRequestCaptor.capture(),
+                any(LbLdapClient.UserEntryMapper.class)))
+                .thenReturn(null);
+
+        lbLdapClient.getMemberOf("user1");
+        return searchRequestCaptor.getValue();
     }
 
     static class DummyPasswordWarning

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbLdapClient.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbLdapClient.java
@@ -14,27 +14,41 @@
 package io.trino.gateway.ha.security;
 
 import io.trino.gateway.ha.config.LdapConfiguration;
+import org.apache.directory.api.asn1.util.Asn1Buffer;
+import org.apache.directory.api.ldap.codec.api.LdapApiService;
+import org.apache.directory.api.ldap.codec.api.LdapEncoder;
 import org.apache.directory.api.ldap.model.message.SearchRequest;
 import org.apache.directory.api.ldap.model.message.SearchRequestImpl;
 import org.apache.directory.api.ldap.model.message.SearchScope;
+import org.apache.directory.api.ldap.model.message.controls.OpaqueControl;
+import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.ldap.client.template.LdapConnectionTemplate;
 import org.apache.directory.ldap.client.template.exception.PasswordException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 final class TestLbLdapClient
 {
+    private static final String AD_DOMAIN_SCOPE_CONTROL_OID = "1.2.840.113556.1.4.1339";
+    private static final String SPECIAL_USER = "user*)(uid=*)\\test";
+    private static final String SPECIAL_USER_FILTER =
+            "(&(objectclass=user)(sAMAccountName=user\\2A\\29\\28uid=\\2A\\29\\5Ctest))";
+
     @Mock
     private LdapConnectionTemplate ldapConnectionTemplate;
 
@@ -78,6 +92,30 @@ final class TestLbLdapClient
     }
 
     @Test
+    void testAuthenticateEscapesFilterValue()
+            throws Exception
+    {
+        SearchRequest searchRequest = mock(SearchRequest.class);
+
+        when(ldapConnectionTemplate.newSearchRequest(
+                eq(ldapConfig.getLdapUserBaseDn()),
+                eq(SPECIAL_USER_FILTER),
+                eq(SearchScope.SUBTREE),
+                any(String[].class)))
+                .thenReturn(searchRequest);
+        when(ldapConnectionTemplate.authenticate(eq(searchRequest), any(char[].class)))
+                .thenReturn(null);
+
+        assertThat(lbLdapClient.authenticate(SPECIAL_USER, "pass1")).isTrue();
+
+        verify(ldapConnectionTemplate).newSearchRequest(
+                eq(ldapConfig.getLdapUserBaseDn()),
+                eq(SPECIAL_USER_FILTER),
+                eq(SearchScope.SUBTREE),
+                any(String[].class));
+    }
+
+    @Test
     void testGetMemberOf()
     {
         String user = "user1";
@@ -110,6 +148,107 @@ final class TestLbLdapClient
                 any(LbLdapClient.UserEntryMapper.class)))
                 .thenReturn(List.of());
         assertThat(lbLdapClient.getMemberOf(user)).isEmpty();
+    }
+
+    @Test
+    void testGetMemberOfEscapesFilterValue()
+    {
+        String[] attributes = new String[] {"memberOf"};
+        SearchRequest searchRequest = mock(SearchRequest.class);
+
+        when(ldapConnectionTemplate.newSearchRequest(
+                eq(ldapConfig.getLdapUserBaseDn()),
+                eq(SPECIAL_USER_FILTER),
+                eq(SearchScope.SUBTREE),
+                eq(attributes)))
+                .thenReturn(searchRequest);
+        when(ldapConnectionTemplate.search(
+                eq(searchRequest),
+                any(LbLdapClient.UserEntryMapper.class)))
+                .thenReturn(List.of(new LbLdapClient.UserRecord("Admin,User")));
+
+        assertThat(lbLdapClient.getMemberOf(SPECIAL_USER)).isEqualTo("Admin,User");
+
+        verify(ldapConnectionTemplate).newSearchRequest(
+                eq(ldapConfig.getLdapUserBaseDn()),
+                eq(SPECIAL_USER_FILTER),
+                eq(SearchScope.SUBTREE),
+                eq(attributes));
+    }
+
+    @Test
+    void testDomainScopeControlIsAddedWhenEnabled()
+    {
+        String user = "user1";
+        String[] attributes = new String[] {"memberOf"};
+        String filter = ldapConfig.getLdapUserSearch().replace("${USER}", user);
+
+        ldapConfig.setLdapAdDomainScopeControl(false);
+        SearchRequest disabledRequest = getMemberOfSearchRequest(filter, attributes);
+        assertThat(disabledRequest.hasControl(AD_DOMAIN_SCOPE_CONTROL_OID)).isFalse();
+
+        ldapConfig.setLdapAdDomainScopeControl(true);
+        SearchRequest enabledRequest = getMemberOfSearchRequest(filter, attributes);
+        assertThat(enabledRequest.hasControl(AD_DOMAIN_SCOPE_CONTROL_OID)).isTrue();
+        assertThat(enabledRequest.getBase().toString()).isEqualTo(ldapConfig.getLdapUserBaseDn());
+        assertThat(enabledRequest.getFilter().toString()).isEqualTo(filter);
+        assertThat(enabledRequest.getScope()).isEqualTo(SearchScope.SUBTREE);
+        assertThat(enabledRequest.getAttributes()).containsExactly("memberOf");
+
+        OpaqueControl control = (OpaqueControl) enabledRequest.getControl(AD_DOMAIN_SCOPE_CONTROL_OID);
+        assertThat(control).isNotNull();
+        assertThat(control.getOid()).isEqualTo("1.2.840.113556.1.4.1339");
+        assertThat(control.isCritical()).isFalse();
+        assertThat(control.hasEncodedValue()).isTrue();
+        assertThat(control.getEncodedValue()).isEmpty();
+    }
+
+    @Test
+    void testDomainScopeControlCanBeEncoded()
+            throws Exception
+    {
+        ldapConfig.setLdapAdDomainScopeControl(true);
+
+        String filter = ldapConfig.getLdapUserSearch().replace("${USER}", "user1");
+        SearchRequest searchRequest = getMemberOfSearchRequest(
+                filter,
+                new String[] {"memberOf"});
+        searchRequest.setMessageId(1);
+
+        LdapApiService ldapApiService = LbLdapClient.createLdapApiService();
+        assertThat(ldapApiService.isControlRegistered(AD_DOMAIN_SCOPE_CONTROL_OID)).isTrue();
+
+        ByteBuffer encoded = LdapEncoder.encodeMessage(
+                new Asn1Buffer(),
+                ldapApiService,
+                searchRequest);
+        assertThat(encoded.remaining()).isGreaterThan(0);
+    }
+
+    private SearchRequest getMemberOfSearchRequest(String filter, String[] attributes)
+    {
+        ArgumentCaptor<SearchRequest> searchRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        SearchRequest searchRequest = new SearchRequestImpl();
+
+        when(ldapConnectionTemplate.newSearchRequest(
+                eq(ldapConfig.getLdapUserBaseDn()),
+                eq(filter),
+                eq(SearchScope.SUBTREE),
+                eq(attributes)))
+                .thenAnswer(invocation -> {
+                    searchRequest.setBase(new Dn(new String[] {invocation.getArgument(0)}));
+                    searchRequest.setFilter((String) invocation.getArgument(1));
+                    searchRequest.setScope(invocation.getArgument(2));
+                    searchRequest.addAttributes(attributes);
+                    return searchRequest;
+                });
+        when(ldapConnectionTemplate.search(
+                searchRequestCaptor.capture(),
+                any(LbLdapClient.UserEntryMapper.class)))
+                .thenReturn(null);
+
+        lbLdapClient.getMemberOf("user1");
+        return searchRequestCaptor.getValue();
     }
 
     static class DummyPasswordWarning

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbLdapClient.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbLdapClient.java
@@ -13,54 +13,42 @@
  */
 package io.trino.gateway.ha.security;
 
-import io.airlift.log.Logger;
 import io.trino.gateway.ha.config.LdapConfiguration;
+import org.apache.directory.api.ldap.model.message.SearchRequest;
+import org.apache.directory.api.ldap.model.message.SearchRequestImpl;
 import org.apache.directory.api.ldap.model.message.SearchScope;
 import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.ldap.client.template.LdapConnectionTemplate;
 import org.apache.directory.ldap.client.template.exception.PasswordException;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 final class TestLbLdapClient
 {
-    private static final Logger log = Logger.get(TestLbLdapClient.class);
     @Mock
-    LdapConnectionTemplate ldapConnectionTemplate;
-    @Spy
-    LdapConfiguration ldapConfig =
-            LdapConfiguration.load("src/test/resources/auth/ldapTestConfig.yml");
-    @InjectMocks
-    LbLdapClient lbLdapClient =
-            new LbLdapClient(LdapConfiguration.load("src/test/resources/auth/ldapTestConfig.yml"));
+    private LdapConnectionTemplate ldapConnectionTemplate;
+
+    private LdapConfiguration ldapConfig;
+    private LbLdapClient lbLdapClient;
 
     @BeforeEach
-    public void initMocks()
+    void setUp()
     {
-        log.info("initializing test");
-        org.mockito.MockitoAnnotations.openMocks(this);
-    }
-
-    @AfterEach
-    public void resetMocks()
-    {
-        log.info("resetting mocks");
-        Mockito.reset(ldapConnectionTemplate);
-        Mockito.reset(ldapConfig);
+        ldapConfig = Mockito.spy(LdapConfiguration.load("src/test/resources/auth/ldapTestConfig.yml"));
+        lbLdapClient = new LbLdapClient(ldapConfig, ldapConnectionTemplate);
     }
 
     @Test
@@ -69,50 +57,27 @@ final class TestLbLdapClient
     {
         String user = "user1";
         String password = "pass1";
-
         String filter = ldapConfig.getLdapUserSearch().replace("${USER}", user);
+        SearchRequest searchRequest = new SearchRequestImpl();
 
-        Mockito
-                .when(ldapConnectionTemplate.authenticate(
-                        ldapConfig.getLdapUserBaseDn(),
-                        filter,
-                        SearchScope.SUBTREE,
-                        password.toCharArray()))
+        when(ldapConnectionTemplate.newSearchRequest(
+                eq(ldapConfig.getLdapUserBaseDn()),
+                eq(filter),
+                eq(SearchScope.SUBTREE),
+                any(String[].class)))
+                .thenReturn(searchRequest);
+
+        when(ldapConnectionTemplate.authenticate(eq(searchRequest), any(char[].class)))
                 .thenReturn(null);
-
-        // Success case
         assertThat(lbLdapClient.authenticate(user, password)).isTrue();
 
-        Mockito
-                .when(ldapConnectionTemplate.authenticate(
-                        ldapConfig.getLdapUserBaseDn(),
-                        filter,
-                        SearchScope.SUBTREE,
-                        password.toCharArray()))
-                .thenReturn(new TestLbLdapClient.DummyPasswordWarning());
-
-        // Warning case
+        when(ldapConnectionTemplate.authenticate(eq(searchRequest), any(char[].class)))
+                .thenReturn(new DummyPasswordWarning());
         assertThat(lbLdapClient.authenticate(user, password)).isTrue();
 
-        Mockito
-                .when(ldapConnectionTemplate.authenticate(
-                        ldapConfig.getLdapUserBaseDn(),
-                        filter,
-                        SearchScope.SUBTREE,
-                        password.toCharArray()))
+        when(ldapConnectionTemplate.authenticate(eq(searchRequest), any(char[].class)))
                 .thenThrow(PasswordException.class);
-
-        // failure case
         assertThat(lbLdapClient.authenticate(user, password)).isFalse();
-
-        assertThatThrownBy(() -> Mockito
-                .when(ldapConnectionTemplate.authenticate(
-                        ldapConfig.getLdapUserBaseDn(),
-                        filter,
-                        SearchScope.SUBTREE,
-                        password.toCharArray()))
-                .thenReturn(null))
-                .isInstanceOf(PasswordException.class);
     }
 
     @Test
@@ -207,41 +172,38 @@ final class TestLbLdapClient
     }
 
     @Test
-    void testMemberof()
+    void testGetMemberOf()
     {
         String user = "user1";
         String[] attributes = new String[] {"memberOf"};
         String filter = ldapConfig.getLdapUserSearch().replace("${USER}", user);
+        SearchRequest searchRequest = new SearchRequestImpl();
 
-        java.util.ArrayList users = new java.util.ArrayList();
-        users.add(new LbLdapClient.UserRecord("Admin,User"));
+        when(ldapConnectionTemplate.newSearchRequest(
+                eq(ldapConfig.getLdapUserBaseDn()),
+                eq(filter),
+                eq(SearchScope.SUBTREE),
+                eq(attributes)))
+                .thenReturn(searchRequest);
 
-        Mockito
-                .when(ldapConnectionTemplate.search(
-                        eq(ldapConfig.getLdapUserBaseDn()),
-                        eq(filter),
-                        eq(SearchScope.SUBTREE),
-                        eq(attributes),
-                        any(LbLdapClient.UserEntryMapper.class)))
-                .thenReturn(users);
+        when(ldapConnectionTemplate.search(
+                eq(searchRequest),
+                any(LbLdapClient.UserEntryMapper.class)))
+                .thenReturn(List.of(new LbLdapClient.UserRecord("Admin,User")));
 
-        // Success case
-        String ret = lbLdapClient.getMemberOf(user);
+        assertThat(lbLdapClient.getMemberOf(user)).isEqualTo("Admin,User");
 
-        log.info("ret is %s", ret);
-        assertThat(ret).isEqualTo("Admin,User");
-
-        org.mockito.Mockito
-                .when(ldapConnectionTemplate.search(
-                        eq(ldapConfig.getLdapUserBaseDn()),
-                        eq(filter),
-                        eq(SearchScope.SUBTREE),
-                        eq(attributes),
-                        any(LbLdapClient.UserEntryMapper.class)))
+        when(ldapConnectionTemplate.search(
+                eq(searchRequest),
+                any(LbLdapClient.UserEntryMapper.class)))
                 .thenReturn(null);
+        assertThat(lbLdapClient.getMemberOf(user)).isEmpty();
 
-        // failure case
-        assertThat(lbLdapClient.getMemberOf(user)).isNotEqualTo("Admin,User");
+        when(ldapConnectionTemplate.search(
+                eq(searchRequest),
+                any(LbLdapClient.UserEntryMapper.class)))
+                .thenReturn(List.of());
+        assertThat(lbLdapClient.getMemberOf(user)).isEmpty();
     }
 
     static class DummyPasswordWarning

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbLdapClient.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbLdapClient.java
@@ -33,11 +33,17 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 final class TestLbLdapClient
 {
+    private static final String SPECIAL_USER = "user*)(uid=*)\\test";
+    private static final String SPECIAL_USER_FILTER =
+            "(&(objectclass=user)(sAMAccountName=user\\2A\\29\\28uid=\\2A\\29\\5Ctest))";
+
     @Mock
     private LdapConnectionTemplate ldapConnectionTemplate;
 
@@ -78,6 +84,30 @@ final class TestLbLdapClient
         when(ldapConnectionTemplate.authenticate(eq(searchRequest), any(char[].class)))
                 .thenThrow(PasswordException.class);
         assertThat(lbLdapClient.authenticate(user, password)).isFalse();
+    }
+
+    @Test
+    void testAuthenticateEscapesFilterValue()
+            throws Exception
+    {
+        SearchRequest searchRequest = mock(SearchRequest.class);
+
+        when(ldapConnectionTemplate.newSearchRequest(
+                eq(ldapConfig.getLdapUserBaseDn()),
+                eq(SPECIAL_USER_FILTER),
+                eq(SearchScope.SUBTREE),
+                any(String[].class)))
+                .thenReturn(searchRequest);
+        when(ldapConnectionTemplate.authenticate(eq(searchRequest), any(char[].class)))
+                .thenReturn(null);
+
+        assertThat(lbLdapClient.authenticate(SPECIAL_USER, "pass1")).isTrue();
+
+        verify(ldapConnectionTemplate).newSearchRequest(
+                eq(ldapConfig.getLdapUserBaseDn()),
+                eq(SPECIAL_USER_FILTER),
+                eq(SearchScope.SUBTREE),
+                any(String[].class));
     }
 
     @Test
@@ -204,6 +234,32 @@ final class TestLbLdapClient
                 any(LbLdapClient.UserEntryMapper.class)))
                 .thenReturn(List.of());
         assertThat(lbLdapClient.getMemberOf(user)).isEmpty();
+    }
+
+    @Test
+    void testGetMemberOfEscapesFilterValue()
+    {
+        String[] attributes = new String[] {"memberOf"};
+        SearchRequest searchRequest = mock(SearchRequest.class);
+
+        when(ldapConnectionTemplate.newSearchRequest(
+                eq(ldapConfig.getLdapUserBaseDn()),
+                eq(SPECIAL_USER_FILTER),
+                eq(SearchScope.SUBTREE),
+                eq(attributes)))
+                .thenReturn(searchRequest);
+        when(ldapConnectionTemplate.search(
+                eq(searchRequest),
+                any(LbLdapClient.UserEntryMapper.class)))
+                .thenReturn(List.of(new LbLdapClient.UserRecord("Admin,User")));
+
+        assertThat(lbLdapClient.getMemberOf(SPECIAL_USER)).isEqualTo("Admin,User");
+
+        verify(ldapConnectionTemplate).newSearchRequest(
+                eq(ldapConfig.getLdapUserBaseDn()),
+                eq(SPECIAL_USER_FILTER),
+                eq(SearchScope.SUBTREE),
+                eq(attributes));
     }
 
     static class DummyPasswordWarning

--- a/gateway-ha/src/test/resources/auth/ldapTestConfig.yml
+++ b/gateway-ha/src/test/resources/auth/ldapTestConfig.yml
@@ -14,3 +14,4 @@ poolMaxIdle: 8
 poolMaxTotal: 8
 poolMinIdle: 0
 poolTestOnBorrow: true
+ldapAdDomainScopeControl: false


### PR DESCRIPTION
## Description

Adds optional support for the Microsoft Active Directory Domain Scope LDAP control.

When `ldapUserBaseDn` is configured to the Active Directory domain root (for example, `DC=example,DC=com`), subtree searches can discover users from all organizational units. However, Active Directory may also return subordinate referrals for naming contexts such as `DomainDnsZones` and `ForestDnsZones`, which can cause authentication to fail when using the Apache Directory LDAP client.

This change introduces an optional configuration that enables the Microsoft Active Directory Domain Scope control (OID `1.2.840.113556.1.4.1339`) for LDAP user searches. When enabled, the search is restricted to the current domain naming context, allowing users across all OUs within the domain to be found without returning subordinate referrals.

The feature is specific to Microsoft Active Directory and is disabled by default.

## Additional context and related issues

This PR supersedes the previous referral-handling approach #1174 .

During the investigation, it became clear that the underlying requirement was not to follow LDAP referrals, but to prevent Active Directory from generating subordinate referrals when searching from the domain root. The Microsoft Active Directory Domain Scope control provides the desired behavior without requiring generic LDAP referral handling.

Closes #1173 

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.

(x) Release notes are required, with the following suggested text:

```markdown
* Add optional support for the Microsoft Active Directory Domain Scope LDAP control, allowing LDAP user searches from the Active Directory domain root without returning subordinate referrals.
```
