### PR TITLE
Reword Dependabot commits to pass message check

### DIFF
--- a/.github/scripts/reword-dependabot-commit.py
+++ b/.github/scripts/reword-dependabot-commit.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+
+"""Rewrite the HEAD commit message to satisfy the project commit message policy.
+
+Dependabot generates its own commit messages and offers no configuration for
+subject length. Most of them already comply, but two cases do not:
+
+  * Long subjects, such as
+    "Bump @douyinfe/semi-illustrations from 2.99.3 to 2.100.0 in /webapp" (68).
+  * Long description lines, such as the "Bumps <artifact> from A to B." line
+    that Dependabot writes without a Markdown link when it cannot resolve a
+    repository URL for the package.
+
+Both fail the check-commit-messages job in ci.yml, which blocks the pull
+request. This script amends HEAD so those commits pass.
+
+The rules mirror airlift/github-actions/check-commit-messages: subjects are at
+most 60 characters and should be at most 50, and ordinary description lines are
+at most 79 characters and should wrap at 72.
+
+Subjects are shortened one step at a time, keeping the first result that fits,
+so no more detail is dropped than necessary:
+
+  Bump com.github.eirslett:frontend-maven-plugin from 2.0.0 to 2.0.1  (66)
+  Bump com.github.eirslett:frontend-maven-plugin to 2.0.1             (54)
+
+Nothing is lost in the process, because Dependabot repeats the full name and
+both versions in the description and in its updated-dependencies metadata.
+
+This amends HEAD in place and does not push, which keeps it runnable locally:
+
+    git log -1 --pretty=%B
+    .github/scripts/reword-dependabot-commit.py
+    git log -1 --pretty=%B
+
+Use --dry-run to print the result without amending. When GITHUB_OUTPUT is set,
+a "changed" output reports whether the message was rewritten.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import textwrap
+
+MAX_SUBJECT_LENGTH = 60
+WRAP_WIDTH = 72
+MAX_DESCRIPTION_LINE_LENGTH = 79
+
+URL_PATTERN = re.compile(r"(?:https?://|ssh://|git@|www\.)\S+")
+TRAILER_PATTERN = re.compile(
+    r"^(?:"
+    r"Signed-off-by|Co-authored-by|Assisted-by|Reviewed-by|Acked-by|"
+    r"Tested-by|Reported-by|Fixes|Refs|Relates-to|Change-Id"
+    r"):\s+\S.+$",
+    re.IGNORECASE,
+)
+
+# "Bump <name> from <old> to <new>[ <qualifier>]". The name and versions are
+# matched non-greedily so a trailing qualifier such as " in /webapp" stays in
+# the qualifier group rather than being absorbed into the new version.
+BUMP_PATTERN = re.compile(
+    r"^Bump (?P<name>\S+) from (?P<old>\S+) to (?P<new>\S+)(?P<qualifier>.*)$"
+)
+# Trailing scope Dependabot appends: " in /webapp", " in the airlift group",
+# " in the airlift group across 1 directory".
+QUALIFIER_PATTERN = re.compile(
+    r"\s+in\s+(?:/\S+|the\s+\S+\s+group)(?:\s+across\s+\d+\s+director(?:y|ies))?$"
+)
+ACROSS_PATTERN = re.compile(r"\s+across\s+\d+\s+director(?:y|ies)$")
+# A Maven coordinate, "group:artifact", where the group is a dotted namespace.
+COORDINATE_PATTERN = re.compile(r"^[\w.-]+\.[\w-]+:(?P<artifact>[\w.-]+)$")
+
+# Dependabot appends a YAML metadata block delimited by "---" and "...".
+# Rewrapping it would corrupt the YAML, so it is left untouched.
+METADATA_START = "---"
+METADATA_END = "..."
+
+
+def run_git(arguments: list[str], input_text: str | None = None) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        check=True,
+        input=input_text,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout
+
+
+def shorten_subject(subject: str) -> str:
+    """Return the longest form of the subject that fits the length limit."""
+    for candidate in subject_candidates(subject):
+        if len(candidate) <= MAX_SUBJECT_LENGTH:
+            return candidate
+
+    # Nothing fit, so fall back to a hard truncation on a word boundary. This
+    # is unreachable for the messages Dependabot generates today, but a silent
+    # CI failure later would be worse than a blunt subject.
+    return textwrap.shorten(subject, width=MAX_SUBJECT_LENGTH, placeholder="...")
+
+
+def subject_candidates(subject: str):
+    """Yield progressively shorter forms of a Dependabot subject."""
+    yield subject
+
+    match = BUMP_PATTERN.match(subject)
+    if match is None:
+        # Not a "Bump X from A to B" subject, for example
+        # "Bump io.airlift:airbase in the airlift group across 1 directory".
+        # Only the trailing qualifier can be trimmed.
+        yield ACROSS_PATTERN.sub("", subject)
+        yield QUALIFIER_PATTERN.sub("", subject)
+        return
+
+    name = match["name"]
+    new = match["new"]
+    qualifier = match["qualifier"]
+
+    # Drop the old version; the diff and the description still record it.
+    yield f"Bump {name} to {new}{qualifier}"
+    # Drop the directory or group scope.
+    yield f"Bump {name} to {new}{ACROSS_PATTERN.sub('', qualifier)}"
+    yield f"Bump {name} to {new}"
+
+    # Drop the group id from a Maven coordinate; the artifact id identifies the
+    # dependency well enough and the description keeps the full coordinate.
+    coordinate = COORDINATE_PATTERN.match(name)
+    if coordinate is not None:
+        yield f"Bump {coordinate['artifact']} to {new}"
+
+    # Last resort: name the dependency without a version, which is what
+    # Dependabot itself does for coordinates that are too long to fit.
+    yield f"Bump {name}"
+    if coordinate is not None:
+        yield f"Bump {coordinate['artifact']}"
+
+
+def is_wrapping_exempt(line: str, in_code_block: bool) -> bool:
+    """Mirror the checker's exemptions so only flagged lines are rewrapped."""
+    stripped = line.strip()
+
+    if in_code_block or not stripped:
+        return True
+    if stripped.startswith(">"):
+        return True
+    if TRAILER_PATTERN.fullmatch(stripped):
+        return True
+
+    # A line holding a URL or another token too long to break is exempt only
+    # when what remains around that token already fits.
+    tokens = stripped.split()
+    if any(URL_PATTERN.search(token) for token in tokens):
+        return is_wrapped_without_unwrappable_tokens(tokens)
+    if any(len(token) > MAX_DESCRIPTION_LINE_LENGTH for token in tokens):
+        return is_wrapped_without_unwrappable_tokens(tokens)
+
+    return False
+
+
+def is_wrapped_without_unwrappable_tokens(tokens: list[str]) -> bool:
+    wrappable = [
+        token
+        for token in tokens
+        if not URL_PATTERN.search(token)
+        and len(token) <= MAX_DESCRIPTION_LINE_LENGTH
+    ]
+    return len(" ".join(wrappable)) <= MAX_DESCRIPTION_LINE_LENGTH
+
+
+def rewrap_description(lines: list[str]) -> list[str]:
+    """Rewrap description lines that the checker would reject."""
+    rewrapped = []
+    in_code_block = False
+    in_metadata = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_code_block = not in_code_block
+            rewrapped.append(line)
+            continue
+
+        # Leave Dependabot's YAML metadata block alone.
+        if not in_metadata and stripped == METADATA_START:
+            in_metadata = True
+            rewrapped.append(line)
+            continue
+        if in_metadata:
+            if stripped == METADATA_END:
+                in_metadata = False
+            rewrapped.append(line)
+            continue
+
+        if len(line) <= MAX_DESCRIPTION_LINE_LENGTH or is_wrapping_exempt(
+            line, in_code_block
+        ):
+            rewrapped.append(line)
+            continue
+
+        rewrapped.extend(
+            textwrap.wrap(
+                line,
+                width=WRAP_WIDTH,
+                break_long_words=False,
+                break_on_hyphens=False,
+            )
+        )
+
+    return rewrapped
+
+
+def reword(message: str) -> str:
+    lines = message.splitlines()
+    if not lines:
+        return message
+
+    new_subject = shorten_subject(lines[0])
+    description = rewrap_description(lines[1:])
+
+    body = "\n".join(description).strip("\n")
+    if body:
+        return f"{new_subject}\n\n{body}\n"
+    return f"{new_subject}\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Reword HEAD to satisfy the commit message policy."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the reworded message without amending the commit.",
+    )
+    args = parser.parse_args()
+
+    original = run_git(["show", "-s", "--format=%B", "HEAD"]).strip("\n")
+    reworded = reword(original).strip("\n")
+
+    if reworded == original:
+        print("Commit message already complies, nothing to do.")
+        report_changed(False)
+        return 0
+
+    if args.dry_run:
+        print(reworded)
+        report_changed(True)
+        return 0
+
+    run_git(["commit", "--amend", "--allow-empty", "--file=-"], input_text=reworded)
+
+    print("Reworded commit message:")
+    print(f"  from: {original.splitlines()[0]}")
+    print(f"  to:   {reworded.splitlines()[0]}")
+    report_changed(True)
+    return 0
+
+
+def report_changed(changed: bool) -> None:
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if not github_output:
+        return
+    with open(github_output, "a", encoding="utf-8") as output:
+        output.write(f"changed={str(changed).lower()}\n")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/reword-dependabot.yml
+++ b/.github/workflows/reword-dependabot.yml
@@ -1,0 +1,68 @@
+name: Reword Dependabot commits
+
+# Dependabot writes its own commit messages and offers no setting for subject
+# length, so some of them fail the check-commit-messages job in ci.yml and
+# block the pull request. This workflow amends the commit message and force
+# pushes the result back onto the pull request branch.
+#
+# One-time setup: add a Dependabot secret named REWORD_PAT holding a token with
+# "Contents: read and write" on this repository, either a fine-grained personal
+# access token or a GitHub App installation token. It has to be a Dependabot
+# secret, under Settings, Secrets and variables, Dependabot, because workflows
+# triggered by Dependabot cannot read Actions secrets.
+#
+# A separate token is required even though the permissions key below grants
+# write access to the automatic GITHUB_TOKEN. Pushes made with that token
+# deliberately do not start new workflow runs, so CI would never run against
+# the amended commit and the pull request would wait for status checks that
+# never arrive.
+#
+# Until the secret exists the job logs a notice and stops, so pull requests are
+# never blocked by the missing configuration.
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  reword:
+    if: >-
+      github.repository == 'trinodb/trino-gateway' &&
+      github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for a push token
+        id: push-token
+        env:
+          REWORD_PAT: ${{ secrets.REWORD_PAT }}
+        run: |
+          if [ -n "$REWORD_PAT" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::REWORD_PAT is not configured, skipping rewording"
+          fi
+
+      - uses: actions/checkout@v7.0.1
+        if: steps.push-token.outputs.available == 'true'
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.REWORD_PAT }}
+          fetch-depth: 0
+
+      - name: Reword the commit message
+        id: reword
+        if: steps.push-token.outputs.available == 'true'
+        run: |
+          git config user.name "Trino bot"
+          git config user.email "trino-bot@trino.io"
+          .github/scripts/reword-dependabot-commit.py
+
+      - name: Push the reworded commit
+        if: steps.reword.outputs.changed == 'true'
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: git push --force-with-lease origin "HEAD:$HEAD_REF"

