### PR TITLE
Create test containers from shared factories

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -441,6 +441,25 @@
     </dependencies>
 
     <build>
+        <testResources>
+            <!-- Filter test-versions.properties only. The other test resources contain
+                 placeholders that are substituted at test runtime, not by Maven. -->
+            <testResource>
+                <filtering>true</filtering>
+                <directory>src/test/resources</directory>
+                <includes>
+                    <include>test-versions.properties</include>
+                </includes>
+            </testResource>
+            <testResource>
+                <filtering>false</filtering>
+                <directory>src/test/resources</directory>
+                <excludes>
+                    <exclude>test-versions.properties</exclude>
+                </excludes>
+            </testResource>
+        </testResources>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/gateway-ha/src/test/java/io/trino/gateway/TrinoGatewayRunner.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/TrinoGatewayRunner.java
@@ -22,7 +22,9 @@ import org.testcontainers.trino.TrinoContainer;
 
 import java.util.List;
 
+import static io.trino.gateway.ha.util.TestcontainersUtils.createMySqlContainer;
 import static io.trino.gateway.ha.util.TestcontainersUtils.createPostgreSqlContainer;
+import static io.trino.gateway.ha.util.TestcontainersUtils.createTrinoContainer;
 import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
 public final class TrinoGatewayRunner
@@ -35,11 +37,11 @@ public final class TrinoGatewayRunner
         Logging.initialize();
         Logger log = Logger.get(TrinoGatewayRunner.class);
 
-        TrinoContainer trino1 = new TrinoContainer("trinodb/trino:466");
+        TrinoContainer trino1 = createTrinoContainer();
         trino1.setPortBindings(List.of("8081:8080"));
         trino1.withCopyFileToContainer(forClasspathResource("trino-config.properties"), "/etc/trino/config.properties");
         trino1.start();
-        TrinoContainer trino2 = new TrinoContainer("trinodb/trino:466");
+        TrinoContainer trino2 = createTrinoContainer();
         trino2.setPortBindings(List.of("8082:8080"));
         trino2.withCopyFileToContainer(forClasspathResource("trino-config.properties"), "/etc/trino/config.properties");
         trino2.start();
@@ -53,7 +55,7 @@ public final class TrinoGatewayRunner
         postgres.setPortBindings(List.of("5432:5432"));
         postgres.start();
 
-        MySQLContainer mysql = new MySQLContainer("mysql:5.7");
+        MySQLContainer mysql = createMySqlContainer();
         mysql.withUsername("root");
         mysql.withPassword("root123");
         mysql.withDatabaseName("trinogateway");

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestForwardedHeadersDisabled.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestForwardedHeadersDisabled.java
@@ -31,6 +31,7 @@ import org.testcontainers.trino.TrinoContainer;
 import java.io.File;
 
 import static io.trino.gateway.ha.util.TestcontainersUtils.createPostgreSqlContainer;
