### PR TITLE
Support current Trino in cluster stats monitors

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -463,7 +463,7 @@ the only metric populated is:
 ```yaml
 monitor:
     metricMinimumValues:
-        trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount: 1
+        trino_node_name_CoordinatorNodeManager_ActiveNodeCount: 1
 ```
 
 This requires the cluster to have at least one active worker node in order to be considered
@@ -474,10 +474,27 @@ Collections, set
 ```yaml
 monitor:
     metricMinimumValues:
-        trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount: 10
+        trino_node_name_CoordinatorNodeManager_ActiveNodeCount: 10
     metricMaximumValues:
         io_airlift_stats_name_GcMonitor_MajorGc_FiveMinutes_count: 2
 ```
+
+Trino 477 renamed the active node count metric from
+`trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount` to
+`trino_node_name_CoordinatorNodeManager_ActiveNodeCount`. The default uses the
+current name. If any backend cluster runs Trino 476 or earlier, configure the
+previous name explicitly:
+
+```yaml
+monitor:
+    metricMinimumValues:
+        trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount: 1
+```
+
+Because this configuration applies to every backend, a Trino Gateway fronting a
+mix of Trino releases across that boundary cannot satisfy both names at once.
+See [Trino version compatibility](#trino-version-compatibility) for the full
+picture.
 
 #### JDBC
 
@@ -509,6 +526,12 @@ Other timeout parameters are not applicable to the JDBC connection.
 The monitor type `JMX` can be used as an alternative to collect cluster information, 
 which is required for the `QueryCountBasedRouterProvider`. This uses the `v1/jmx/mbean` 
 endpoint on Trino clusters.
+
+> **This monitor does not work with Trino 480 and later.** The `v1/jmx/mbean`
+> endpoint it depends on is not present in those releases, and it is not part of
+> the documented [Trino JMX interface](https://trino.io/docs/current/admin/jmx.html),
+> which covers RMI access only. Use `METRICS`, `JDBC`, or `INFO_API` instead.
+> See [Trino version compatibility](#trino-version-compatibility).
 
 To enable this:
 
@@ -561,6 +584,65 @@ supported for legacy reasons and may be deprecated in the future. It is only
 supported for backend clusters with `web-ui.authentication.type=FORM`. Set
 a username and password using `backendState` as with the `JDBC` option.
 
+Trino 483 replaced the previous Web UI with the preview Web UI, which serves its
+login resource at a different location and expects a JSON request body. The
+`uiLoginType` setting selects which one to use:
+
+```yaml
+backendState:
+  username: "user"
+  password: "password"
+  uiLoginType: "AUTH_API"
+```
+
+| `uiLoginType` | Login resource | Backend Trino version |
+|---|---|---|
+| `AUTH_API`, the default | `/ui/auth/login` | 483 and later |
+| `FORM` | `/ui/login` | 482 and earlier |
+
+Because this setting applies to all backends, a Trino Gateway fronting clusters
+on both sides of Trino 483 cannot use this monitor for all of them. Use
+`INFO_API`, `JDBC`, or `METRICS` in that case.
+
+Do not point this monitor at `/ui/legacy/login`, which also works on Trino 483.
+The previous Web UI is scheduled for removal, and that resource goes with it,
+whereas `/ui/auth/login` and the `/ui/api` endpoints this monitor reads belong to
+the current Web UI.
+
 #### NOOP
 
 This option disables health checks.
+
+### Trino version compatibility
+
+The monitor types depend on different Trino interfaces, and some of those
+interfaces changed in recent Trino releases. The following table summarizes
+which monitor types work against which Trino versions.
+
+| Monitor type | Trino 476 and earlier | 477 to 479 | 480 to 482 | 483 and later |
+|---|---|---|---|---|
+| `INFO_API` | Yes | Yes | Yes | Yes |
+| `JDBC` | Yes | Yes | Yes | Yes |
+| `METRICS` | Yes, with the previous metric name configured | Yes | Yes | Yes |
+| `JMX` | Yes | Yes | No | No |
+| `UI_API` | Yes, with `uiLoginType: FORM` | Yes, with `uiLoginType: FORM` | Yes, with `uiLoginType: FORM` | Yes |
+| `NOOP` | Not applicable | Not applicable | Not applicable | Not applicable |
+
+The causes are:
+
+- Trino 477 renamed the active node count metric used by the `METRICS` monitor,
+  so the default only matches Trino 477 and later. Configure
+  `metricMinimumValues` explicitly for older clusters.
+- Trino 480 removed the `v1/jmx/mbean` endpoint that the `JMX` monitor depends
+  on. That endpoint was never part of the documented Trino JMX interface.
+- Trino 483 replaced the previous Web UI with the preview Web UI, which changed
+  the login resource that the `UI_API` monitor uses. Select the matching one
+  with `uiLoginType`.
+
+`INFO_API` and `JDBC` use stable, documented Trino interfaces and are the safest
+choices for a Trino Gateway fronting clusters on a range of Trino versions. Note
+that the `QueryCountBasedRouter` requires either `METRICS` or `JDBC`.
+
+Monitor configuration applies to all backends, so a deployment fronting clusters
+on both sides of one of these boundaries cannot currently configure a single
+monitor that satisfies all of them.

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterStatsHttpMonitor.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/clustermonitor/ClusterStatsHttpMonitor.java
@@ -19,9 +19,11 @@ import io.airlift.http.client.HttpStatus;
 import io.airlift.log.Logger;
 import io.trino.gateway.ha.config.BackendStateConfiguration;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
+import io.trino.gateway.ha.config.UiLoginType;
 import okhttp3.Call;
 import okhttp3.FormBody;
 import okhttp3.HttpUrl;
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -37,7 +39,6 @@ import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 import static io.airlift.http.client.HttpStatus.fromStatusCode;
 import static io.trino.gateway.ha.handler.HttpUtils.UI_API_QUEUED_LIST_PATH;
 import static io.trino.gateway.ha.handler.HttpUtils.UI_API_STATS_PATH;
-import static io.trino.gateway.ha.handler.HttpUtils.UI_LOGIN_PATH;
 import static java.util.Objects.requireNonNull;
 
 public class ClusterStatsHttpMonitor
@@ -46,16 +47,21 @@ public class ClusterStatsHttpMonitor
     private static final Logger log = Logger.get(ClusterStatsHttpMonitor.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String SESSION_USER = "sessionUser";
+    private static final String AUTH_API_LOGIN_PATH = "/ui/auth/login";
+    private static final String FORM_LOGIN_PATH = "/ui/login";
+    private static final MediaType JSON_MEDIA_TYPE = MediaType.parse("application/json");
 
     private final String username;
     private final String password;
     private final boolean xForwardedProtoHeader;
+    private final UiLoginType uiLoginType;
 
     public ClusterStatsHttpMonitor(BackendStateConfiguration backendStateConfiguration)
     {
         username = backendStateConfiguration.getUsername();
         password = backendStateConfiguration.getPassword();
         xForwardedProtoHeader = backendStateConfiguration.getXForwardedProtoHeader();
+        uiLoginType = backendStateConfiguration.getUiLoginType();
     }
 
     @Override
@@ -105,17 +111,38 @@ public class ClusterStatsHttpMonitor
         return clusterStats.userQueuedCount(clusterUserStats).build();
     }
 
+    private String loginPath()
+    {
+        return switch (uiLoginType) {
+            case AUTH_API -> AUTH_API_LOGIN_PATH;
+            case FORM -> FORM_LOGIN_PATH;
+        };
+    }
+
+    private RequestBody loginBody()
+    {
+        return switch (uiLoginType) {
+            // The login resource of the Web UI in Trino 483 and later rejects a form encoded body
+            case AUTH_API -> RequestBody.create(
+                    OBJECT_MAPPER.createObjectNode()
+                            .put("username", username)
+                            .put("password", password)
+                            .toString(),
+                    JSON_MEDIA_TYPE);
+            case FORM -> new FormBody.Builder()
+                    .add("username", username)
+                    .add("password", password)
+                    .build();
+        };
+    }
+
     private OkHttpClient acquireClientWithCookie(String loginUrl)
     {
         UiApiCookieJar cookieJar = new UiApiCookieJar();
         OkHttpClient client = new OkHttpClient.Builder().cookieJar(cookieJar).build();
-        RequestBody formBody = new FormBody.Builder()
-                .add("username", username)
-                .add("password", password)
-                .build();
         Request loginRequest = new Request.Builder()
                 .url(HttpUrl.parse(loginUrl))
-                .post(formBody)
+                .post(loginBody())
                 .build();
 
         Call call = client.newCall(loginRequest);
@@ -132,7 +159,7 @@ public class ClusterStatsHttpMonitor
 
     private String queryCluster(ProxyBackendConfiguration backend, String path)
     {
-        String loginUrl = backend.getProxyTo() + UI_LOGIN_PATH;
+        String loginUrl = backend.getProxyTo() + loginPath();
         OkHttpClient client = acquireClientWithCookie(loginUrl);
         if (client == null) {
             log.error("Client received is null");

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/BackendStateConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/BackendStateConfiguration.java
@@ -20,7 +20,21 @@ public class BackendStateConfiguration
     private Boolean ssl = false;
     private boolean xForwardedProtoHeader;
 
+    // Defaults to the login resource of the Web UI in Trino 483 and later. Backend clusters
+    // running Trino 482 or earlier need UiLoginType.FORM configured.
+    private UiLoginType uiLoginType = UiLoginType.AUTH_API;
+
     public BackendStateConfiguration() {}
+
+    public UiLoginType getUiLoginType()
+    {
+        return this.uiLoginType;
+    }
+
+    public void setUiLoginType(UiLoginType uiLoginType)
+    {
+        this.uiLoginType = uiLoginType;
+    }
 
     public String getUsername()
     {

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/MonitorConfiguration.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/MonitorConfiguration.java
@@ -39,8 +39,10 @@ public class MonitorConfiguration
 
     private String queuedQueriesMetricName = "trino_execution_name_QueryManager_QueuedQueries";
 
-    // Require 1 node for health by default. This configuration only applies to the ClusterStatsMetricsMonitor
-    private Map<String, Float> metricMinimumValues = ImmutableMap.of("trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount", 1f);
+    // Require 1 node for health by default. This configuration only applies to the ClusterStatsMetricsMonitor.
+    // Trino 477 renamed this metric from trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount. Clusters
+    // running Trino 476 or earlier need the previous name configured explicitly.
+    private Map<String, Float> metricMinimumValues = ImmutableMap.of("trino_node_name_CoordinatorNodeManager_ActiveNodeCount", 1f);
 
     private Map<String, Float> metricMaximumValues = ImmutableMap.of();
 

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/config/UiLoginType.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/config/UiLoginType.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.config;
+
+/**
+ * How the UI_API cluster stats monitor authenticates against a backend Trino cluster.
+ * Trino 483 replaced the previous Web UI with the preview Web UI, which uses a different
+ * login resource and expects a JSON request body.
+ */
+public enum UiLoginType
+{
+    /**
+     * Post a JSON body to {@code /ui/auth/login}, the login resource of the Web UI in
+     * Trino 483 and later.
+     */
+    AUTH_API,
+    /**
+     * Post a form encoded body to {@code /ui/login}, the login resource of the Web UI in
+     * Trino 482 and earlier.
+     */
+    FORM,
+}

--- a/gateway-ha/src/main/java/io/trino/gateway/ha/handler/HttpUtils.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/handler/HttpUtils.java
@@ -21,7 +21,6 @@ public class HttpUtils
     public static final String V1_INFO_PATH = "/v1/info";
     public static final String V1_NODE_PATH = "/v1/node";
     public static final String UI_API_STATS_PATH = "/ui/api/stats";
-    public static final String UI_LOGIN_PATH = "/ui/login";
     public static final String UI_API_QUEUED_LIST_PATH = "/ui/api/query?state=QUEUED";
     public static final String TRINO_UI_PATH = "/ui";
     public static final String OAUTH_PATH = "/oauth2";

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/clustermonitor/TestClusterStatsMonitor.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/clustermonitor/TestClusterStatsMonitor.java
@@ -25,6 +25,7 @@ import io.airlift.units.Duration;
 import io.trino.gateway.ha.config.BackendStateConfiguration;
 import io.trino.gateway.ha.config.MonitorConfiguration;
 import io.trino.gateway.ha.config.ProxyBackendConfiguration;
+import io.trino.gateway.ha.config.UiLoginType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,11 @@ import static org.testcontainers.utility.MountableFile.forClasspathResource;
 @TestInstance(PER_CLASS)
 final class TestClusterStatsMonitor
 {
+    // The active node count metric name used by Trino 476 and earlier, which is the version the
+    // container below is pinned to. Trino 477 renamed it, and the renamed metric is the default in
+    // MonitorConfiguration.
+    private static final String LEGACY_ACTIVE_NODE_COUNT_METRIC = "trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount";
+
     private TrinoContainer trino;
 
     @BeforeAll
@@ -63,7 +69,12 @@ final class TestClusterStatsMonitor
     @Test
     void testHttpMonitor()
     {
-        testClusterStatsMonitor(ClusterStatsHttpMonitor::new);
+        // The container runs Trino 476, which serves the Web UI login resource at the location used
+        // before Trino 483, so the default UiLoginType.AUTH_API does not apply here
+        testClusterStatsMonitor(backendStateConfiguration -> {
+            backendStateConfiguration.setUiLoginType(UiLoginType.FORM);
+            return new ClusterStatsHttpMonitor(backendStateConfiguration);
+        });
     }
 
     @Test
@@ -156,10 +167,15 @@ final class TestClusterStatsMonitor
     @Test
     void testMetricsMonitor()
     {
+        // The container runs Trino 476, which still uses the metric name from before Trino 477, so
+        // the default value of metricMinimumValues does not apply here. Once the container moves to
+        // a current Trino release, this override can go and the default is exercised instead.
+        MonitorConfiguration monitorConfiguration = new MonitorConfiguration();
+        monitorConfiguration.setMetricMinimumValues(ImmutableMap.of(LEGACY_ACTIVE_NODE_COUNT_METRIC, 1f));
         testClusterStatsMonitor(backendStateConfiguration -> new ClusterStatsMetricsMonitor(
                 new JettyHttpClient(new HttpClientConfig()),
                 backendStateConfiguration,
-                new MonitorConfiguration()));
+                monitorConfiguration));
     }
 
     private void testClusterStatsMonitor(Function<BackendStateConfiguration, ClusterStatsMonitor> monitorFactory)
@@ -181,16 +197,16 @@ final class TestClusterStatsMonitor
     void testMetricsRanges()
     {
         // Active node count should always be 1.0 for this test
-        Map<String, Float> metricMinimumsFail = ImmutableMap.of("trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount", 100f);
+        Map<String, Float> metricMinimumsFail = ImmutableMap.of(LEGACY_ACTIVE_NODE_COUNT_METRIC, 100f);
         testMetricsWithRange(metricMinimumsFail, ImmutableMap.of(), TrinoStatus.UNHEALTHY);
 
-        Map<String, Float> metricMaximumsFail = ImmutableMap.of("trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount", 0.5f);
+        Map<String, Float> metricMaximumsFail = ImmutableMap.of(LEGACY_ACTIVE_NODE_COUNT_METRIC, 0.5f);
         testMetricsWithRange(ImmutableMap.of(), metricMaximumsFail, TrinoStatus.UNHEALTHY);
 
-        Map<String, Float> metricMinimumsPass = ImmutableMap.of("trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount", 0.5f);
+        Map<String, Float> metricMinimumsPass = ImmutableMap.of(LEGACY_ACTIVE_NODE_COUNT_METRIC, 0.5f);
         testMetricsWithRange(metricMinimumsPass, ImmutableMap.of(), TrinoStatus.HEALTHY);
 
-        Map<String, Float> metricMaximumsPass = ImmutableMap.of("trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount", 100f);
+        Map<String, Float> metricMaximumsPass = ImmutableMap.of(LEGACY_ACTIVE_NODE_COUNT_METRIC, 100f);
         testMetricsWithRange(ImmutableMap.of(), metricMaximumsPass, TrinoStatus.HEALTHY);
     }
 


### PR DESCRIPTION
## Description

Three of the six cluster stats monitor types do not work against a current
Trino release. This fixes two of them and documents the third, which cannot be
fixed from the Trino Gateway side.

**`METRICS`** — Trino 477 renamed the active node count metric from
`trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount` to
`trino_node_name_CoordinatorNodeManager_ActiveNodeCount`. That metric is the
default entry of `metricMinimumValues`, so the monitor reports every cluster on
Trino 477 or later as unhealthy with a missing required key. The default now
uses the current name. Reported in #1155.

**`UI_API`** — Trino 483 replaced the previous Web UI with the preview Web UI.
The form login the monitor posts to is no longer served at `/ui/login`, which
now answers `GET` but rejects `POST` with `405`. Without a session cookie every
subsequent request returns `401` and the monitor reports `UNKNOWN`. Reported in
#1219.

The preview Web UI logs in through `/ui/auth/login` with a JSON body, so this is
not only a path change, and a new `uiLoginType` setting on `backendState`
selects between the two:

| `uiLoginType` | Login resource | Body | Backend Trino version |
|---|---|---|---|
| `AUTH_API`, the default | `/ui/auth/login` | JSON | 483 and later |
| `FORM` | `/ui/login` | form encoded | 482 and earlier |

**`JMX`** — not fixed, and not fixable here. See the following section.

## Additional context and related issues

### Verified behavior

Measured directly against stock Trino containers rather than inferred from
release notes:

| Trino | Active node count metric | `v1/jmx/mbean` | Web UI login that authenticates |
|---|---|---|---|
| 476 | `trino_metadata_name_DiscoveryNodeManager_ActiveNodeCount` | 200 | `/ui/login`, form |
| 477 | `trino_node_name_CoordinatorNodeManager_ActiveNodeCount` | 200 | `/ui/login`, form |
| 478, 479 | `trino_node_name_...` | 200 | `/ui/login`, form |
| 480, 482 | `trino_node_name_...` | **404** | `/ui/login`, form |
| 483 | `trino_node_name_...` | 404 | **`/ui/auth/login`, JSON** |

None of these changes appear in the Trino release notes for 477 through 483,
which contain no mention of JMX at all.

### Why not `/ui/legacy/login`

On Trino 483 the previous Web UI moved to `/ui/legacy`, and `/ui/legacy/login`
still accepts a form post and issues a working cookie. Using it would be a
smaller change, and it is deliberately avoided. The previous Web UI is scheduled
for removal, and that resource goes with it, so the monitor would break a second
time. `/ui/auth/login` and the `/ui/api` endpoints the monitor reads are the
preview Web UI's own, confirmed from the endpoints its front end calls, so they
survive that removal.

### The `JMX` monitor

`ClusterStatsJmxMonitor` reads `v1/jmx/mbean`, which is not served from Trino
480 onwards. It is also not part of the
[documented Trino JMX interface](https://trino.io/docs/current/admin/jmx.html),
which covers RMI access only, so there is no supported replacement to point the
monitor at. This pull request documents the limitation and leaves #773 open.
Removing or reimplementing that monitor is a separate discussion.

### Configuration granularity

`uiLoginType` and `metricMinimumValues` are both gateway wide, so a Trino
Gateway fronting clusters on both sides of one of these version boundaries
cannot satisfy all of them with one setting. That is a known limitation of this
approach, called out in the documentation, with `INFO_API` and `JDBC` as the
recommended alternatives for mixed deployments.

Two better solutions, both larger and deliberately out of scope here:

1. **Per backend configuration.** Backends are configured in the database rather
   than the configuration file, so this needs a schema change, but it models a
   fleet mid-upgrade correctly.
2. **Detect per backend.** Probe the cluster once and cache which interface it
   offers, so a mixed fleet needs no configuration at all. `/ui/auth/info` looks
   like a usable signal. The cost is detection logic and a less obvious failure
   mode when detection is wrong.

The underlying problem is that both monitors read interfaces that are not
covered by any compatibility guarantee: the Web UI is explicitly not an API, and
JMX MBean names are internals. `INFO_API` and `JDBC` keep working across all
versions tested precisely because they use stable, documented interfaces.

### Test coverage gap

`TestClusterStatsMonitor` is pinned to `trinodb/trino:476` because the JMX
monitor cannot work on anything newer, so the tests exercise `uiLoginType: FORM`
and the previous metric name. **The new defaults are therefore not covered by
CI.** Both were verified by hand against Trino 483:

```
$ curl -s -c c.txt -o /dev/null -w "%{http_code}\n" -X POST \
    -H "Content-Type: application/json" -d '{"username":"probe","password":""}' \
    http://localhost:8080/ui/auth/login
204
$ curl -s -b c.txt -o /dev/null -w "%{http_code}\n" http://localhost:8080/ui/api/stats
200
```

Closing that gap means running the non-JMX monitor tests against a current Trino
release, which needs the test container split by monitor type.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required, with the following suggested text:

```markdown
* {Breaking} Fix the `METRICS` cluster stats monitor for Trino 477 and later, where the
  active node count metric was renamed. Backends running Trino 476 or earlier
  require the previous metric name in `metricMinimumValues`. ({issue}`1155`)
* {Breaking} Fix the `UI_API` cluster stats monitor for Trino 483 and later, where the Web
  UI login resource changed. Backends running Trino 482 or earlier now require
  `uiLoginType` set to `FORM`. ({issue}`1219`)
```