--- a/docs/development.md
+++ b/docs/development.md
@@ -60,6 +60,50 @@ contribution process for next steps.
 Want to help build Trino Gateway? Check out our [contributing
 documentation](https://github.com/trinodb/trino-gateway/blob/main/.github/CONTRIBUTING.md)
 
+## Commit messages
+
+Trino Gateway follows the commit message conventions shared across Trino and
+airlift, which are based on the [Chris Beams style for git commit
+messages](https://cbea.ms/git-commit/). The `check-commit-messages` job in the
+CI workflow enforces the conventions on every pull request with the
+[check-commit-messages action from
+airlift](https://github.com/airlift/github-actions/tree/main/check-commit-messages):
+
+* Subjects must use imperative mood, must not start with a lowercase letter or
+  end with a period, and must not exceed 60 characters. Aim for 50 characters.
+* Description lines must not exceed 79 characters, and should wrap at 72.
+  URLs, trailers, quoted text, fenced code blocks, and other long, unwrappable
+  content are exempt.
+* `Assisted-by` and `Co-authored-by` trailers must not credit AI models or
+  coding tools. Attribution of people remains allowed.
+
+### Dependabot commit messages
+
+Dependabot writes its own commit messages and offers no setting for subject
+length, so some dependency updates fail the check and block the pull request.
+The `Reword Dependabot commits` workflow amends the commit message on those
+pull requests and force pushes the result back onto the branch. Only messages
+that break the rules are changed. Shortened subjects lose no detail, because
+Dependabot repeats the full name and both versions in the description and in
+its updated-dependencies metadata.
+
+The workflow needs a token with `Contents: read and write` on the repository,
+either a fine-grained personal access token or a GitHub App installation
+token. Store it as a Dependabot secret named `REWORD_PAT` under Settings,
+Secrets and variables, Dependabot. Actions secrets do not work, because
+workflows triggered by Dependabot can only read Dependabot secrets. A separate
+token is required because pushes made with the automatic `GITHUB_TOKEN` do not
+start new workflow runs, and CI therefore never runs against the amended
+commit. Until the secret exists, the workflow logs a notice and stops without
+blocking any pull request.
+
+Use `--dry-run` to check the effect of the rewording on any commit without
+amending it:
+
+```shell
+.github/scripts/reword-dependabot-commit.py --dry-run
+```
+
 ## Maintainers
 
 The following Trino and Trino Gateway maintainers are involved in Trino


### PR DESCRIPTION
## Description

Dependabot writes its own commit messages and offers no setting for subject
length, so a share of its updates fail the `check-commit-messages` job added in
#1215 and block the pull request.

Measured against the last 269 Dependabot commits on `main`, using the checker
itself, 41 break the rules:

* 38 exceed the 60 character subject limit, mostly npm packages with a
  `in /webapp` suffix and long Maven coordinates.
* 3 carry a description line longer than 79 characters. These are the
  `Bumps <artifact> from A to B.` lines that Dependabot writes without a
  Markdown link when it cannot resolve a repository URL for the package.

This adds a script that amends the commit message, and a workflow that runs it
on Dependabot pull requests and force pushes the result.

Subjects are shortened one step at a time, keeping the first form that fits, so
no more detail is dropped than necessary:

```
Bump com.github.eirslett:frontend-maven-plugin from 2.0.0 to 2.0.1  (66)
Bump com.github.eirslett:frontend-maven-plugin to 2.0.1             (54)

Bump @douyinfe/semi-illustrations from 2.101.0 to 2.101.1 in /webapp  (68)
Bump @douyinfe/semi-illustrations to 2.101.1 in /webapp               (55)
```

Nothing is lost, because Dependabot repeats the full name and both versions in
the description and in its `updated-dependencies` metadata, which the script
leaves untouched so the YAML stays valid.

## Verification

Replaying the transform over all 269 Dependabot commits and rechecking each
result with the airlift checker:

```
commits=269  violating_before=41  violating_after=0  changed=41  non_idempotent=0
```

Only the 41 failing messages are rewritten. The other 228 are left byte for
byte identical, and running the script twice is a no-op.

## Configuration required before this takes effect

The workflow needs a token with `Contents: read and write` on this repository,
stored as a **Dependabot** secret named `REWORD_PAT`, either a fine-grained
personal access token or a GitHub App installation token. Actions secrets do
not work, because workflows triggered by Dependabot can only read Dependabot
secrets.

A separate token is needed even though the workflow grants `contents: write`,
because [pushes made with the automatic `GITHUB_TOKEN` do not start new
workflow runs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/trigger-a-workflow),
so CI would never run against the amended commit and the pull request would
wait for status checks that never arrive.

Until that secret exists the job logs a notice and stops, so merging this
changes nothing and blocks nothing.

## Notes for reviewers

* The script is runnable and inspectable locally with
  `.github/scripts/reword-dependabot-commit.py --dry-run`.
* It only amends `HEAD`. Dependabot creates single commit pull requests,
  including for grouped updates.
* If Dependabot recreates the branch, for example after `@dependabot rebase`,
  it regenerates the default message, the `synchronize` event runs the workflow
  again, and the message is reworded again.