+import static io.trino.gateway.ha.util.TestcontainersUtils.createTrinoContainer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
@@ -47,7 +48,7 @@ final class TestForwardedHeadersDisabled
     void setup()
             throws Exception
     {
-        trino = new TrinoContainer("trinodb/trino");
+        trino = createTrinoContainer();
         trino.withCopyFileToContainer(forClasspathResource("trino-config.properties"), "/etc/trino/config.properties");
         trino.start();
 

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaMultipleBackend.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaMultipleBackend.java
@@ -51,6 +51,7 @@ import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.MediaType.JSON_UTF_8;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static io.trino.gateway.ha.util.TestcontainersUtils.createPostgreSqlContainer;
+import static io.trino.gateway.ha.util.TestcontainersUtils.createTrinoContainer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
@@ -84,10 +85,10 @@ final class TestGatewayHaMultipleBackend
     void setup()
             throws Exception
     {
-        adhocTrino = new TrinoContainer("trinodb/trino");
+        adhocTrino = createTrinoContainer();
         adhocTrino.withCopyFileToContainer(forClasspathResource("trino-config.properties"), "/etc/trino/config.properties");
         adhocTrino.start();
-        scheduledTrino = new TrinoContainer("trinodb/trino");
+        scheduledTrino = createTrinoContainer();
         scheduledTrino.withCopyFileToContainer(forClasspathResource("trino-config.properties"), "/etc/trino/config.properties");
         scheduledTrino.start();
         postgresql.start();

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaSingleBackend.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaSingleBackend.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.util.List;
 
 import static io.trino.gateway.ha.util.TestcontainersUtils.createPostgreSqlContainer;
+import static io.trino.gateway.ha.util.TestcontainersUtils.createTrinoContainer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
@@ -49,7 +50,7 @@ final class TestGatewayHaSingleBackend
     void setup()
             throws Exception
     {
-        trino = new TrinoContainer("trinodb/trino");
+        trino = createTrinoContainer();
         trino.withCopyFileToContainer(forClasspathResource("trino-config.properties"), "/etc/trino/config.properties");
         trino.start();
 

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaWithRoutingRulesSingleBackend.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/TestGatewayHaWithRoutingRulesSingleBackend.java
@@ -30,6 +30,7 @@ import org.testcontainers.trino.TrinoContainer;
 import java.io.File;
 
 import static io.trino.gateway.ha.util.TestcontainersUtils.createPostgreSqlContainer;
+import static io.trino.gateway.ha.util.TestcontainersUtils.createTrinoContainer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
@@ -45,7 +46,7 @@ final class TestGatewayHaWithRoutingRulesSingleBackend
     void setup()
             throws Exception
     {
-        trino = new TrinoContainer("trinodb/trino");
+        trino = createTrinoContainer();
         trino.withCopyFileToContainer(forClasspathResource("trino-config.properties"), "/etc/trino/config.properties");
         trino.start();
         postgresql.start();

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/clustermonitor/TestClusterStatsMonitor.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/clustermonitor/TestClusterStatsMonitor.java
@@ -42,13 +42,21 @@ import static org.testcontainers.utility.MountableFile.forClasspathResource;
 @TestInstance(PER_CLASS)
 final class TestClusterStatsMonitor
 {
+    // Deliberately pinned instead of using TestcontainersUtils.createTrinoContainer, because the
+    // cluster stats monitors do not work against Trino 477 and later. The JMX monitor breaks
+    // because Trino 477 removed the DiscoveryNodeManager MBean, see
+    // https://github.com/trinodb/trino-gateway/issues/773, the metrics monitor looks for a metric
+    // of the same name, see https://github.com/trinodb/trino-gateway/issues/1155, and the HTTP
+    // monitor fails as well. Switch to createTrinoContainer once the monitors are fixed.
+    // TODO https://github.com/trinodb/trino-gateway/issues/773 Update Trino version
+    private static final String PINNED_TRINO_IMAGE = "trinodb/trino:476";
+
     private TrinoContainer trino;
 
     @BeforeAll
     void setUp()
     {
-        // TODO https://github.com/trinodb/trino-gateway/issues/773 Update Trino version
-        trino = new TrinoContainer("trinodb/trino:476");
+        trino = new TrinoContainer(PINNED_TRINO_IMAGE);
         trino.withCopyFileToContainer(forClasspathResource("trino-config-with-rmi.properties"), "/etc/trino/config.properties");
         trino.withCopyFileToContainer(forClasspathResource("jvm-with-rmi.config"), "/etc/trino/jvm.config");
         trino.start();

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestDatabaseMigrationsMySql.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/persistence/TestDatabaseMigrationsMySql.java
@@ -14,14 +14,15 @@
 package io.trino.gateway.ha.persistence;
 
 import org.jdbi.v3.core.Handle;
-import org.testcontainers.mysql.MySQLContainer;
+
+import static io.trino.gateway.ha.util.TestcontainersUtils.createMySqlContainer;
 
 final class TestDatabaseMigrationsMySql
         extends BaseTestDatabaseMigrations
 {
     public TestDatabaseMigrationsMySql()
     {
-        super(new MySQLContainer("mysql:8.0.36"), "test");
+        super(createMySqlContainer(), "test");
     }
 
     @Override

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestExternalUrlQueryHistoryMySql.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestExternalUrlQueryHistoryMySql.java
@@ -13,13 +13,13 @@
  */
 package io.trino.gateway.ha.router;
 
-import org.testcontainers.mysql.MySQLContainer;
+import static io.trino.gateway.ha.util.TestcontainersUtils.createMySqlContainer;
 
 public class TestExternalUrlQueryHistoryMySql
         extends BaseExternalUrlQueryHistoryTest
 {
     public TestExternalUrlQueryHistoryMySql()
     {
-        super(new MySQLContainer("mysql:8.0.36"));
+        super(createMySqlContainer());
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryHistoryManagerMySql.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestQueryHistoryManagerMySql.java
@@ -14,7 +14,8 @@
 package io.trino.gateway.ha.router;
 
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.mysql.MySQLContainer;
+
+import static io.trino.gateway.ha.util.TestcontainersUtils.createMySqlContainer;
 
 public class TestQueryHistoryManagerMySql
         extends BaseTestQueryHistoryManager
@@ -22,7 +23,7 @@ public class TestQueryHistoryManagerMySql
     @Override
     protected final JdbcDatabaseContainer<?> startContainer()
     {
-        JdbcDatabaseContainer<?> container = new MySQLContainer("mysql:8.0.36");
+        JdbcDatabaseContainer<?> container = createMySqlContainer();
         container.start();
         return container;
     }

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingAPI.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingAPI.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.util.List;
 
 import static io.trino.gateway.ha.util.TestcontainersUtils.createPostgreSqlContainer;
+import static io.trino.gateway.ha.util.TestcontainersUtils.createTrinoContainer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
@@ -52,7 +53,7 @@ final class TestRoutingAPI
     void setup()
             throws Exception
     {
-        trino = new TrinoContainer("trinodb/trino");
+        trino = createTrinoContainer();
         trino.withCopyFileToContainer(forClasspathResource("trino-config.properties"), "/etc/trino/config.properties");
         trino.start();
 

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/util/TestcontainersUtils.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/util/TestcontainersUtils.java
@@ -16,23 +16,66 @@ package io.trino.gateway.ha.util;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
+import org.testcontainers.mysql.MySQLContainer;
 import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.trino.TrinoContainer;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.time.Duration;
+import java.util.Properties;
+
+import static com.google.common.base.Preconditions.checkState;
 
 public final class TestcontainersUtils
 {
+    private static final String VERSIONS_RESOURCE = "/test-versions.properties";
+    private static final String POSTGRESQL_IMAGE = "postgres:17";
+    private static final String MYSQL_IMAGE = "mysql:8.0.36";
+
     private TestcontainersUtils() {}
 
     public static PostgreSQLContainer createPostgreSqlContainer()
     {
         //noinspection resource
-        return new PostgreSQLContainer("postgres:17")
+        return new PostgreSQLContainer(POSTGRESQL_IMAGE)
                 .waitingFor(new WaitAllStrategy()
                         .withStrategy(Wait.forListeningPort())
                         .withStrategy(new LogMessageWaitStrategy()
                                 .withRegEx(".*database system is ready to accept connections.*\\s")
                                 .withTimes(2)
                                 .withStartupTimeout(Duration.ofMinutes(1))));
+    }
+
+    public static MySQLContainer createMySqlContainer()
+    {
+        //noinspection resource
+        return new MySQLContainer(MYSQL_IMAGE);
+    }
+
+    /**
+     * Creates a Trino container using the Trino version the project depends on, so that
+     * a Dependabot update of dep.trino.version also updates the tested Trino release.
+     */
+    public static TrinoContainer createTrinoContainer()
+    {
+        //noinspection resource
+        return new TrinoContainer("trinodb/trino:" + trinoVersion());
+    }
+
+    private static String trinoVersion()
+    {
+        Properties properties = new Properties();
+        try (InputStream input = TestcontainersUtils.class.getResourceAsStream(VERSIONS_RESOURCE)) {
+            checkState(input != null, "Resource %s not found. It is filtered by Maven and only exists in a Maven build.", VERSIONS_RESOURCE);
+            properties.load(input);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        String version = properties.getProperty("trino.version");
+        checkState(version != null && !version.isBlank(), "Property trino.version not set in %s", VERSIONS_RESOURCE);
+        return version;
     }
 }

--- a/gateway-ha/src/test/java/io/trino/gateway/proxyserver/TestProxyRequestHandlerQueryHistoryDisabled.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/proxyserver/TestProxyRequestHandlerQueryHistoryDisabled.java
@@ -34,6 +34,7 @@ import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterrup
 import static io.trino.gateway.ha.HaGatewayTestUtils.buildGatewayConfig;
 import static io.trino.gateway.ha.HaGatewayTestUtils.setUpBackend;
 import static io.trino.gateway.ha.util.TestcontainersUtils.createPostgreSqlContainer;
+import static io.trino.gateway.ha.util.TestcontainersUtils.createTrinoContainer;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -50,7 +51,7 @@ final class TestProxyRequestHandlerQueryHistoryDisabled
     TestProxyRequestHandlerQueryHistoryDisabled()
             throws Exception
     {
-        trino = new TrinoContainer("trinodb/trino:476");
+        trino = createTrinoContainer();
         trino.withCopyFileToContainer(forClasspathResource("trino-config.properties"), "/etc/trino/config.properties");
         trino.start();
 

--- a/gateway-ha/src/test/resources/test-versions.properties
+++ b/gateway-ha/src/test/resources/test-versions.properties
@@ -1,0 +1,3 @@
+# Filtered by Maven so that tests use the same Trino version as the project dependencies.
+# Update dep.trino.version in gateway-ha/pom.xml, not this file.
+trino.version=${dep.trino.version}


### PR DESCRIPTION
## Description

The Trino and MySQL container images were hardcoded at every use in the tests,
and had drifted apart:

| Image | Uses |
|---|---|
| `trinodb/trino` unpinned | 6 |
| `trinodb/trino:476` | 2 |
| `trinodb/trino:466` | 2 |
| `mysql:8.0.36` | 3 |
| `mysql:5.7` | 1 |

The six unpinned uses resolved to whatever was last published as `latest`, so
those tests were not reproducible and silently changed behavior whenever a new
Trino release appeared. Meanwhile the project depends on Trino 483 through
`dep.trino.version`, so most tests exercised Trino Gateway against a Trino release
it does not build against.

Container creation now goes through factory methods in `TestcontainersUtils`,
alongside the existing `createPostgreSqlContainer`. The Trino version is read
from `dep.trino.version` through a Maven-filtered properties file, so a
Dependabot update of the Trino dependency also moves the Trino release under
test, with no second place to remember to update.

Each factory takes its image from a single named source, so all three are
consistent and there is one place to change per image:

| Factory | Image source |
|---|---|
| `createPostgreSqlContainer()` | `POSTGRESQL_IMAGE` constant |
| `createMySqlContainer()` | `MYSQL_IMAGE` constant |
| `createTrinoContainer()` | `dep.trino.version` through `test-versions.properties` |

The PostgreSQL and MySQL versions stay as constants rather than moving into the
filtered properties file, because neither has a corresponding Maven property to
track. Only the Trino version does.

Maven test resource filtering is deliberately scoped to
`test-versions.properties` alone. The other test resources are configuration
templates containing `${...}` placeholders that the tests substitute themselves
at runtime, and filtering those would let Maven consume the placeholders first.

`TestClusterStatsMonitor` keeps its existing pin to `trinodb/trino:476`, because
the cluster stats monitors do not work against Trino 477 and later. The reason
and the tracking issues are now recorded next to the pin, rather than the pin
sitting there unexplained.

## Additional context and related issues

Moving `TestClusterStatsMonitor` to 483 fails four tests, which is how the pin
turned out to be load-bearing:

```
testHttpMonitor     expected: HEALTHY  but was: UNKNOWN
testJmxMonitor      expected: HEALTHY  but was: UNHEALTHY
testMetricsMonitor
testMetricsRanges
```

Those failures are three separate defects, all pre-existing and none introduced
here:

- #773 — Trino 477 removed the `trino.metadata:name=DiscoveryNodeManager`
  MBean, which `ClusterStatsJmxMonitor` depends on
- #1155 — the metrics monitor looks for
  `trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount`, gone for the same
  reason
- #1219 — Trino 483 made the preview Web UI the default and deactivated the
  legacy UI, so the UI API monitor can no longer authenticate

Keeping the pin in this pull request is intentional, so that the change stays a
test infrastructure cleanup. Fixing the monitors is separate work.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
