### PR TITLE
Document breaking HTTP port change in 21 release notes

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -44,6 +44,12 @@ Changes:
 * [:warning: Breaking change:](#breaking) Stop building, testing, and shipping
   container images for PowerPC (ppc64le) processors.
   ([#1198](https://github.com/trinodb/trino-gateway/pull/1198))
+* [:warning: Breaking change:](#breaking) Fail startup when the
+  `http-server.http.port` configuration property is set while
+  `http-server.http.enabled` is `false`, since the port is no longer read when
+  the HTTP listener is disabled. Remove the property from `serverConfig` in
+  HTTPS-only deployments.
+  ([#1245](https://github.com/trinodb/trino-gateway/pull/1245))
 
 More details and a list of all merged pull requests are [available in the
 milestone 21


### PR DESCRIPTION
## Description

Add a missing breaking change entry to the Trino Gateway 21 release notes.

The Airlift upgrade in #1245 changed when `http-server.http.port` is read.
Airlift now only consumes the property when the HTTP listener is enabled, so a
configuration that sets the port alongside `http-server.http.enabled` set to
`false` now fails startup:

```
Configuration is invalid

1) Configuration property 'http-server.http.port' was not used. Did you mean to
   use 'http-server.https.port', 'http-server.http.enabled' or
   'http-server.https.keystore.path'?
```

The identical configuration starts without complaint on 20. This shipped in 21
undocumented, so an HTTPS-only deployment that upgrades hits a crash loop with
no pointer to the cause in the release notes.

## Additional context and related issues

Verified by running both images against a PostgreSQL backend with the same
`config.yaml`, differing only in the image tag:

* `trinodb/trino-gateway:20` reaches `======== SERVER STARTED ========`
* `trinodb/trino-gateway:21` exits with the error above

To be precise about the scope: rejecting unused configuration properties is not
new. Both 20 and 21 reject an outright bogus property such as
`http-server.totally-bogus-property` with the same message. What changed is only
that `http-server.http.port` is no longer consumed when the HTTP listener is
disabled, which is what newly makes it an unused property. The entry is worded
to match that narrower behavior.

This also affects the Helm chart, which carried `http-server.http.port: 8080` as
a default that Helm merged into every HTTPS-only override. Fixed separately in
https://github.com/trinodb/charts/pull/436.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
