### PR TITLE
Wait for backend probes when searching for an unknown query id

### DIFF
--- a/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
+++ b/gateway-ha/src/main/java/io/trino/gateway/ha/router/BaseRoutingManager.java
@@ -35,10 +35,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * This class performs health check, stats counts for each backend and provides a backend given
@@ -48,6 +50,7 @@ public abstract class BaseRoutingManager
         implements RoutingManager
 {
     private static final Logger log = Logger.get(BaseRoutingManager.class);
+    private static final long BACKEND_SEARCH_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(5);
     private final ExecutorService executorService = Executors.newFixedThreadPool(5);
     private final GatewayBackendManager gatewayBackendManager;
     private final ConcurrentHashMap<String, TrinoStatus> backendToStatus;
@@ -230,19 +233,36 @@ public abstract class BaseRoutingManager
                                 });
                 responseCodes.put(backend.getProxyTo(), call);
             }
+            // The probes run concurrently, so wait for them against a single shared budget
+            // rather than per future: the executor is a fixed pool, so with more backends
+            // than threads a per-future timeout would compound.
+            long deadline = System.nanoTime() + BACKEND_SEARCH_TIMEOUT_NANOS;
             for (Map.Entry<String, Future<Integer>> entry : responseCodes.entrySet()) {
-                if (entry.getValue().isDone()) {
-                    int responseCode = entry.getValue().get();
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    log.warn("Timed out searching backends for query [%s]", queryId);
+                    break;
+                }
+                try {
+                    int responseCode = entry.getValue().get(remaining, TimeUnit.NANOSECONDS);
                     if (responseCode == 200) {
                         log.info("Found query [%s] on backend [%s]", queryId, entry.getKey());
                         setBackendForQueryId(queryId, entry.getKey());
                         return entry.getKey();
                     }
                 }
+                catch (ExecutionException | TimeoutException e) {
+                    log.debug(e, "Could not check backend [%s] for query [%s]", entry.getKey(), queryId);
+                }
             }
         }
         catch (Exception e) {
             log.warn("Query id [%s] not found", queryId);
+        }
+        finally {
+            // Nothing reads the remaining probes, and the executor is shared, so do not
+            // leave them occupying its threads.
+            responseCodes.values().forEach(future -> future.cancel(true));
         }
         // Fallback on first active backend if queryId mapping not found.
         return gatewayBackendManager.getActiveBackends(defaultRoutingGroup).stream()

