### PR TITLE
Support direct LDAP bind without a user search

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -162,6 +162,7 @@ The LDAP config file should have the following contents:
   ldapAdminBindDn: <>
   ldapUserBaseDn: <>
   ldapUserSearch: <>
+  ldapUserDnPattern: <optional, enables direct bind>
   ldapGroupMemberAttribute: <>
   ldapAdminPassword: <>
   ldapTrustStorePath: <for a secure ldap connectivity>
@@ -171,6 +172,37 @@ The LDAP config file should have the following contents:
   poolMinIdle: 0
   poolTestOnBorrow: true
 ```
+
+### Direct bind
+
+By default the gateway authenticates a user in two steps. It binds with
+`ldapAdminBindDn` and `ldapAdminPassword`, searches for the user entry under
+`ldapUserBaseDn` with `ldapUserSearch`, and then binds as the DN it found.
+
+If the user DN can be derived from the login name, set `ldapUserDnPattern` to
+skip the search and bind directly:
+
+```yaml
+  ldapUserDnPattern: 'uid=${USER},ou=people,dc=example,dc=com'
+```
+
+The `${USER}` placeholder is replaced with the login name, escaped according to
+the DN escaping rules. A bind with an empty password is rejected before it
+reaches the server, because some directory servers treat it as an anonymous
+unauthenticated bind and answer with success.
+
+The pattern is validated while the configuration is loaded. It must contain the
+`${USER}` placeholder, otherwise every login would bind as the same DN, and it
+must resolve to a valid DN. An invalid pattern fails the startup instead of
+failing every login attempt.
+
+When `ldapUserDnPattern` is not set, the search based flow is used, so existing
+configurations are unaffected.
+
+LDAP authorization still performs a search to read
+`ldapGroupMemberAttribute`, and therefore still requires `ldapAdminBindDn`.
+Direct bind removes the need for an admin account only when LDAP authorization
+is not used.
 
 ## Web page permissions
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/LdapConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/LdapConfiguration.java
@@ -16,14 +16,22 @@ package io.trino.gateway.ha.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.airlift.log.Logger;
+import org.apache.directory.api.ldap.model.exception.LdapInvalidDnException;
+import org.apache.directory.api.ldap.model.name.Dn;
+import org.apache.directory.api.ldap.model.name.Rdn;
 
 import java.io.IOException;
 import java.nio.file.Path;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class LdapConfiguration
 {
     private static final Logger log = Logger.get(LdapConfiguration.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
+    private static final String USER_PLACEHOLDER = "${USER}";
+    // Stand-in login name used to check that the pattern resolves to a parseable DN
+    private static final String VALIDATION_USER = "validation-user";
     private String ldapHost;
     private Integer ldapPort;
     private boolean useTls;
@@ -31,6 +39,7 @@ public class LdapConfiguration
     private String ldapAdminBindDn;
     private String ldapUserBaseDn;
     private String ldapUserSearch;
+    private String ldapUserDnPattern;
     private String ldapGroupMemberAttribute;
     private String ldapAdminPassword;
     private String ldapTrustStorePath;
@@ -48,6 +57,7 @@ public class LdapConfiguration
             String ldapAdminBindDn,
             String ldapUserBaseDn,
             String ldapUserSearch,
+            String ldapUserDnPattern,
             String ldapGroupMemberAttribute,
             String ldapAdminPassword,
             String ldapTrustStorePath,
@@ -64,6 +74,7 @@ public class LdapConfiguration
         this.ldapAdminBindDn = ldapAdminBindDn;
         this.ldapUserBaseDn = ldapUserBaseDn;
         this.ldapUserSearch = ldapUserSearch;
+        this.ldapUserDnPattern = ldapUserDnPattern;
         this.ldapGroupMemberAttribute = ldapGroupMemberAttribute;
         this.ldapAdminPassword = ldapAdminPassword;
         this.ldapTrustStorePath = ldapTrustStorePath;
@@ -86,7 +97,34 @@ public class LdapConfiguration
             log.error(e, "Error loading configuration file");
             throw new RuntimeException(e);
         }
+        configuration.validate();
         return configuration;
+    }
+
+    /**
+     * Rejects values that cannot work at authentication time, so that a bad configuration
+     * fails while the gateway starts instead of failing every login attempt.
+     */
+    public void validate()
+    {
+        if (ldapUserDnPattern == null || ldapUserDnPattern.isEmpty()) {
+            return;
+        }
+        checkArgument(
+                ldapUserDnPattern.contains(USER_PLACEHOLDER),
+                "ldapUserDnPattern must contain the %s placeholder, otherwise every login binds as the same DN: %s",
+                USER_PLACEHOLDER,
+                ldapUserDnPattern);
+        // Resolve the pattern the same way authentication does, so an unparseable template
+        // is caught here rather than when the first user tries to log in
+        String resolved = ldapUserDnPattern.replace(USER_PLACEHOLDER, Rdn.escapeValue(VALIDATION_USER));
+        try {
+            new Dn(resolved);
+        }
+        catch (LdapInvalidDnException e) {
+            throw new IllegalArgumentException(
+                    "ldapUserDnPattern does not resolve to a valid DN: %s".formatted(ldapUserDnPattern), e);
+        }
     }
 
     public String getLdapHost()
@@ -157,6 +195,22 @@ public class LdapConfiguration
     public void setLdapUserSearch(String ldapUserSearch)
     {
         this.ldapUserSearch = ldapUserSearch;
+    }
+
+    /**
+     * Template used to derive a user DN directly from the login name, for example
+     * {@code uid=${USER},ou=people,dc=example,dc=com}. When set, authentication binds
+     * as that DN without first searching for the user entry. When unset, the
+     * {@link #getLdapUserSearch() search} based flow is used instead.
+     */
+    public String getLdapUserDnPattern()
+    {
+        return ldapUserDnPattern;
+    }
+
+    public void setLdapUserDnPattern(String ldapUserDnPattern)
+    {
+        this.ldapUserDnPattern = ldapUserDnPattern;
     }
 
     public String getLdapGroupMemberAttribute()

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbLdapClient.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/security/LbLdapClient.java
@@ -18,7 +18,10 @@ import io.trino.gateway.ha.config.LdapConfiguration;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.exception.LdapInvalidDnException;
 import org.apache.directory.api.ldap.model.message.SearchScope;
+import org.apache.directory.api.ldap.model.name.Dn;
+import org.apache.directory.api.ldap.model.name.Rdn;
 import org.apache.directory.ldap.client.api.DefaultLdapConnectionFactory;
 import org.apache.directory.ldap.client.api.LdapClientTrustStoreManager;
 import org.apache.directory.ldap.client.api.LdapConnectionConfig;
@@ -77,14 +80,34 @@ public class LbLdapClient
 
     public boolean authenticate(String user, String password)
     {
+        // A bind with an empty password is an unauthenticated bind, which some directory
+        // servers answer with success. Reject it before it reaches the server.
+        if (password == null || password.isEmpty()) {
+            log.error("Rejected authentication attempt with an empty password");
+            return false;
+        }
+
         try {
-            String filter = config.getLdapUserSearch().replace("${USER}", user);
-            PasswordWarning passwordWarning =
-                    ldapConnectionTemplate.authenticate(
-                            config.getLdapUserBaseDn(),
-                            filter,
-                            SearchScope.SUBTREE,
-                            password.toCharArray());
+            PasswordWarning passwordWarning;
+            String userDnPattern = config.getLdapUserDnPattern();
+
+            if (userDnPattern != null && !userDnPattern.isEmpty()) {
+                // The user name is interpolated into a DN, so it needs DN escaping rather
+                // than search filter escaping. Without it a name such as "x,ou=admins"
+                // would change which DN gets bound.
+                Dn userDn = new Dn(userDnPattern.replace("${USER}", Rdn.escapeValue(user)));
+                passwordWarning =
+                        ldapConnectionTemplate.authenticate(userDn, password.toCharArray());
+            }
+            else {
+                String filter = config.getLdapUserSearch().replace("${USER}", user);
+                passwordWarning =
+                        ldapConnectionTemplate.authenticate(
+                                config.getLdapUserBaseDn(),
+                                filter,
+                                SearchScope.SUBTREE,
+                                password.toCharArray());
+            }
 
             if (passwordWarning != null) {
                 log.warn("password warning %s", passwordWarning);
@@ -93,6 +116,10 @@ public class LbLdapClient
         }
         catch (PasswordException exception) {
             log.error("Failed to authenticate %s", exception.getResultCode());
+            return false;
+        }
+        catch (LdapInvalidDnException exception) {
+            log.error(exception, "ldapUserDnPattern did not produce a valid DN");
             return false;
         }
         log.info("Authenticated successfully");

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/config/TestLdapConfiguration.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/config/TestLdapConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestLdapConfiguration
+{
+    @Test
+    void testValidateAcceptsUnsetUserDnPattern()
+    {
+        LdapConfiguration configuration = new LdapConfiguration();
+        configuration.validate();
+
+        configuration.setLdapUserDnPattern("");
+        configuration.validate();
+    }
+
+    @Test
+    void testValidateAcceptsUserDnPattern()
+    {
+        LdapConfiguration configuration = new LdapConfiguration();
+        configuration.setLdapUserDnPattern("uid=${USER},OU=accts,DC=dept1,DC=example,DC=com");
+        configuration.validate();
+    }
+
+    @Test
+    void testValidateRejectsUserDnPatternWithoutPlaceholder()
+    {
+        LdapConfiguration configuration = new LdapConfiguration();
+        configuration.setLdapUserDnPattern("uid=user1,OU=accts,DC=dept1,DC=example,DC=com");
+
+        assertThatThrownBy(configuration::validate)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must contain the ${USER} placeholder");
+    }
+
+    @Test
+    void testValidateRejectsUserDnPatternThatIsNotADn()
+    {
+        LdapConfiguration configuration = new LdapConfiguration();
+        configuration.setLdapUserDnPattern("not a dn ${USER}");
+
+        assertThatThrownBy(configuration::validate)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not resolve to a valid DN");
+    }
+
+    @Test
+    void testLoadValidatesUserDnPattern()
+    {
+        assertThatThrownBy(() -> LdapConfiguration.load("src/test/resources/auth/ldapTestConfigInvalidUserDnPattern.yml"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not resolve to a valid DN");
+
+        // The search based configuration keeps loading
+        LdapConfiguration configuration = LdapConfiguration.load("src/test/resources/auth/ldapTestConfig.yml");
+        assertThat(configuration.getLdapUserDnPattern()).isNull();
+        assertThat(configuration.getLdapUserSearch()).isEqualTo("(&(objectclass=user)(sAMAccountName=${USER}))");
+    }
+}

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbLdapClient.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/security/TestLbLdapClient.java
@@ -16,12 +16,14 @@ package io.trino.gateway.ha.security;
 import io.airlift.log.Logger;
 import io.trino.gateway.ha.config.LdapConfiguration;
 import org.apache.directory.api.ldap.model.message.SearchScope;
+import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.ldap.client.template.LdapConnectionTemplate;
 import org.apache.directory.ldap.client.template.exception.PasswordException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -111,6 +113,97 @@ final class TestLbLdapClient
                         password.toCharArray()))
                 .thenReturn(null))
                 .isInstanceOf(PasswordException.class);
+    }
+
+    @Test
+    void testAuthenticateWithUserDnPattern()
+            throws Exception
+    {
+        String user = "user1";
+        String password = "pass1";
+
+        Mockito
+                .when(ldapConfig.getLdapUserDnPattern())
+                .thenReturn("uid=${USER},OU=accts,DC=dept1,DC=example,DC=com");
+
+        Dn expectedDn = new Dn("uid=user1,OU=accts,DC=dept1,DC=example,DC=com");
+
+        Mockito
+                .when(ldapConnectionTemplate.authenticate(expectedDn, password.toCharArray()))
+                .thenReturn(null);
+
+        // Success case
+        assertThat(lbLdapClient.authenticate(user, password)).isTrue();
+
+        // The user entry is bound directly, without a search
+        Mockito
+                .verify(ldapConnectionTemplate, Mockito.never())
+                .authenticate(
+                        any(String.class),
+                        any(String.class),
+                        any(SearchScope.class),
+                        any(char[].class));
+
+        Mockito
+                .when(ldapConnectionTemplate.authenticate(expectedDn, password.toCharArray()))
+                .thenReturn(new TestLbLdapClient.DummyPasswordWarning());
+
+        // Warning case
+        assertThat(lbLdapClient.authenticate(user, password)).isTrue();
+
+        Mockito
+                .when(ldapConnectionTemplate.authenticate(expectedDn, password.toCharArray()))
+                .thenThrow(PasswordException.class);
+
+        // Failure case
+        assertThat(lbLdapClient.authenticate(user, password)).isFalse();
+    }
+
+    @Test
+    void testAuthenticateWithUserDnPatternEscapesUserName()
+            throws Exception
+    {
+        String user = "x,OU=admins";
+        String password = "pass1";
+
+        Mockito
+                .when(ldapConfig.getLdapUserDnPattern())
+                .thenReturn("uid=${USER},OU=accts,DC=dept1,DC=example,DC=com");
+
+        assertThat(lbLdapClient.authenticate(user, password)).isTrue();
+
+        ArgumentCaptor<Dn> boundDn = ArgumentCaptor.forClass(Dn.class);
+        Mockito
+                .verify(ldapConnectionTemplate)
+                .authenticate(boundDn.capture(), eq(password.toCharArray()));
+
+        // The comma in the user name stays inside the uid value instead of adding an RDN
+        assertThat(boundDn.getValue().size()).isEqualTo(5);
+        assertThat(boundDn.getValue().getName())
+                .isEqualTo("uid=x\\,OU\\=admins,OU=accts,DC=dept1,DC=example,DC=com");
+    }
+
+    @Test
+    void testAuthenticateRejectsEmptyPassword()
+    {
+        assertThat(lbLdapClient.authenticate("user1", "")).isFalse();
+        assertThat(lbLdapClient.authenticate("user1", null)).isFalse();
+
+        Mockito.verifyNoInteractions(ldapConnectionTemplate);
+    }
+
+    @Test
+    void testAuthenticateWithInvalidUserDnPattern()
+    {
+        // LdapConfiguration rejects such a pattern while loading, so this only covers the
+        // defensive handling for a configuration that was built without validation
+        Mockito
+                .when(ldapConfig.getLdapUserDnPattern())
+                .thenReturn("not a dn ${USER}");
+
+        assertThat(lbLdapClient.authenticate("user1", "pass1")).isFalse();
+
+        Mockito.verifyNoInteractions(ldapConnectionTemplate);
     }
 
     @Test

--- a/gateway-ha/src/test/resources/auth/ldapTestConfigInvalidUserDnPattern.yml
+++ b/gateway-ha/src/test/resources/auth/ldapTestConfigInvalidUserDnPattern.yml
@@ -1,0 +1,17 @@
+ldapHost: 'exmple.com'
+ldapPort: 389
+useTls: true
+#ldapPort: 636
+useSsl: false
+ldapAdminBindDn: 'CN=AD Query,OU=accts,DC=dept1,DC=example,DC=com'
+ldapUserBaseDn: 'OU=accts,DC=dept1,DC=example,DC=com'
+ldapUserSearch: '(&(objectclass=user)(sAMAccountName=${USER}))'
+ldapUserDnPattern: 'not a dn ${USER}'
+ldapGroupMemberAttribute: 'memberOf'
+ldapAdminPassword: 'passit'
+ldapTrustStorePath: '/etc/ssl/certs/java/cacerts'
+ldapTrustStorePassword: 'secret'
+poolMaxIdle: 8
+poolMaxTotal: 8
+poolMinIdle: 0
+poolTestOnBorrow: true


### PR DESCRIPTION
Add an optional ldapUserDnPattern to derive the user DN from the login name and bind as it directly, instead of binding as the admin account to search for the entry first. The search based flow stays the default.

<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://trinodb.github.io/trino-gateway/development/#contributing
and contact us on #trino-gateway-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Support direct LDAP bind without a user search
- Add an optional ldapUserDnPattern to derive the user DN from the login name and bind as it directly, instead of binding as the admin account to search for the entry first. The search based flow stays the default.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required, with the following suggested text:

```markdown
* Support direct LDAP bind without a user search
```
