### PR TITLE
Add X-Trino-User header to backend search probe

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
@@ -213,6 +213,7 @@ public abstract class BaseRoutingManager
                                     conn.setConnectTimeout((int) TimeUnit.SECONDS.toMillis(5));
                                     conn.setReadTimeout((int) TimeUnit.SECONDS.toMillis(5));
                                     conn.setRequestMethod(HttpMethod.HEAD);
+                                    conn.setRequestProperty("X-Trino-User", "trino-gateway");
                                     return conn.getResponseCode();
                                 });
                 responseCodes.put(backend.getProxyTo(), call);


### PR DESCRIPTION
  ---                                                                                                                                                                                                                                                                         
  Routing group follow-up requests fail in multi-pod trino-gateway deployments
                                                                                                                                                                                                                                                                              
  We're running trino-gateway v18 with 6 replicas behind an NLB, using `QueryCountBasedRouterProvider + MVEL routing rules `to route queries to specific clusters via custom routing groups (e.g. RG-<clusterName> for multi-cluster DDL fan-out).
                                                                                                                                                                                                                                                                              
  The problem:
                                                                                                                                                                                                                                                                              
  When a JDBC client sends POST /v1/statement, trino-gateway routes it correctly and caches queryId → backend in the pod's in-memory Caffeine cache. But the follow-up polling requests (GET /v1/statement/executing/<queryId>/...) may hit a different pod via the NLB — that pod has no cache entry for the queryId.
                                                                                                                                                                                                                                                                              
  The fallback path in BaseRoutingManager:                     
  1. Check in-memory cache → MISS (different pod)
  2. Check queryHistoryManager.getBackendForQueryId() → returns null if queryHistoryEnabled: false                                                                                                                                                                            
  3. searchAllBackendForQuery() → sends HEAD /v1/query/<queryId> without X-Trino-User header      
  4. Trino returns 401 because QueryResource is annotated with @ResourceSecurity(AUTHENTICATED_USER)                                                                                                                                                                          
  5. All backends return 401 → no backend found → IllegalStateException: Number of active backends found zero     
  
  ---                                                                                                                                                                                                                          
  ## Root Cause                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                              
  Trino's `QueryResource` class is annotated with `@ResourceSecurity(AUTHENTICATED_USER)`:                                                                                                                                                                                    
                                                               
  ```java                                                                                                                                                                                                                                                                     
  @Path("/v1/query")                                           
  @ResourceSecurity(AUTHENTICATED_USER)
  public class QueryResource { ... }                                                                                                                                                                                                                                                                              
  This requires a valid user identity on every request to /v1/query/*, even when                                                                                                                                                                                              
  no explicit authentication type is configured. Without X-Trino-User, Trino                                                                                                                                                                                                  
  returns 401. Since all backends return 401 (not 200), the fallback never                                                                                                                                                                                                    
  identifies the correct backend.  
   ```                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                              
  When This Matters                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                              
  This code path is reached when:                                                                                                                                                                                                                                             
  1. In-memory queryIdBackendCache misses (multi-pod deployments where the load
  balancer routes a follow-up request to a different gateway pod)                                                                                                                                                                                                             
  2. queryHistoryEnabled: false (query history DB lookup returns null)
                                                                                                                                                                                                                                                                              
  In multi-pod trino-gateway deployments (common in production), the load balancer                                                                                                                                                                                            
  distributes requests across pods. The initial POST /v1/statement hits pod A (which                                                                                                                                                                                          
  caches queryId → backend), but follow-up polling requests may hit pod B (cache miss).                                                                                                                                                                                       
  Without a working fallback, these requests fail with:                                                                                                                                                                                                                       
  IllegalStateException:` Number of active backends found zero `                                                                                                                                                              
                                                                                                                                                                                                                                                                              
                                                                                                         
                                                                                                                                                                                                                                                                              
  Checked v18, v19, and main — the issue exists in all versions. No open PRs or issues address this.                                                                                                                                                                          
                                                                                                                                                                                                                                                                              
  Options we've considered:                                                                                                                                                                                                                                                   
                                                               
  **Option 1:** queryHistoryEnabled: true (current workaround) — the DB acts as a shared store across pods. Works, but adds one INSERT per query to the query_history table. For high-throughput deployments this may not be desirable.                                           
   
  **Option 2:** Add X-Trino-User header to the HEAD probe — simple one-line fix in searchAllBackendForQuery(). Works for deployments without explicit auth (Trino's insecure authenticator accepts any X-Trino-User value). Doesn't help if the coordinator has real              
  authentication (OAuth/password) configured.                  
                                                                                                                                                                                                                                                                              
  **Option 3:** Propagate the original user from the incoming request — the follow-up GET request already has X-Trino-User from the JDBC client, but it's not passed down to searchAllBackendForQuery(). Would require threading the user through the cache loader or storing it  
  alongside the queryId.
                                                                                                                                                                                                                                                                              
  **Option 4:** Distributed cache (Valkey/Redis) — replace the per-pod Caffeine cache with a shared distributed cache. All pods read/write the same store. No HEAD probe needed, no query history DB needed, sub-ms latency. We have a WIP branch for this.                       
   
  Questions for the community:                                                                                                                                                                                                                                                
  - Is option 4 (distributed cache) something the project would accept upstream? It would make multi-pod deployments work correctly out of the box without requiring queryHistoryEnabled: true.
  - For option 2, should the user be hardcoded (e.g. trino-gateway) or derived from the original request? If derived, what's the preferred pattern for threading request context into the Caffeine cache loader?                                                              
  - Has anyone else hit this in production with multi-pod + routing groups?                                                                                                                                     
                                                                                                                                                                                                                                                                              
  Related PRs:                                                                                                                                                                                                                                                                
  - https://github.com/trinodb/trino-gateway/pull/800 (queryHistoryEnabled config option)                                                                                                                                                                                     
  - https://github.com/hpopuri2/trino-gateway-os/tree/valkey (Valkey distributed cache WIP)                                                                                                                                                                                   
  - https://github.com/hpopuri2/trino-gateway-os/tree/fix/search-backend-user-header (X-Trino-User fix)                                                                                                                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                   
  Related
                                                                                                                                                                                                                                                                              
  - #800 — Add configurable queryHistoryEnabled option         

  ---