--- a/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingManagerSearchAllBackends.java
+++ b/gateway-ha/src/test/java/io/trino/gateway/ha/router/TestRoutingManagerSearchAllBackends.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.gateway.ha.router;
+
+import com.google.common.net.HostAndPort;
+import com.sun.net.httpserver.HttpServer;
+import io.trino.gateway.ha.config.DataStoreConfiguration;
+import io.trino.gateway.ha.config.DatabaseCacheConfiguration;
+import io.trino.gateway.ha.config.ProxyBackendConfiguration;
+import io.trino.gateway.ha.config.RoutingConfiguration;
+import io.trino.gateway.ha.persistence.JdbcConnectionManager;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+import static io.trino.gateway.ha.TestingJdbcConnectionManager.createTestingJdbcConnectionManager;
+import static io.trino.gateway.ha.TestingJdbcConnectionManager.dataStoreConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(Lifecycle.PER_CLASS)
+final class TestRoutingManagerSearchAllBackends
+{
+    private static final String QUERY_ID = "20260903_120000_00001_abcde";
+
+    private HttpServer queryOwner;
+    private HttpServer otherBackend;
+    private BaseRoutingManager routingManager;
+    private String queryOwnerUrl;
+    private String otherBackendUrl;
+
+    @BeforeAll
+    void setUp()
+            throws IOException
+    {
+        // The backend that actually knows the query answers 200. It responds with a small delay,
+        // which is what a real cluster does and what makes the outcome independent of whether the
+        // probe happens to have finished by the time its result is inspected.
+        queryOwner = startBackend(200, 150);
+        // Any other backend does not know the query.
+        otherBackend = startBackend(404, 0);
+        queryOwnerUrl = urlOf(queryOwner);
+        otherBackendUrl = urlOf(otherBackend);
+
+        DataStoreConfiguration dataStoreConfig = dataStoreConfig();
+        JdbcConnectionManager connectionManager = createTestingJdbcConnectionManager(dataStoreConfig);
+        RoutingConfiguration routingConfiguration = new RoutingConfiguration();
+        routingConfiguration.setDefaultRoutingGroup("default");
+
+        GatewayBackendManager backendManager = new HaGatewayManager(connectionManager.getJdbi(), routingConfiguration, new DatabaseCacheConfiguration());
+        QueryHistoryManager historyManager = new HaQueryHistoryManager(connectionManager.getJdbi(), dataStoreConfig);
+
+        // Only the fallback candidate is in the default routing group, so returning the query
+        // owner cannot be an accident of the fallback picking it.
+        backendManager.addBackend(backend("query-owner", queryOwnerUrl, "owners"));
+        backendManager.addBackend(backend("other-backend", otherBackendUrl, "default"));
+
+        routingManager = new StochasticRoutingManager(backendManager, historyManager, routingConfiguration);
+    }
+
+    @AfterAll
+    void tearDown()
+    {
+        if (queryOwner != null) {
+            queryOwner.stop(0);
+        }
+        if (otherBackend != null) {
+            otherBackend.stop(0);
+        }
+    }
+
+    @Test
+    void testFindsBackendThatOwnsTheQuery()
+    {
+        assertThat(routingManager.findBackendForUnknownQueryId(QUERY_ID))
+                .isEqualTo(queryOwnerUrl);
+    }
+
+    private static HttpServer startBackend(int statusCode, long delayMillis)
+            throws IOException
+    {
+        HttpServer server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        server.createContext("/v1/query/", exchange -> {
+            if (delayMillis > 0) {
+                try {
+                    Thread.sleep(delayMillis);
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            exchange.sendResponseHeaders(statusCode, -1);
+            exchange.close();
+        });
+        server.start();
+        return server;
+    }
+
+    private static String urlOf(HttpServer server)
+    {
+        InetSocketAddress address = server.getAddress();
+        return "http://" + HostAndPort.fromParts(address.getAddress().getHostAddress(), address.getPort());
+    }
+
+    private static ProxyBackendConfiguration backend(String name, String proxyTo, String routingGroup)
+    {
+        ProxyBackendConfiguration backend = new ProxyBackendConfiguration();
+        backend.setActive(true);
+        backend.setName(name);
+        backend.setProxyTo(proxyTo);
+        backend.setExternalUrl(proxyTo);
+        backend.setRoutingGroup(routingGroup);
+        return backend;
+    }
+}


### PR DESCRIPTION
## Description

`findBackendForUnknownQueryId` submits a probe to every backend and then inspects the futures with `isDone()`:

```java
for (Map.Entry<String, Future<Integer>> entry : responseCodes.entrySet()) {
    if (entry.getValue().isDone()) {
        int responseCode = entry.getValue().get();
```

The loop runs immediately after submission, so in practice no probe has completed and `isDone()` is false for all of them. No response code is ever read, and the method falls through to the fallback at the end, returning the first active backend in the default routing group. The backend that actually owns the query is found only by luck.

This affects requests that arrive without a routing cookie or cached mapping. The gateway forwards them to an arbitrary cluster rather than the one running the query.

## Additional context and related issues

Fixes #1241.

The change waits for the probes rather than polling them, but against **one deadline shared across all backends** rather than a timeout per future. `executorService` is `Executors.newFixedThreadPool(5)`, so with more backends than threads the later probes do not start until earlier ones finish; a per future timeout would compound to five seconds per backend in the worst case, while a shared budget bounds the whole search at five seconds regardless of backend count.

`ExecutionException` and `TimeoutException` are caught per backend so that one unreachable cluster does not abort the search. Previously any throw from `get()` was caught by the outer `catch (Exception)` and logged as "not found", which ended the search entirely.

Outstanding probes are cancelled in a `finally` block. Nothing reads them once the search returns, and the executor is shared with the rest of the routing manager, so leaving them to run would occupy pool threads that other lookups need.

## Testing

`TestRoutingManagerSearchAllBackends` starts two stub backends: one that answers `200` after a short delay (the query owner) and one that answers `404`. The owner is placed in a routing group other than the default, and the second backend in the default group, so the fallback path cannot return the owner by accident. The assertion passes only if the search loop actually located it.

Verified with a negative control: reverting only `BaseRoutingManager.java` and keeping the test makes it fail with the fallback backend's URL rather than the owner's, matching the reported symptom.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required, with the following suggested text:

```markdown
* Fix routing of requests for a query whose backend is not cached, which
  previously went to an arbitrary active backend instead of the one running
  the query. ({issue}`1241`)
```