### PR TITLE
Remove PPC container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: $MAVEN install ${MAVEN_FAST_INSTALL}
       - uses: docker/setup-qemu-action@v4.2.0
         with:
-          platforms: amd64,arm64,ppc64le
+          platforms: amd64,arm64
       - name: Build and Test Docker Image
         run: docker/build.sh
       - name: Set up Helm

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4.2.0
         with:
-          platforms: amd64,arm64,ppc64le
+          platforms: amd64,arm64
 
       - name: Install crane
         uses: imjasonh/setup-crane@v0.7

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -8,7 +8,7 @@ Usage: $0 [-h] [-a <ARCHITECTURES>] [-r <VERSION>]
 Builds the Trino Gateway Docker image
 
 -h       Display help
--a       Build the specified comma-separated architectures, defaults to amd64,arm64,ppc64le
+-a       Build the specified comma-separated architectures, defaults to amd64,arm64
 -r       Build the specified Trino Gateway release version, downloads all required artifacts
 -j       Build the Trino Gateway release with specified Temurin JDK release
 EOF
@@ -20,7 +20,7 @@ cd "${SCRIPT_DIR}" || exit 2
 
 SOURCE_DIR="${SCRIPT_DIR}/.."
 
-ARCHITECTURES=(amd64 arm64 ppc64le)
+ARCHITECTURES=(amd64 arm64)
 TRINO_GATEWAY_VERSION=
 JDK_RELEASE_NAME=$(cat "${SOURCE_DIR}/.java-version")
 # necessary to allow version parsing from the pom file
@@ -70,9 +70,6 @@ function temurin_jdk_link() {
     ;;
     amd64)
       echo "https://api.adoptium.net/v3/binary/version/${JDK_RELEASE_NAME}/linux/x64/jdk/hotspot/normal/eclipse?project=jdk"
-    ;;
-    ppc64le)
-      echo "https://api.adoptium.net/v3/binary/version/${JDK_RELEASE_NAME}/linux/ppc64le/jdk/hotspot/normal/eclipse?project=jdk"
     ;;
   *)
     echo "${ARCH} is not supported for Docker image"
@@ -132,9 +129,6 @@ echo "🏃 Testing built images"
 source container-test.sh
 
 for arch in "${ARCHITECTURES[@]}"; do
-    # TODO: remove when https://github.com/multiarch/qemu-user-static/issues/128 is fixed
-    if [[ "$arch" != "ppc64le" ]]; then
-        test_container "${TAG_PREFIX}-$arch" "linux/$arch" "${SCRIPT_DIR}/docker-compose.yml" "trino-gateway" "postgres"
-    fi
+    test_container "${TAG_PREFIX}-$arch" "linux/$arch" "${SCRIPT_DIR}/docker-compose.yml" "trino-gateway" "postgres"
     docker image inspect -f '🚀 Built {{.RepoTags}} {{.Id}}' "${TAG_PREFIX}-$arch"
 done

--- a/docker/release-docker.sh
+++ b/docker/release-docker.sh
@@ -18,7 +18,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 $SCRIPT_DIR/build.sh -r "$VERSION"
 
-architectures=(amd64 arm64 ppc64le)
+architectures=(amd64 arm64)
 
 # Create temp directory for digest references
 REFS_DIR=$(mktemp -d)
@@ -34,10 +34,8 @@ done
 # Create multi-arch manifests from the digest references
 crane index append -t "$TARGET" \
     -m "$(cat $REFS_DIR/amd64.ref)" \
-    -m "$(cat $REFS_DIR/arm64.ref)" \
-    -m "$(cat $REFS_DIR/ppc64le.ref)"
+    -m "$(cat $REFS_DIR/arm64.ref)"
 
 crane index append -t "$REPO:latest" \
     -m "$(cat $REFS_DIR/amd64.ref)" \
-    -m "$(cat $REFS_DIR/arm64.ref)" \
-    -m "$(cat $REFS_DIR/ppc64le.ref)"
+    -m "$(cat $REFS_DIR/arm64.ref)"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -38,8 +38,8 @@ Then build the image for your desired processor architecture in the `docker` dir
 ./build.sh -a arm64
 ```
 
-By default, the scripts builds all valid processor architectures `amd64`,
-`arm64`, and `ppc64le`:
+By default, the scripts builds all valid processor architectures `amd64` and
+`arm64`:
 
 ```bash
 ./build.sh
@@ -52,7 +52,6 @@ number and`-yyy` is the processor architecture:
 ```bash
 $ docker images
 REPOSITORY            TAG                  IMAGE ID       CREATED          SIZE
-trino-gateway         6-SNAPSHOT-ppc64le   a72b750d2745   33 seconds ago   547MB
 trino-gateway         6-SNAPSHOT-arm64     bc5e8b0db63c   35 seconds ago   523MB
 trino-gateway         6-SNAPSHOT-amd64     6c066fa5b0c5   36 seconds ago   518MB
 ...


### PR DESCRIPTION
Remove PPC64LE Docker image support from local builds, CI, release manifests, and documentation.

Follow up to https://github.com/trinodb/trino/pull/30422

RN suggestion

Breaking Stop building, testing, and shipping container images for PowerPC processors.