### PR TITLE
Validate pull request commit messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,20 @@ env:
   MAVEN_FAST_INSTALL: "-B -V -T 1C -DskipTests -Dmaven.source.skip=true -Dair.check.skip-all"
 
 jobs:
+  check-commit-messages:
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: airlift/github-actions/check-commit-messages@1652e24519f5c7cec59d841070bf9beffadabdf9 # v1
+        with:
+          base_ref: ${{ github.event.pull_request.base.ref }}
+
   maven-build:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Add a `check-commit-messages` CI job that runs the airlift `check-commit-messages` action on pull requests, enforcing the project commit message conventions before merge.

Ported from the equivalent change in the core Trino repository: trinodb/trino@aee9e39624e4148f9193a96f7e249c8635bb123c

The Gateway CI workflow has no aggregate `pull-request-check` job, so only the standalone job was ported; the `needs`/status-gate hunks from the upstream diff do not apply here. The `if: github.event_name == 'pull_request'` guard is kept because this workflow also runs on push to `main`.

See https://github.com/trinodb/trino/pull/30489