### PR TITLE
Replace deprecated MBeanExporter.unexportAll

### DIFF
--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestBackendStateManager.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestBackendStateManager.java
@@ -45,7 +45,7 @@ final class TestBackendStateManager
     @AfterEach
     void tearDown()
     {
-        exporter.unexportAll();
+        exporter.destroy();
     }
 
     @Test


### PR DESCRIPTION
## Description

`TestBackendStateManager` teardown called `MBeanExporter.unexportAll()`, which is deprecated. I switched it to `destroy()`, the current cleanup API (same unexport, reports failures).

Picked this one warning from a `test-compile` with deprecation lint. `TestBackendStateManager` is green locally.

## Additional context and related issues

#864

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:

```markdown
* Fix some things.
```
